### PR TITLE
Added OLC setting for the "Huh!?!" message.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -87,6 +87,7 @@ int load_into_inventory = YES;
 
 /* "okay" etc. */
 const char *OK = "Okay.\r\n";
+const char *HUH = "Huh!?!\r\n";
 const char *NOPERSON = "No one by that name here.\r\n";
 const char *NOEFFECT = "Nothing seems to happen.\r\n";
 

--- a/src/config.h
+++ b/src/config.h
@@ -31,6 +31,7 @@ extern int idle_max_level;
 extern int dts_are_dumps;
 extern int load_into_inventory;
 extern const char *OK;
+extern const char *HUH;
 extern const char *NOPERSON;
 extern const char *NOEFFECT;
 extern int track_through_doors;

--- a/src/db.c
+++ b/src/db.c
@@ -3787,9 +3787,10 @@ static void load_default_config( void )
   CONFIG_IDLE_MAX_LEVEL	        = idle_max_level;
   CONFIG_DTS_ARE_DUMPS	        = dts_are_dumps;
   CONFIG_LOAD_INVENTORY         = load_into_inventory;
-  CONFIG_OK			            = strdup(OK);
-  CONFIG_NOPERSON	          	= strdup(NOPERSON);
-  CONFIG_NOEFFECT	         	= strdup(NOEFFECT);
+  CONFIG_OK			= strdup(OK);
+  CONFIG_HUH			= strdup(HUH);
+  CONFIG_NOPERSON	        = strdup(NOPERSON);
+  CONFIG_NOEFFECT	        = strdup(NOEFFECT);
   CONFIG_TRACK_T_DOORS          = track_through_doors;
   CONFIG_NO_MORT_TO_IMMORT	    = no_mort_to_immort;
   CONFIG_DISP_CLOSED_DOORS      = display_closed_doors;
@@ -3944,6 +3945,13 @@ void load_config( void )
       case 'h':
         if (!str_cmp(tag, "holler_move_cost"))
           CONFIG_HOLLER_MOVE_COST = num;
+        else if (!str_cmp(tag, "huh")) {
+          char tmp[READ_SIZE];
+          if (CONFIG_HUH)
+            free(CONFIG_HUH);
+          snprintf(tmp, sizeof(tmp), "%s\r\n", line);
+          CONFIG_HUH = strdup(tmp);
+        }
         break;
 
       case 'i':

