### PR TITLE
new unfollow command available for all players

### DIFF
--- a/lib/text/help/help.hlp
+++ b/lib/text/help/help.hlp
@@ -12054,6 +12054,20 @@ Usage: unaffect [target]
 Removes all affections (i.e., spell effects) from a player.
 
 #31
+UNFOLLOW
+
+Usage: unfollow
+
+The UNFOLLOW command will stop a player from following another player or
+creature.  This command will not succeed if the player is under the 
+influence of a CHARM spell.
+
+Examples:
+
+  > unfollow
+
+See also: FOLLOW
+#0
 UNGROUP DISBAND
 
 Usage: ungroup [group member]

--- a/src/act.h
+++ b/src/act.h
@@ -162,6 +162,7 @@ ACMD(do_rest);
 ACMD(do_sit);
 ACMD(do_sleep);
 ACMD(do_stand);
+ACMD(do_unfollow);
 ACMD(do_wake);
 /* Global variables from act.movement.c */
 #ifndef __ACT_MOVEMENT_C__

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -826,8 +826,13 @@ ACMD(do_score)
   if (GET_QUEST(ch) == NOTHING)
     send_to_char(ch, "and you are not on a quest at the moment.\r\n");
   else
-    send_to_char(ch, "and your current quest is %d.\r\n",
-                     GET_QUEST(ch) == NOTHING ? -1 : GET_QUEST(ch));
+  {
+    send_to_char(ch, "and your current quest is %s", QST_DESC(real_quest(GET_QUEST(ch))));
+    if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_SHOWVNUMS))
+        send_to_char(ch, " [%d]\r\n", GET_QUEST(ch));
+    else
+        send_to_char(ch, "\r\n");
+  }
 
   playing_time = *real_time_passed((time(0) - ch->player.time.logon) +
 				  ch->player.time.played, 0);

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -828,7 +828,8 @@ ACMD(do_score)
     send_to_char(ch, "and you are not on a quest at the moment.\r\n");
   else
   {
-    send_to_char(ch, "and your current quest is %s", QST_DESC(real_quest(GET_QUEST(ch))));
+    send_to_char(ch, "and your current quest is: %s", QST_NAME(real_quest(GET_QUEST(ch))));
+
     if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_SHOWVNUMS))
         send_to_char(ch, " [%d]\r\n", GET_QUEST(ch));
     else

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -27,6 +27,7 @@
 #include "fight.h"
 #include "modify.h"
 #include "asciimap.h"
+#include "quest.h"
 
 /* prototypes of local functions */
 /* do_diagnose utility functions */

--- a/src/act.movement.c
+++ b/src/act.movement.c
@@ -970,3 +970,18 @@ ACMD(do_follow)
     }
   }
 }
+
+ACMD(do_unfollow)
+{
+  if (ch->master) {
+    if (AFF_FLAGGED(ch, AFF_CHARM)) {
+       send_to_char(ch, "You feel compelled to follow %s.\r\n",
+         GET_NAME(ch->master));
+    } else {
+      stop_follower(ch);
+    }
+  } else {
+    send_to_char(ch, "You are not following anyone.\r\n");
+  }
+  return;
+}

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -699,11 +699,7 @@ static void perform_complex_alias(struct txt_q *input_q, char *orig, struct alia
 	write_point += strlen(tokens[num]);
       } else if (*temp == ALIAS_GLOB_CHAR) {
         skip_spaces(&orig);
-<<<<<<< HEAD
-	strcpy(write_point, orig);		/* strcpy: OK */
-=======
         strcpy(write_point, orig);		/* strcpy: OK */
->>>>>>> f81cf2451717859aecaebb3ca07daf7b9d9a45a5
 	write_point += strlen(orig);
       } else if ((*(write_point++) = *temp) == '$')	/* redouble $ for act safety */
 	*(write_point++) = '$';

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -325,6 +325,7 @@ cpp_extern const struct command_info cmd_info[] = {
   { "unlock"   , "unlock"  , POS_SITTING , do_gen_door , 0, SCMD_UNLOCK },
   { "unban"    , "unban"   , POS_DEAD    , do_unban    , LVL_GRGOD, 0 },
   { "unaffect" , "unaffect", POS_DEAD    , do_wizutil  , LVL_GOD, SCMD_UNAFFECT },
+  { "unfollow" , "unf"     , POS_RESTING , do_unfollow , 0, 0 },
   { "uptime"   , "uptime"  , POS_DEAD    , do_date     , LVL_GOD, SCMD_UPTIME },
   { "use"      , "use"     , POS_SITTING , do_use      , 1, SCMD_USE },
   { "users"    , "users"   , POS_DEAD    , do_users    , LVL_GOD, 0 },


### PR DESCRIPTION
This is the implementation of an "unfollow" command that will stop a player from following another PC or NPC.  It is a shortcut for longer commands such as 'follow self'.
