### PR TITLE
Prevent compiler warnings and potential OLC setting string truncation.

### DIFF
--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -1698,7 +1698,7 @@ ACMD(do_levels)
   }
   one_argument(argument, arg);
 
-  if (arg != NULL && *arg) {
+  if (*arg) {
     if (isdigit(*arg)) {
       ret = sscanf(arg, "%d-%d", &min_lev, &max_lev);
       if (ret == 0) {

--- a/src/ban.c
+++ b/src/ban.c
@@ -262,7 +262,7 @@ int valid_name(char *newname)
     return (0);
 
   /* return valid if list doesn't exist */
-  if (invalid_list == NULL || num_invalid < 1)
+  if (num_invalid < 1)
     return (1);
 
   /* change to lowercase */

--- a/src/db.c
+++ b/src/db.c
@@ -3915,14 +3915,14 @@ void load_config( void )
         else if (!str_cmp(tag, "dflt_dir")) {
           if (CONFIG_DFLT_DIR)
             free(CONFIG_DFLT_DIR);
-          if (line != NULL && *line)
+          if (*line)
             CONFIG_DFLT_DIR = strdup(line);
           else
             CONFIG_DFLT_DIR = strdup(DFLT_DIR);
         } else if (!str_cmp(tag, "dflt_ip")) {
           if (CONFIG_DFLT_IP)
             free(CONFIG_DFLT_IP);
-          if (line != NULL && *line)
+          if (*line)
             CONFIG_DFLT_IP = strdup(line);
           else
             CONFIG_DFLT_IP = NULL;
@@ -3967,7 +3967,7 @@ void load_config( void )
         else if (!str_cmp(tag, "logname")) {
           if (CONFIG_LOGNAME)
             free(CONFIG_LOGNAME);
-          if (line != NULL && *line)
+          if (*line)
             CONFIG_LOGNAME = strdup(line);
           else
             CONFIG_LOGNAME = NULL;

--- a/src/dg_misc.c
+++ b/src/dg_misc.c
@@ -169,8 +169,7 @@ void do_dg_affect(void *go, struct script_data *sc, trig_data *trig,
   half_chop(cmd, value_p, duration_p);
 
   /* make sure all parameters are present */
-  if (charname == NULL || !*charname || property == NULL || !*property ||
-      value_p == NULL || !*value_p || duration_p == NULL || !*duration_p) {
+  if (!*charname || !*property || !*value_p || !*duration_p) {
     script_log("Trigger: %s, VNum %d. dg_affect usage: <target> <property> <value> <duration>",
       GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig));
     return;

--- a/src/dg_mobcmd.c
+++ b/src/dg_mobcmd.c
@@ -385,9 +385,9 @@ ACMD(do_mload)
         return;
       }
       two_arguments(target, arg1, arg2); /* recycling ... */
-      tch = (arg1 != NULL && *arg1 == UID_CHAR) ? get_char(arg1) : get_char_room_vis(ch, arg1, NULL);
+      tch = (*arg1 == UID_CHAR) ? get_char(arg1) : get_char_room_vis(ch, arg1, NULL);
       if (tch) {
-        if (arg2 != NULL && *arg2 && (pos = find_eq_pos_script(arg2)) >= 0 &&
+        if (*arg2 && (pos = find_eq_pos_script(arg2)) >= 0 &&
             !GET_EQ(tch, pos) && can_wear_on_pos(object, pos)) {
           equip_char(tch, object, pos);
           load_otrigger(object);
@@ -397,7 +397,7 @@ ACMD(do_mload)
         load_otrigger(object);
         return;
       }
-      cnt = (arg1 != NULL && *arg1 == UID_CHAR) ? get_obj(arg1) : get_obj_vis(ch, arg1, NULL);
+      cnt = (*arg1 == UID_CHAR) ? get_obj(arg1) : get_obj_vis(ch, arg1, NULL);
       if (cnt && GET_OBJ_TYPE(cnt) == ITEM_CONTAINER) {
       	obj_to_obj(object, cnt);
         load_otrigger(object);

--- a/src/dg_objcmd.c
+++ b/src/dg_objcmd.c
@@ -510,7 +510,7 @@ static OCMD(do_dgoload)
       two_arguments(target, arg1, arg2); /* recycling ... */
       tch = get_char_near_obj(obj, arg1);
       if (tch) {
-        if (arg2 != NULL && *arg2 && (pos = find_eq_pos_script(arg2)) >= 0 &&
+        if (*arg2 && (pos = find_eq_pos_script(arg2)) >= 0 &&
             !GET_EQ(tch, pos) && can_wear_on_pos(object, pos)) {
           equip_char(tch, object, pos);
           load_otrigger(object);
@@ -687,7 +687,7 @@ static OCMD(do_osetval)
   struct char_data *worn_by = NULL;
 
   two_arguments(argument, arg1, arg2);
-  if (arg1 == NULL || !*arg1 || arg2 == NULL || !*arg2 || !is_number(arg1) || !is_number(arg2)) {
+  if (!*arg1 || !*arg2 || !is_number(arg1) || !is_number(arg2)) {
     obj_log(obj, "osetval: bad syntax");
     return;
   }

--- a/src/dg_scripts.c
+++ b/src/dg_scripts.c
@@ -1193,7 +1193,7 @@ ACMD(do_detach)
         }
       }
 
-      if (arg3 == NULL || !*arg3)
+      if (!*arg3)
         send_to_char(ch, "You must specify a trigger to remove.\r\n");
       else
         trigger = arg3;
@@ -1218,7 +1218,7 @@ ACMD(do_detach)
         }
       }
 
-      if (arg3 == NULL || !*arg3)
+      if (!*arg3)
         send_to_char(ch, "You must specify a trigger to remove.\r\n");
       else
         trigger = arg3;
@@ -1957,7 +1957,7 @@ static void makeuid_var(void *go, struct script_data *sc, trig_data *trig,
     return;
   }
 
-  if (arg == NULL || !*arg) {
+  if (!*arg) {
     script_log("Trigger: %s, VNum %d. makeuid invalid id arg: '%s'",
             GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), cmd);
     return;
@@ -1969,7 +1969,7 @@ static void makeuid_var(void *go, struct script_data *sc, trig_data *trig,
     eval_expr(arg, result, go, sc, trig, type);
     snprintf(uid, sizeof(uid), "%c%s", UID_CHAR, result);
   } else { /* a lot more work without it */
-    if (name == NULL || !*name) {
+    if (!*name) {
       script_log("Trigger: %s, VNum %d. makeuid needs name: '%s'",
             GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), cmd);
       return;
@@ -2242,7 +2242,7 @@ int perform_set_dg_var(struct char_data *ch, struct char_data *vict, char *val_a
 
   var_value = any_one_arg(val_arg, var_name);
 
-  if (var_name == NULL || !*var_name || var_value == NULL || !*var_value) {
+  if (!*var_name || var_value == NULL || !*var_value) {
     send_to_char(ch, "Usage: set <char> <varname> <value>\r\n");
     return 0;
   }

--- a/src/dg_wldcmd.c
+++ b/src/dg_wldcmd.c
@@ -483,7 +483,7 @@ WCMD(do_wload)
       two_arguments(target, arg1, arg2); /* recycling ... */
       tch = get_char_in_room(room, arg1);
       if (tch) {
-        if (arg2 != NULL && *arg2 && (pos = find_eq_pos_script(arg2)) >= 0 &&
+        if (*arg2 && (pos = find_eq_pos_script(arg2)) >= 0 &&
             !GET_EQ(tch, pos) && can_wear_on_pos(object, pos)) {
           equip_char(tch, object, pos);
           load_otrigger(object);

--- a/src/genolc.c
+++ b/src/genolc.c
@@ -86,7 +86,7 @@ char *str_udupnl(const char *txt)
   ptr = (txt && *txt) ? txt : undef;
   CREATE(str, char, strlen(ptr) + 3);
 
-  strlcpy(str, ptr, strlen(ptr));
+  strlcpy(str, ptr, strlen(str));
   strcat(str, "\r\n");
 
   return str;


### PR DESCRIPTION
- Prevented compiler warnings when using
’-Wtautological-pointer-compare’ on development system (Darwin)
- Prevented possible string truncation when adding a newline to an OLC
setting string.