--- a/src/dg_mobcmd.c
+++ b/src/dg_mobcmd.c
@@ -56,7 +56,7 @@ ACMD(do_masound)
 
     if (!MOB_OR_IMPL(ch))
     {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -94,7 +94,7 @@ ACMD(do_mkill)
     char_data *victim;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -148,7 +148,7 @@ ACMD(do_mjunk)
     obj_data *obj_next;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -195,7 +195,7 @@ ACMD(do_mechoaround)
     char *p;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -231,7 +231,7 @@ ACMD(do_msend)
     char *p;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -265,7 +265,7 @@ ACMD(do_mecho)
     char *p;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -290,7 +290,7 @@ ACMD(do_mzoneecho)
         
     if (!MOB_OR_IMPL(ch))
     {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
     msg = any_one_arg(argument, room_number);
@@ -322,7 +322,7 @@ ACMD(do_mload)
     int pos;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -423,7 +423,7 @@ ACMD(do_mpurge)
   obj_data  *obj;
 
   if (!MOB_OR_IMPL(ch)) {
-    send_to_char(ch, "Huh?!?\r\n");
+    send_to_char(ch, "%s", CONFIG_HUH);
     return;
   }
 
@@ -490,7 +490,7 @@ ACMD(do_mgoto)
     room_rnum location;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -524,7 +524,7 @@ ACMD(do_mat)
     room_rnum location, original;
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -564,7 +564,7 @@ ACMD(do_mteleport)
   char_data *vict, *next_ch;
 
   if (!MOB_OR_IMPL(ch)) {
-    send_to_char(ch, "Huh?!?\r\n");
+    send_to_char(ch, "%s", CONFIG_HUH);
     return;
   }
 
@@ -625,7 +625,7 @@ ACMD(do_mdamage) {
   char_data *vict;
 
   if (!MOB_OR_IMPL(ch)) {
-    send_to_char(ch, "Huh?!?\r\n");
+    send_to_char(ch, "%s", CONFIG_HUH);
     return;
   }
 
@@ -660,7 +660,7 @@ ACMD(do_mforce)
     char arg[MAX_INPUT_LENGTH];
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -721,7 +721,7 @@ ACMD(do_mhunt)
     char arg[MAX_INPUT_LENGTH];
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -763,7 +763,7 @@ ACMD(do_mremember)
     char arg[MAX_INPUT_LENGTH];
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -814,7 +814,7 @@ ACMD(do_mforget)
     char arg[MAX_INPUT_LENGTH];
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -873,7 +873,7 @@ ACMD(do_mtransform)
   int pos;
 
   if (!MOB_OR_IMPL(ch)) {
-    send_to_char(ch, "Huh?!?\r\n");
+    send_to_char(ch, "%s", CONFIG_HUH);
     return;
   }
 
@@ -986,7 +986,7 @@ ACMD(do_mdoor)
     };
 
     if (!MOB_OR_IMPL(ch)) {
-        send_to_char(ch, "Huh?!?\r\n");
+        send_to_char(ch, "%s", CONFIG_HUH);
         return;
     }
 
@@ -1074,7 +1074,7 @@ ACMD(do_mfollow)
   struct follow_type *j, *k;
 
   if (!MOB_OR_IMPL(ch)) {
-    send_to_char(ch, "Huh?!?\r\n");
+    send_to_char(ch, "%s", CONFIG_HUH);
     return;
   }
 
@@ -1145,7 +1145,7 @@ ACMD(do_mrecho)
     char start[MAX_INPUT_LENGTH], finish[MAX_INPUT_LENGTH], *msg;
 
     if (!MOB_OR_IMPL(ch)) {
-      send_to_char(ch, "Huh?!?\r\n");
+      send_to_char(ch, "%s", CONFIG_HUH);
       return;
     }
     msg = two_arguments(argument, start, finish);

--- a/src/genolc.c
+++ b/src/genolc.c
@@ -82,11 +82,13 @@ char *str_udupnl(const char *txt)
 {
   char *str = NULL, undef[] = "undefined";
   const char *ptr = NULL;
+  size_t n;
 
   ptr = (txt && *txt) ? txt : undef;
-  CREATE(str, char, strlen(ptr) + 3);
+  n = strlen(ptr) + 3;
 
-  strlcpy(str, ptr, strlen(str));
+  CREATE(str, char, n);
+  strlcpy(str, ptr, n);
   strcat(str, "\r\n");
 
   return str;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -528,7 +528,7 @@ void command_interpreter(struct char_data *ch, char *argument)
 
   if (*complete_cmd_info[cmd].command == '\n') {
     int found = 0;
-    send_to_char(ch, "Huh!?!\r\n");
+    send_to_char(ch, "%s", CONFIG_HUH);
 
     for (cmd = 0; *cmd_info[cmd].command != '\n'; cmd++)
     {

--- a/src/oasis.h
+++ b/src/oasis.h
@@ -331,14 +331,15 @@ extern const char *nrm, *grn, *cyn, *yel;
 #define CEDIT_ROOM_NUMBERS_MENU		6
 #define CEDIT_AUTOWIZ_OPTIONS_MENU	7
 #define CEDIT_OK			8
-#define CEDIT_NOPERSON			9
-#define CEDIT_NOEFFECT			10
-#define CEDIT_DFLT_IP			11
-#define CEDIT_DFLT_DIR			12
-#define CEDIT_LOGNAME			13
-#define CEDIT_MENU			14
-#define CEDIT_WELC_MESSG		15
-#define CEDIT_START_MESSG		16
+#define CEDIT_HUH			9
+#define CEDIT_NOPERSON			10
+#define CEDIT_NOEFFECT			11
+#define CEDIT_DFLT_IP			12
+#define CEDIT_DFLT_DIR			13
+#define CEDIT_LOGNAME			14
+#define CEDIT_MENU			15
+#define CEDIT_WELC_MESSG		16
+#define CEDIT_START_MESSG		17
 
 /* Numerical responses. */
 #define CEDIT_NUMERICAL_RESPONSE	20

--- a/src/oasis_delete.c
+++ b/src/oasis_delete.c
@@ -74,6 +74,9 @@ int free_strings(void *data, int type)
       if (config->play.OK)
         free(config->play.OK);
 
+      if (config->play.HUH)
+        free(config->play.HUH);
+
       if (config->play.NOPERSON)
         free(config->play.NOPERSON);
 

--- a/src/quest.c
+++ b/src/quest.c
@@ -658,9 +658,7 @@ void quest_stat(struct char_data *ch, char argument[MAX_STRING_LENGTH])
   char buf[MAX_STRING_LENGTH];
   char targetname[MAX_STRING_LENGTH];
 
-  if (GET_LEVEL(ch) < LVL_IMMORT)
-    send_to_char(ch, "Huh!?!\r\n");
-  else if (!*argument)
+  if (!*argument)
     send_to_char(ch, "%s\r\n", quest_imm_usage);
   else if ((rnum = real_quest(atoi(argument))) == NOTHING )
     send_to_char(ch, "That quest does not exist.\r\n");

--- a/src/structs.h
+++ b/src/structs.h
@@ -1321,8 +1321,9 @@ struct game_data
   int minimap_size;       /**< Default size for mini-map (automap)  */
   int script_players;     /**< Is attaching scripts to players allowed? */
 
-  char *OK; /**< When player receives 'Okay.' text.    */
-  char *NOPERSON; /**< 'No one by that name here.'   */
+  char *OK;       /**< When player receives 'Okay.' text.    */
+  char *HUH;      /**< 'Huh!?!'                              */ 
+  char *NOPERSON; /**< 'No one by that name here.'           */
   char *NOEFFECT; /**< 'Nothing seems to happen.'            */
 };
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -970,8 +970,10 @@ do                                                              \
 #define CONFIG_TRACK_T_DOORS    config_info.play.track_through_doors
 /** Get the permission to level up from mortal to immortal. */
 #define CONFIG_NO_MORT_TO_IMMORT config_info.play.no_mort_to_immort
-/** Get the 'OK' message. */
+/** Get the OK message. */
 #define CONFIG_OK               config_info.play.OK
+/** Get the HUH message. */
+#define CONFIG_HUH              config_info.play.HUH
 /** Get the NOPERSON message. */
 #define CONFIG_NOPERSON         config_info.play.NOPERSON
 /** Get the NOEFFECT message. */


### PR DESCRIPTION
Allows DG mob commands (and any future custom commands) to use a standardized message.

Also in this commit:
- Altered previous truncation fix to work in (hopefully) all situations.
- Removed redundant level check with "quest status" command.