### PR TITLE
New slay command for LVL_GRGOD and higher

### DIFF
--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -8835,6 +8835,14 @@ skillset rumble 'magic missile' 100
 
 See also: SET, SKILLS, SPELLS
 #31
+SLAY
+
+Usage: slay <victim>
+
+   This command will instantly put the specified victim to death as long as 
+   the victim's level is less than the person attempting the command.
+
+#32
 SLEEP
 
 SLEEP is both a command and the name of a spell.

--- a/src/act.h
+++ b/src/act.h
@@ -185,6 +185,7 @@ ACMD(do_kick);
 ACMD(do_kill);
 ACMD(do_order);
 ACMD(do_rescue);
+ACMD(do_slay);
 ACMD(do_whirlwind);
 
 /*****************************************************************************

--- a/src/act.offensive.c
+++ b/src/act.offensive.c
@@ -519,3 +519,30 @@ ACMD(do_kick)
 
   WAIT_STATE(ch, PULSE_VIOLENCE * 3);
 }
+
+ACMD(do_slay)
+{
+  char arg[MAX_INPUT_LENGTH];
+  struct char_data *vict;
+
+  one_argument(argument, arg);
+
+  if (!*arg) {
+    send_to_char(ch, "Kill who?\r\n");
+  } else {
+    if (!(vict = get_char_vis(ch, arg, NULL, FIND_CHAR_ROOM)))
+      send_to_char(ch, "They aren't here.\r\n");
+    else if (ch == vict)
+      send_to_char(ch, "Your mother would be so sad.. :(\r\n");
+    else if (GET_LEVEL(ch) < GET_LEVEL(vict)) {
+      send_to_char(ch, "You do not have the strength to slay %s.\r\n",
+         GET_NAME(vict));
+    } else {
+      act("You chop $M to pieces!  Ah!  The blood!", FALSE, ch, 0, vict, TO_CHAR);
+      act("$N chops you to pieces!", FALSE, vict, 0, ch, TO_CHAR);
+      act("$n brutally slays $N!", FALSE, ch, 0, vict, TO_NOTVICT);
+      raw_kill(vict, ch);
+    }
+  }
+}
+

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -294,6 +294,7 @@ cpp_extern const struct command_info cmd_info[] = {
   { "shutdown" , "shutdown", POS_DEAD    , do_shutdown , LVL_IMPL, SCMD_SHUTDOWN },
   { "sip"      , "sip"     , POS_RESTING , do_drink    , 0, SCMD_SIP },
   { "skillset" , "skillset", POS_SLEEPING, do_skillset , LVL_GRGOD, 0 },
+  { "slay"     , "slay"    , POS_FIGHTING, do_slay     , LVL_GRGOD, 0 },
   { "sleep"    , "sl"      , POS_SLEEPING, do_sleep    , 0, 0 },
   { "slist"    , "slist"   , POS_SLEEPING, do_oasis_list, LVL_BUILDER, SCMD_OASIS_SLIST },
   { "sneak"    , "sneak"   , POS_STANDING, do_sneak    , 1, 0 },


### PR DESCRIPTION
This new command is added for LVL_GRGOD characters to instantly kill a (lesser level) victim (PC or NPC).
