### PR TITLE
follow command with no arguments reports leader (when already following)

### DIFF
--- a/src/act.movement.c
+++ b/src/act.movement.c
@@ -941,7 +941,12 @@ ACMD(do_follow)
       return;
     }
   } else {
-    send_to_char(ch, "Whom do you wish to follow?\r\n");
+    if (ch->master != (char_data*)  NULL) {
+      send_to_char(ch, "You are following %s.\r\n", 
+         GET_NAME(ch->master));
+    } else {
+      send_to_char(ch, "Whom do you wish to follow?\r\n");
+    }
     return;
   }
 


### PR DESCRIPTION
This is a very minor enhancement to the "follow" command that will report the name of the leader when a player is already following another PC or NPC.  Usage is just "follow" (no arguments).  The original behavior is maintained if the player is not following anyone.
