### PR TITLE
Updated immortal "show" command to list all attached triggers

### DIFF
--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -8709,7 +8709,8 @@ stats     Shows game status information including players in game, mobs etc.
 houses    Shows the houses that are currently defined.
 errors    Shows errant rooms.
 snoop     Shows all people currently snooping.
-colour    Shows all 256 colors
+colour    Shows all 256 colors.
+trigger   Shows all instances of an attached trigger vnum.
 
 Examples:
   show zone

--- a/src/act.h
+++ b/src/act.h
@@ -53,6 +53,7 @@ ACMD(do_write);
 /* Utility Functions */
 /** @todo Move to a utility library */
 char *find_exdesc(char *word, struct extra_descr_data *list);
+void print_object_location(int num, struct obj_data *obj, struct char_data *ch, int recur);
 /** @todo Move to a mud centric string utility library */
 void space_to_minus(char *str);
 /** @todo Move to a help module? */

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -47,7 +47,6 @@ static void show_obj_modifiers(struct obj_data *obj, struct char_data *ch);
 /* do_where utility functions */
 static void perform_immort_where(struct char_data *ch, char *arg);
 static void perform_mortal_where(struct char_data *ch, char *arg);
-static void print_object_location(int num, struct obj_data *obj, struct char_data *ch, int recur);
 
 /* Subcommands */
 /* For show_obj_to_char 'mode'.	/-- arbitrary */
@@ -1589,8 +1588,7 @@ static void perform_mortal_where(struct char_data *ch, char *arg)
   }
 }
 
-static void print_object_location(int num, struct obj_data *obj, struct char_data *ch,
-			        int recur)
+void print_object_location(int num, struct obj_data *obj, struct char_data *ch, int recur)
 {
   if (num > 0)
     send_to_char(ch, "O%3d. %-25s%s - ", num, obj->short_description, QNRM);

--- a/src/dg_scripts.h
+++ b/src/dg_scripts.h
@@ -160,7 +160,7 @@ struct trig_data {
     int loops;                          /**< loop iteration counter          */
     struct event *wait_event;           /**< event to pause the trigger  */
     ubyte purged;                       /**< trigger is set to be purged     */
-    struct trig_var_data *var_list;	    /**< list of local vars for trigger  */
+    struct trig_var_data *var_list;     /**< list of local vars for trigger  */
 
     struct trig_data *next;
     struct trig_data *next_in_world;    /**< next in the global trigger list */


### PR DESCRIPTION
I've added another utility to the immortal "show" command to list all attached triggers of a given vnumber.  Usage is, e.g., "show trigger 501".
