### PR TITLE
Corrected sector types in wld-files according last known good

### DIFF
--- a/lib/world/wld/0.wld
+++ b/lib/world/wld/0.wld
@@ -3,7 +3,7 @@ The Void~
    You don't think that you are not floating in nothing.  You can see
 a strange portal located above you.
 ~
-0 8 0 0 0 0
+0 8 0 0 0 1
 D4
 ~
 ~
@@ -16,7 +16,7 @@ Limbo~
 matter, surrounded by swirling glowing light, which fades into the relative
 darkness around you without any trace of edges or shadow.
 ~
-0 8 0 0 0 0
+0 8 0 0 0 1
 D5
 A strange portal in the floor is the only exit.
 ~

--- a/lib/world/wld/1.wld
+++ b/lib/world/wld/1.wld
@@ -131,7 +131,7 @@ is in need.  A large rectangular table with thirteen chairs surrounding it
 fills the center of the room.  A large pane window overhead admits a glowing
 aura that fills the room with serenity.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D5
 ~
 ~
@@ -174,7 +174,7 @@ most revered of all the classes as they are the most powerful.  But that power
 has a price.  Only five Magi have survived.  Five decorative cushions are
 placed in a circle in the middle of the room.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D5
 ~
 ~
@@ -197,7 +197,7 @@ Magi.  The dome curves along the walls of the city and can not be seen for more
 than a few feet in any direction.  It flickers as if a mirage, only visible when
 glanced at from one side.  Stone stairs lead down into the city wall.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -288,7 +288,7 @@ The Temple of Sanctus rises above to the southeast, its single spire reaching up
 into the sky higher than any other building in the realm.  A stone stairwell
 leads down to the inner city.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -303,7 +303,7 @@ strange smell.  Few people know, or want to know, what lies beyond the city
 walls and the safety of the dome.  A stone stairwell leads down to the inner
 city.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -340,7 +340,7 @@ heard, as the sentinels grow weary from their standing their posts hour after
 hour.  The city to the east looks tranquil and safe.  It is not possible to see
 much to the west past the shimmering dome.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -362,7 +362,7 @@ to fight.  The city has never fallen to this day.  To the north one can see the
 barracks, to the south the Hall of Clerics.  A stone stairwell leads down to the
 inner city.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -418,7 +418,7 @@ Mansion of the Magi.  The Temple of Sanctus rises from the center of the city to
 the west.  All looks well from this perspective.  It is not possible to see
 beyond the city walls.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -432,7 +432,7 @@ for keeping the dome up.  But two of the seven have already died.  The War
 Master is planning for the worst, and preparing the army for battle.  The guards
 stir restlessly below.  A stone stairwell leads down to the gate.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -468,7 +468,7 @@ To the west one can see the Hall of Clerics.  To the south the Tower of the High
 Council of Clerics glows pristinely white.  The town seems peaceful and
 untroubled by the turmoils outside the walls.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -489,7 +489,7 @@ protecting dome that ensures oner safety.  To the south the black stone of the
 Tower of the Magi glistens serenely.  To the east you can see the Mansion of the
 Magi in all its extravagance.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -700,7 +700,7 @@ this is where the sick and wounded are put up for the night.  Even the
 apprentices sometimes stay here when they are too tired to go home after a hard
 days work.  The room is empty now, the healers must have done their jobs well.
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D3
 ~
 ~
@@ -714,7 +714,7 @@ for the safety of the Orb of Sanctum.  The Orb is what was given to the Magi by
 the gods to sustain the protective dome.  As long as the orb is safely in place
 and a Magi is present to sustain it the dome will remain.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D1
 ~
 ~
@@ -810,7 +810,7 @@ are the only inhabitants.  All of them are made out of wood and are polished to
 a glossy shine.  A single window looks out over the Southern Gate.  To live a
 life as a Cleric is to life a life without desire and need.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 ~
@@ -860,7 +860,7 @@ spells line all three walls.  Everything from potions to pills and everything
 in between.  Some of the jars contain strange beasts soaking in a strange
 liquid.  The smell of dust and strange herbs permeates the room.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 ~
@@ -874,7 +874,7 @@ Most never make it.  The Magi of the Purple and Grey robes has never been
 achieved.  The actual testing to be a Magi remains a mystery as only the Magi
 themselves have witnessed it.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 ~
@@ -888,7 +888,7 @@ Tower of the High Council and the Tower of the Magi.  All three structures are
 impressive works of architecture and magic combined.  To the south the dome
 rises high into the air, blocking all view to the chaotic world beyond.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D5
 ~
 ~
@@ -909,7 +909,7 @@ guarded diligently.  These gates are normally locked at night to ensure the
 safety of the city.  Only the east and west gates remain open all day.  The
 luminescent dome encompassing the city can be seen just to the north.    
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D2
 ~
 ~
@@ -1021,7 +1021,7 @@ west and no sound escapes the building to the east.  The North Way splits the
 city of Sanctus into two Quarters.  The thieves quarter in the east and the
 Warriors Quarter to the west.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1151,7 +1151,7 @@ is just to the north and the army barracks are in the building to the west.
 Various stores lie further along Warriors Avenue to the east.  There is a fair
 amount of people, mostly soldiers, going about their daily lives.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1176,7 +1176,7 @@ themselves of their worries.  The cobblestone street is clean and well
 maintained.  The buildings all around are made of wood and some are several
 stories tall.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1201,7 +1201,7 @@ in Sanctus, excluding of course the temple.  Many travellers go there to relax
 and unwind.  Several small houses are to the south along this road while the
 northern half seems to consist mostly of shops.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1226,7 +1226,7 @@ of someone working a grindstone can be heard to the north, most likely the
 weaponsmith.  A small house to the south is shadowed by the tower of Sanctus in
 the middle of the city.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1250,7 +1250,7 @@ Warriors Avenue~
 towns Smithy.  The street continues east and west with a small house to the
 south.  Townspeople walk the streets going about their business.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1276,7 +1276,7 @@ shadows and mystery.  Not a single sound escapes from that section of the city.
 This intersection stands upon the North Way which runs from the North Gate down
 to the Temple of Sanctus.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1302,7 +1302,7 @@ responsible for the economic policies of the city and do a very good job.  Of
 course they are so worried about keeping one another from stealing from the city
 that they don't dare do it themselves.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1327,7 +1327,7 @@ reminding of the need to hold onto gold very tightly while in this quarter of
 the city.  The thieves may run the cities finances fairly, but they could care
 less about a single adventurer.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1352,7 +1352,7 @@ hides.  Must be the towns leather shop.  Tall buildings to the south must be the
 houses of the locals.  Probably shouldn't go wandering around, this place is
 full of thieves as it is and it would be easy to be mistaken for one.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1377,7 +1377,7 @@ local bar for the thieves.  The town used to have only one bar until the
 warriors and thieves got into a huge braul and ended up burning the place to the
 ground.  A few citizens walk past staring at each other curiously.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1402,7 +1402,7 @@ above you to the east.  Thieves Avenue makes a turn here to the south or west.
 This area is now in the northeastern corner of the city, in the heart of the
 Thieves Quarter.  A traveler would be wise to watch their purse carefully.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1467,7 +1467,7 @@ the city has fought in.  Sanctus has never fallen.  Various weapons and suits
 of armor are all bolted to the floor and walls.  A small doorway leads into the
 bunk room to the east.  The hall continues north and south.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 ~
@@ -1509,7 +1509,7 @@ well-travelled road continues north and south.  This appears to be the Warriors
 Quarter where the army of Sanctus bases it's operations.  Several recruits rush
 past on assignment.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1579,7 +1579,7 @@ horses.  A small amount of dust is kicked up by every footstep.  Directly to the
 south one can see the Temple.  A small stone bridge arches over a small stream
 to the north.  There is something unusual about the bridge.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1597,7 +1597,7 @@ cover the entire floor.  A candelabra sits in the middle of a polished oak
 table.  A four post bed can be seen in the back of the house.  Nothing like
 living the good life.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 door~
@@ -1610,7 +1610,7 @@ this house.  Small mattresses lay on the floor in the back of the room.  Not
 much hope for privacy in this house.  A few dolls are having a tea party in one
 corner.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 door~
@@ -1623,7 +1623,7 @@ trespassing, I'm sure no one will mind.  The house is very compact.  The
 kitchen and bedrooms are not separated by any walls.  This must be a house for
 the poor.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 door~
@@ -1635,7 +1635,7 @@ A Clean House~
 Well maintained it seems.  Not everyone is rich enough to afford a housekeeper,
 but these folks must be.  You can hear a baby crying, sounds hungry.    
 ~
-1 8 0 0 0 0
+1 8 0 0 0 1
 D0
 ~
 door~
@@ -1648,7 +1648,7 @@ to the west.  The entrance looks to be a ways further north in the heart of the
 Thieve's Quarter.  South can be seen another intersection and the northest
 corner of the inner wall.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1741,7 +1741,7 @@ The alley crosses the city east to west behind the homes of the local citizens.
 The alley is very narrow and dark as the inner city wall follows it on the
 southern side.  Warriors Avenue continues north and south.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1763,7 +1763,7 @@ and then bolts as it senses some trespasser on its territory.  This alley does
 not look safe and one might wonder whether or not they could encounter some
 lurking thugs.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1779,7 +1779,7 @@ Warriors Alley~
 rattling of armor can be heard from the guards patrolling the top of the wall.
 The alley is even darker here and a person could easily hide in the shadows.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1796,7 +1796,7 @@ but all are bolted, locked, or nailed shut.  This is definitely not the most
 friendly section of the city.  An alley cat bolts past as a large pile of
 garbage almost collapses on it.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1813,7 +1813,7 @@ The sound of creaking wagons and the pound of horse hooves on the dirt road
 become trapped between the inner city wall and the houses within the alley
 making strange echoing sounds that are very distracting.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1830,7 +1830,7 @@ be surprisingly empty for some reason.  Shadowy alleys can be noticed to the
 east and west along the inner city wall.  To the south is the Northern Gate to
 the inner city.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -1855,7 +1855,7 @@ bother cleaning this place up.  The sound of a fight can be heard further to
 the east within the alley.  This is definitely the most dangerous section of
 Sanctus.    
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1872,7 +1872,7 @@ that dispute was settled one way or the other.  The inner city wall to the
 south keeps the alley eternally in shadows, no matter the time of day or night.
 Houses to the north have their back doors shut and locked.    
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1889,7 +1889,7 @@ garbage pile a few feet away.  A mangy mutt trots slowly past and starts licking
 up the pool of blood.  A traveler here should keep moving unless they wanted to
 draw attention to themselves.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1906,7 +1906,7 @@ of the light.  The wall looks to be made from stone blocks and some sort of
 filler.  Its not possible to tell how thick it is, but judging from the height
 one could guess at least half as wide as it is tall.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D1
 ~
 ~
@@ -1923,7 +1923,7 @@ This intersection is at the northeast corner of the inner city wall.  On top of
 the wall one can see some type of post where the guards watch for any trouble.
 A large building to the east must be some sort of warehouse.  
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~
@@ -2036,7 +2036,7 @@ booming voice that echoes off the buildings and walls around.  The clank of
 armor and weapons is all about as guards change watches and work on their
 equipment.
 ~
-1 0 0 0 0 0
+1 0 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/100.wld
+++ b/lib/world/wld/100.wld
@@ -44,7 +44,7 @@ recluse hermit lives. You can't imagine living out here, beyond the safety of th
 city walls. Thick forests block any exit to the north and you can see the city wall
 to the south.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -61,7 +61,7 @@ slight gloom hangs over this part of the woods.  You start to walk a little
 faster.  Further to the west you can see a small clearing with something that
 looks like a shack.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -82,7 +82,7 @@ is thickening slightly, a little less sunlight is making it to the forest floor.
 Overhead you can hear birds chirping and squirrels chattering. This place feels very
 peaceful.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -103,7 +103,7 @@ Dun Maura. Many rumors abound of these savage beasts but few leave the city wall
 to explore. To the north you see a thick forest. To the east and west are small 
 paths along the city wall.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -123,7 +123,7 @@ Along the City Wall~
 looks as if the forest disappears all together and turns into a grassy plain.  
 Small innocent forest creatures abound in this healthy forest.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -144,7 +144,7 @@ far as the eyes can see. An unnatural cold breeze blows from the east. You have 
 sudden urge to head back towards the safety of the forest, or even better yet, 
 back to the city.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -164,7 +164,7 @@ A Dead End~
 the east. It looks impossible to cross. You have no choice but to head back west.
 These plains give you an eerie feeling anyways.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D3
 ~
 ~
@@ -176,7 +176,7 @@ Deep Forest~
 blocking your vision. It would be very easy for someone, or something, to sneak
 up on you here. You can continue north or east through the forest.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -192,7 +192,7 @@ Deep Forest~
 the animals gone? Tall trees are blocking alot of the sunlight here. It looks 
 even thicker to the west. The forest continues in all directions.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -216,7 +216,7 @@ Off the Northern Road~
 sounds of nature sooth you into a feeling of false security. You wonder at the
 tall trees and abundant wildlife.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -241,7 +241,7 @@ both travellers, merchants, and peddlers. Wagon tracks leave small ruts in the
 road. To the west is some thick woodlands, while to the east you think you can
 make out some plains in the distance. The road continues north or south.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -265,7 +265,7 @@ Off the Northern Road~
 the trees here are shorter and spaced further apart. To the east you see that the
 forest fades away into plains. You can explore in any direction.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -289,7 +289,7 @@ The Beginning of the Plains~
 casm that blocks any further travel east. You wonder at what could have caused 
 this natural barrier. You are blocked from continuing north or east.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D2
 ~
 ~
@@ -306,7 +306,7 @@ the exits to the north and east.  You start to wonder if someone could be spying
 on you.  Someone could be standing behind any one of these huge trees and you
 would never know.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -322,7 +322,7 @@ Deep Forest~
 northern road. Small animals scatter as you walk by, leaves and twigs crunch 
 under your feet. Someone could hear you coming from a mile away.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -346,7 +346,7 @@ Off the Northern Road~
 north.  The trees here are spaced several feet apart and you can see the
 movement of wildlife in the distance.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -372,7 +372,7 @@ the city.  To the north you can make out what looks like a body of water in the
 distance.  The forest is to the west and there are some plains in the distance
 to the east.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -396,7 +396,7 @@ Light Forest~
 east. It seems a little cold for this time of year. To the north you think you
 can hear the sound of rushing water. 
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -420,7 +420,7 @@ Before the Plains~
 to flow through it. But somehow it must of dried up. You can hear the sound of 
 running water in the distance.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -436,7 +436,7 @@ Deep Forest~
 blocked by the thick brush. To the north you can hear the roar of rushing water.
 Animals seem to abound in this forest. They keep distracting you.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -452,7 +452,7 @@ Deep Forest~
 is to continue east or west between the massive trees. The safety and easy travel
 of the northern road is just to your east.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -469,7 +469,7 @@ in fog. You can not make out what is on the other side. A large river feeds into
 the lake to the north. You can follow the road north or head back toward the 
 city to the east.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -493,7 +493,7 @@ The Northern Road~
 clean and refreshing. A blanket of fog obscures what is on the other side. The
 road goes continues east to west to go around the lake.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -513,7 +513,7 @@ A Bend in the Northern Road~
 realize it curves around to the west. The lake has a layer of fog over it. 
 To the east you can see plains in the distance.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -533,7 +533,7 @@ Edge of the Lake~
 water to the north. The lake seems very serene, you're tempted to take a quick
 dip in the water, but who knows what could be watching you.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -554,7 +554,7 @@ for good travelling. You feel like you are making good time and actually getting
 somewhere. The forest thickens to the west and north, leaving the only exits to
 the south and east.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -570,7 +570,7 @@ Before the Plains~
 make your way across it.  The only way to continue is to the west or to the north.
 You can hear the sound of running water to the north.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -586,7 +586,7 @@ By the River~
 cross without a bridge. To the west the thick forest looks inpenetrable. You 
 think you can see a road to the east.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -602,7 +602,7 @@ By the River~
 the east you can see the northern road and what looks like a bridge to get
 across the river.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -618,7 +618,7 @@ The River Bridge~
 and must have taken years to build. The river empties into a massive lake just 
 to the east. The northern road continues across the bridge.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -638,7 +638,7 @@ Beside the Lake~
 blocks the way north. Though small, the rivers current looks fast and strong.
 You doubt you could wade across without being swept downstream. 
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -654,7 +654,7 @@ Light Forest~
 signs of civilization around. You would think this would be a great place to
 live off the land. You can continue along the river east or west.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -671,7 +671,7 @@ lake to the east.  Across the canyon you see fields of grass.  A small rickety
 rope bridge crosses the river to the north.  It looks like it might be able to
 hold one person at a time.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -691,7 +691,7 @@ Deep Forest~
 precariously over the river as the water washes away the soil from underneath
 them. The forest continues north or west.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -707,7 +707,7 @@ A Curve in the Northern Road~
 you are being watched. Someone could easily hide in these woods.  The road 
 continues north or turns east towards a bridge.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -727,7 +727,7 @@ A Curve in the Northern Road~
 east looks like the beginning of a swamp. A heavy fog from the lake billows 
 slowly across the road.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -751,7 +751,7 @@ North of the Lake~
 in the soft soil. The fog blowing off the lake is getting thicker. The silence
 is almost scary. You wonder what kind of creatures live in a swamp?
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -771,7 +771,7 @@ North of the Lake~
 stench of rot and decay is thick along with the fog. The wind coming off the
 lake does not seem to help at all.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -792,7 +792,7 @@ feet firm.  The river to the south must be the outlet to the massive lake.
 You can only leave to the north or west.  It looks like swampland in both
 directions.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -809,7 +809,7 @@ swamp.  Fetid water surrounds you, leaving the only way out to the north.
 Something causes ripples in the water, but is gone before you can tell what it
 was.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -821,7 +821,7 @@ Before the Plains~
 the east looks dangerous.  To the north you can continue into the plains.  The
 way east is blocked by the river.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -838,7 +838,7 @@ city.  You wonder about the fabled Dun Maura, city of the minotaurs.  Many
 stories abound about it, but you doubt half of them are true.  To the south you
 could enter the dense forest.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -859,7 +859,7 @@ The pond just to the north looks more like a bog than anything else.  Sick and
 dying trees are scattered throughout it.  It looks as if the area was recently
 flooded.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -879,7 +879,7 @@ Swamp~
 to the south and west that appear to be where the northern road works its way
 around this marsh.  The smell of decomposition is strong here.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -904,7 +904,7 @@ step into the muck.  It seems to be getting deeper here.  Your feet sink above
 the ankles once in a while.  Wildlife seems scarce.  You wonder why anything
 would live here.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -929,7 +929,7 @@ starting to sink almost all the way up to your knees now.  You wonder about the
 possibilities of quicksand, and all those stories you hear about people
 disappearing in these swamps.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -953,7 +953,7 @@ Swamp~
 down a little.  To the west you think you can see some drier land.  You thank
 the gods above.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -978,7 +978,7 @@ large crater in the ground.  You wonder who the unfortunate soul was to be
 walking across that when it gave out.  To the south and west the swamp looks
 even worse.  East you see the beginning of some plains.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -999,7 +999,7 @@ south you can hear the sound of rushing water.  West you stare into a dismal
 swampland.  The stories you've heard about getting lost in those plains makes
 you decide to stick closer to civilization.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1019,7 +1019,7 @@ The Northern Road~
 west looks too thick to bother leaving the easy travelling of this road.  The
 road continues north and south.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1035,7 +1035,7 @@ Beside the Pond~
 the north is more forest while east and south it looks a little swampy.  Small
 animals scatter as you intrude on their territory.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1055,7 +1055,7 @@ Swamp~
 your eyes tear.  The swamp continues to the south.  To the west you can see a
 body of water.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D2
 ~
 ~
@@ -1071,7 +1071,7 @@ A Small Bridge~
 walk in the muddy swamp.  It feels good to be on dry ground for a change.  The
 bridge leads north or south.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1087,7 +1087,7 @@ The Edge of a Sink Hole~
 fall away.  Luckily, you jump back before falling into this natural trap.  You
 look down into the sink hole and think you can see a Corpse.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D2
 ~
 ~
@@ -1105,7 +1105,7 @@ The Edge of the Plains~
 clean, open air.  A sink hole is just to the west.  Someone must have walked
 over it and caused it to collapse.  You pity the poor adventurer.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1122,7 +1122,7 @@ the city of Dun Maura.  The road to the south leads back to the safety of the
 city.  North is more dense forest.  To the west a fresh path has been hacked
 through the woods.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1142,7 +1142,7 @@ A Turn in the Northern Road~
 not just make a straight road.  Then you realize the swamp probably made it
 impossible.  The pond is to the south and it looks like a swamp to the east.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1162,7 +1162,7 @@ Swamp~
 not seem like a good day anymore.  The swamp is dismal and smelly.  The
 northern road is to the west.  Dry forest is north or east.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1186,7 +1186,7 @@ Deep Forest~
 and too suspicious for you to see.  You only hear the rufle of leaves as they
 hide from you.  The forest continues in all directions.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1206,7 +1206,7 @@ Deep Forest~
 surrounds you on all other sides.  This part of the forest seems peaceful.  
 Birds chirping and small animals chattering.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1231,7 +1231,7 @@ fields of grass.  Perfectly level land that you can see for miles.  South of
 you is a large natural crater of some sort.  It looks as if the ground had
 recently just given way.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1251,7 +1251,7 @@ Light Forest~
 some distance.  To the east the trees grow even more sparse and finally give
 way to the plains.  West will take you back into the thick forest.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1271,7 +1271,7 @@ The Edge of the Plains~
 perfectly level, allowing you to see for miles, one could easily get lost out
 there once they lost sight of the forest.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1291,7 +1291,7 @@ Deep Forest~
 small pine and fur trees hug the ground, reducing visibility.  The northern
 road is just south and east of here.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1307,7 +1307,7 @@ The Northern Road~
 The road continues north and south.  To the east and west is thick forest.  
 You think you can see an intersection of roads to the north.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1323,7 +1323,7 @@ Deep Forest~
 have found some sort of trail leading north and south between them.  You brush
 past the trees thankful for the bed of pine needles that quiets your footsteps.
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1339,7 +1339,7 @@ Deep Forest~
 through the underbrush.  Cobwebs cling to your face and sticks keep seeming to
 try and poke you in the eye.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1359,7 +1359,7 @@ Light Forest~
 forest continues in all directions.  To the north you think you can see the
 northern road.  South looks like more swamp.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1384,7 +1384,7 @@ any dangerous animals in these woods.  Childhood stories of viscious minotaurs
 spark sudden fears.  They were just stories to kep the children inside the city
 walls, weren't they?    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1405,7 +1405,7 @@ enjoy the fine scenery.  Nothing to worry about here.  Just a bunch of harmless
 little forest animals.  Then again, maybe some of these animals are not so
 harmless.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1421,7 +1421,7 @@ The Edge of the Plains~
 think of the stories about the plains of lost souls and wonder whether those
 were just stories or actually true.  
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1437,7 +1437,7 @@ Deep Forest~
 make out a small road of some sort.  It definitely is not the northern road
 which you believe is due east of where you are.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1453,7 +1453,7 @@ A Turn in the Northern Road~
 smaller road leading off to the north.  It looks like it has been rarely used.
 Which way to go?  How about the one less travelled?    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1473,7 +1473,7 @@ The Northern Road~
 eventually turn back north to the city of minotaurs.  To the west it heads back
 to the city.  North and south you see more forest.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1493,7 +1493,7 @@ The Northern Road~
 south.  The road seems a little less travelled through this part.  You notice
 fewer ruts in the road from wagons and even fewer people.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1517,7 +1517,7 @@ A Small Road~
 west the forest stretches out in all other directions.  This road looks like it
 has not been used for years.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1541,7 +1541,7 @@ A Bend in the Small Road~
 the start of the plains is to the east.  This road is covered with grass and
 even a few small trees.  It looks like no one has travelled it for years.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1565,7 +1565,7 @@ Light Forest~
 and south is even more forest.  It seems no one ever comes this deep into the
 woods.  All the animals seem to be staring at you.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D2
 ~
 ~
@@ -1582,7 +1582,7 @@ woods compared to this open vulnerability.  To the north you can see a small
 road.  You occasionally notice the sway of the grass on the plains as something
 or someone moves stealthily through.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1598,7 +1598,7 @@ A Small Road~
 meant to go.  It looks like it might continue to the east, or you can enter the
 forest to the south.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1614,7 +1614,7 @@ A Small Road~
 remain that allow you to determine which way it goes.  It looks like it
 continues to the west and to the south.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1638,7 +1638,7 @@ Deep Forest~
 another smaller road lies to the west.  Small animals sit and stare at you
 instead of running away.  They must not be used to seeing trespassers.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1655,7 +1655,7 @@ coming close to Dun Maura by now.  You have been travelling forever.  Fewer
 people seem to be on the road anymore.  You are not sure if that is a good or
 bad sign.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1679,7 +1679,7 @@ Light Forest~
 The road also seems to curve to the south.  West is the main road to Dun Maura
 or back to the safety of the city.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1703,7 +1703,7 @@ A Small Road~
 can see the northern road.  You look for any signs of life, but find nothing.
 It seems you are deep into the wilderness where few dare go.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1723,7 +1723,7 @@ A Small Road~
 keep track of where it goes.  It seems to be heading to the east toward the
 plains.  It also goes west toward the main road.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1743,7 +1743,7 @@ A Small Road Into the Plains~
 northern road towards the minotaur city.  The confines of the forest seem to
 beckon you compared to the openness of the plains.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D2
 ~
 ~
@@ -1759,7 +1759,7 @@ Deep Forest~
 the south you can make out a small road.  To the north you think you can see
 some sort of wall.  Could it be the city of the minotaurs at last?    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1780,7 +1780,7 @@ be getting a little claustrophobic.  To the south you can make out the northern
 road.  North you can just barely see some sort of wall.  Definitely not natures
 work.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1800,7 +1800,7 @@ Near the End of the Northern Road~
 Just to the north you can see the city of the minotaurs.  A great wall
 surrounds the entire city.  You wonder about heading back south to safety.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1824,7 +1824,7 @@ Light Forest~
 city of minotaurs.  The woods here are very dark and quiet.  Few creaturs seem
 to live in these parts.  A gloom seems to hang over this forest.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1848,7 +1848,7 @@ Light Forest~
 gloom and despair.  The woods seem to look darker by the minute.  Something is
 definitely wrong with this part of the woods, but you can not tell what.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1864,7 +1864,7 @@ Edge of the Plains~
 the walls of a city.  West you can enter a dark forest.  A wind blows from the
 east, bringing with it an unseasonal chill.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D0
 ~
 ~
@@ -1884,7 +1884,7 @@ Beside the City Walls of Dun Maura~
 been cut back away from the walls to allow good visibility for defense.  The
 gate of the city must be to the east.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1900,7 +1900,7 @@ Beside the City Walls of Dun Maura~
 You couldn't imagine any human being able to life such things.  The walls are
 definite eye sores, but they serve their purpose well.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1921,7 +1921,7 @@ gates are closed and they look like they have been that way for quite some
 time.  You can search the city walls east and west or head back south towards
 home.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1942,7 +1942,7 @@ not help but wonder if someone has a bow pointed at you from above.  You should
 probably move a little deeper into the woods away from the walls before you
 find out.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1963,7 +1963,7 @@ The gates to the city must be west from here.  The forest south looks very
 gloomy.  To the east is more of the city wall that heads out into the plains.
   
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D1
 ~
 ~
@@ -1979,7 +1979,7 @@ Beside the City Walls of Dun Maura~
 are directly north of you.  Also to the west you can see a light forest and
 what looks like the northern road in the distance.    
 ~
-100 0 0 0 0 0
+100 0 0 0 0 3
 D2
 ~
 ~

--- a/lib/world/wld/101.wld
+++ b/lib/world/wld/101.wld
@@ -26,7 +26,7 @@ the east warning you that the desert isn't far off in that direction.  The road
 leads off to the south, and north into the capital.  To the east and west
 farmland stretches as far as you can see.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D2
 ~
 ~
@@ -44,7 +44,7 @@ Fields stretch to the east and west, while the road continues north toward the
 souther gate of the capital which you can just barely see from here, and south
 through the farmland.  A warm wind from the east reminds you of the desert.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -61,7 +61,7 @@ you of the desert not too far off in that direction.  The walls of a large city
 can be seen on the horizon to the north, while farmland to the east and south
 has forced the road to take a turn to the west.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -78,7 +78,7 @@ here, while farmland stretches to the north and west.  A gust of warm wind
 blowing in from the east reminds you of the desert dominating the southeastern
 part of the continent.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -95,7 +95,7 @@ dominates the view to the east and west, while the road continues to the north
 and south.  A gust of warm wind blowing in from the east reminds you that you
 are not as far off from the desert as you might have thought.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -113,7 +113,7 @@ east from here.  A warm gust of wind blows in from the east, and reminds you of
 the desert to the east.  You can faintly hear the sound of running water
 somewhere to the south.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -130,7 +130,7 @@ as far as you can see, while the road continues east and west from here.
 There is a faint sound of running water from somewhere to the south.  A warm
 wind blows in from the desert in the east.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -147,7 +147,7 @@ and east from here, while the road continues south and west.  A warm wind is
 comming from the desert to the east, the sound of running water greets you from
 the south.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D2
 ~
 ~
@@ -163,7 +163,7 @@ The South Road~
 stretches to the east and west from here, while the road continues north and
 south.  You can hear the sound of running water from the south.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -181,7 +181,7 @@ wind from the east reminds you of the desert dominating the southeastern part of
 the continent.  You notice a small trail leading down to the river bank from
 here.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -198,7 +198,7 @@ far as your eyes can see, while the road continues to the east.  To the south a
 bridge crosses the river, connecting with the road on the other side.  A gust
 of warm wind from the east reminds you of the desert not too far off.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -215,7 +215,7 @@ south, while the river flows west toward the ocean somewhere in the distance.
 A gust of warm wind blows in from the east as if to remind you of the desert
 and the secrets it holds.
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -233,7 +233,7 @@ road continues to the south from here.  To the east and west grassland stretch
 as far as you can see.  A warm wind blows in from the east as to remind you of
 the desert dominating the southeastern part of the continent.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -250,7 +250,7 @@ continues north and west from here around a small formation of rocks.  To the
 east grassy plains stretch as far as you can see.  And you can hear the sound of
 running water greeting you from the north.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -267,7 +267,7 @@ continues to the east and south from here.  To the north and west you see grassy
 plains stretching as far as you can see.  You also notice the sound of running
 water to the north.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -284,7 +284,7 @@ continues north and south from here, while to the east a formation of rocks
 blocks your view and passage.  To the west grassy plains stretch as far as you
 can see.  A faint sound of running water can be heard comming from the north.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -301,7 +301,7 @@ continues to the north and south, while to the east your path and view is
 blocked by a formation of rocks.  To the west grassy plains stretch as far as
 you can see.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -319,7 +319,7 @@ rocks.  To the west grassy plains stretch as far as you can see.  A gust of warm
 wind blows down from the rocks to the east, as if to remind you that you are
 still relatively close to the desert.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -336,7 +336,7 @@ south.  The road leads off to the north and east here, while to the south and
 west grassy plains stretch as far as you can see.  A gust of warm wind comes in
 from the east, as if to remind you of the desert and the secrets it holds.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -353,7 +353,7 @@ road continues east and west from here, while to the north your view and path is
 blocked by a small formation of rocks.  In the distance to the south you can
 barely see the beginning of a seemingly ancient dense forest.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -371,7 +371,7 @@ North and east of here grassy plains stretch as far as you can see.  A gust of
 warm wind blows in from the desert in the east as if to remind you of the
 secrets it holds.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D2
 ~
 ~
@@ -389,7 +389,7 @@ traded between the two cities.  The road continues north and south here, a gust
 of warm wind comes in from the desert which can barely be seen somewhere to the
 east, while fertile plains stretch to the west.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -409,7 +409,7 @@ the desert not too far off.  You see fertile grasslands to the east and west,
 while the road itself continues to the north and south, just south of here you
 can barely make out a small path leading off to the west.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -427,7 +427,7 @@ secrets.  The road continues north and south here, while a small trail leads off
 to the west.  Your view to the east is dominated by fertile grasslands, which
 are broken by a fine yellow line in the horizon.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -447,7 +447,7 @@ A Small Trail~
 north and south of you, while the trail continues to the east where it joins a
 busy north south bound road, and to the west deeper into the wilderness.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -465,7 +465,7 @@ forest in the distance, while there is nothing but grass to be seen to the
 north.  The trail continues to the east and to the west where it makes a turn
 south.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -482,7 +482,7 @@ see a dense forest some where in the distance, while vast grasslands stretch as
 far as you can see in all other directions.  The trail leads off to the east
 and to the south where it makes a turn to the west.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -500,7 +500,7 @@ to the south where a dense forest rises near the horizon.  The trail leads off
 to the north where it makes a turn eastward and to the west where it makes a
 turn to the north again.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -518,7 +518,7 @@ to the south where a dense forest rise near the horizon.  The trail leads off
 to the north where it makes a turn to the west, and to the east where it makes
 a turn north.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -534,7 +534,7 @@ A Small Trail~
 here, to the west you can see the trail getting wider, as it continues toward
 what seems to be smoking chimneys.  Maybe there is a village near here.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D2
 ~
 ~
@@ -551,7 +551,7 @@ off to the east, where it makes a turn southward.  Also to the west it turns
 toward an eerie looking village.  An uneasy feeling comes over you as your gaze
 returns to the village.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D1
 ~
 ~
@@ -566,7 +566,7 @@ with it's presence.  The road continues to the north where you can just barely
 make out a small trail leading west, and to the south, closer to the mountains,
 and Haven.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -585,7 +585,7 @@ where a dense forest forces it to make a turn eastward, and north through the
 open land towards the city.  The great southern mountain range towers before you
 in the southeast.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -605,7 +605,7 @@ distance.  The mountains provide some cover for the desert winds, but you can
 just feel it here, warm winds blowing in from the east as if to remind you of
 the mysteries hidden there.  
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D0
 ~
 ~
@@ -625,7 +625,7 @@ shrubs and woods preventing entrance to the adventures which are likely to be
 within.  The wind here is a strange blend of hot dry desert air and biting cold
 from the mountain glaciers.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 2
 D2
 ~
 ~
@@ -642,7 +642,7 @@ through the foothills between the mountains to the east, and a dense forest to
 the west.  Animal sounds can be heard from the forest, which at this point is
 too dense to enter.
 ~
-101 0 0 0 0 0
+101 0 0 0 0 4
 D0
 ~
 ~
@@ -660,7 +660,7 @@ east, gusts of cold wind comes in from the mountains to the east, strangling
 the sounds from the forest.  You barely notice the small trail leading east
 from here towards the mountains.    
 ~
-101 0 0 0 0 0
+101 0 0 0 0 4
 D0
 ~
 ~

--- a/lib/world/wld/103.wld
+++ b/lib/world/wld/103.wld
@@ -86,7 +86,7 @@ Kami's Lookout~
 person is kneeling here tending to a well kempt flower garden whistling happily.
 Another person stands here, a tall green man with pointy ears.  
 ~
-103 20 0 0 0 0
+103 20 0 0 0 1
 S
 #10305
 Start of Planet Namek~
@@ -96,7 +96,7 @@ are also here, and many green people are walking around working here.  Some
 tending to the gardens, others training their skills.  But one thing is certain,
 all of them look male.
 ~
-103 0 0 0 0 0
+103 0 0 0 0 1
 D0
 ~
 ~
@@ -113,7 +113,7 @@ Base of Korins Tower~
 allowing the sun in.  Towards the east is a dirt path in which you cannot see
 the end of.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 3
 D1
 ~
 ~
@@ -125,7 +125,7 @@ Forest path~
 air.  @gTrees limit you to this single path, sounds come from the woods and area
 ahead.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D1
 ~
 ~
@@ -141,7 +141,7 @@ Forest Intersection~
 towards the north is another small clearing.  A large gaping hole is in the
 middle of the ground here.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D0
 ~
 ~
@@ -165,7 +165,7 @@ Gokus' House~
 This is a cleared out space in the forest.  @gThe house seems to make everything
 feel good again, as if it has some magical feeling to it.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D2
 ~
 ~
@@ -177,7 +177,7 @@ A Dark Hole~
 surrounding you.  @gThe walls are sleek, it seems that if one were to fall into
 this hole, they would not be able to escape easily.  
 ~
-103 1 0 0 0 0
+103 1 0 0 0 3
 D4
 ~
 ~
@@ -193,7 +193,7 @@ The Base of the Dark Hole~
 and then, strange plants grow all over the walls here. @gIt is dark, almost so
 dark it makes it hard to see, the only light comes from above you. 
 ~
-103 1 0 0 0 0
+103 1 0 0 0 3
 D4
 ~
 ~
@@ -205,7 +205,7 @@ A Forest Path~
 air.  @gThe trees still cover the area around the path, just limiting you to
 this one spot.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D1
 ~
 ~
@@ -221,7 +221,7 @@ The end of the Forest~
 still inhabbit this area, and the smell of death is still strong, but not as
 strong as it used to be.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D1
 ~
 ~
@@ -239,7 +239,7 @@ like it has been through many storms.  Off to the east you see a small island
 with an even smaller house, to the south is a large dome building marked with a
 large black CC.  
 ~
-103 4 0 0 0 0
+103 4 0 0 0 2
 D0
 ~
 ~
@@ -263,7 +263,7 @@ The Entrance to Capsul Corp~
 To the south is a large entrance to the building marked with a CC.  This dome
 shaped building seems a lot bigger than it did before.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 2
 D0
 ~
 ~
@@ -369,7 +369,7 @@ lies amongst the sand here and there, and small birds chirp in the forest.
 This place seems to be perfect to just relax and take a break from the everyday
 life.  @n
 ~
-103 20 0 0 0 0
+103 20 0 0 0 2
 D0
 ~
 ~
@@ -392,7 +392,7 @@ destructive human hand,@n @Bthe trees to the northwest are to thick to see
 through much less walk through.  This also seems to be a perfect place to relax
 from the troubles of everyday.  @n
 ~
-103 20 0 0 0 0
+103 20 0 0 0 3
 D2
 ~
 ~
@@ -440,7 +440,7 @@ Soaring Over the Ocean~
 abundant here then they were on the beach and this does place is not as soothing
 either.  @n
 ~
-103 0 0 0 0 0
+103 0 0 0 0 8
 D1
 ~
 ~
@@ -456,7 +456,7 @@ Soaring Over the Ocean~
 abundant here then they were on the beach and this does place is not as soothing
 either.  @n
 ~
-103 0 0 0 0 0
+103 0 0 0 0 8
 D1
 ~
 ~
@@ -472,7 +472,7 @@ Soaring Over the Ocean~
 abundant here then they were on the beach and this does place is not as soothing
 either.  @n
 ~
-103 0 0 0 0 0
+103 0 0 0 0 8
 D0
 ~
 ~
@@ -488,7 +488,7 @@ Soaring Over the Ocean~
 But the salt still lingers in the air and the Seaguls fly overhead.  @n @gThe
 sun seems to be harsher here then it is any other part of the ocean.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 8
 D1
 ~
 ~
@@ -504,7 +504,7 @@ In Shallow Water~
 a house with 'KAMI' in large red letters.  A bald old man sits out front looking
 at a dirty magazine.  @n
 ~
-103 0 0 0 0 0
+103 0 0 0 0 8
 D0
 ~
 ~
@@ -520,7 +520,7 @@ Infront of Kami House~
 white facial hair and large sunglasses.  He wears a turtle shell on his back.  
 @gWaves wash gentle up onto the shore, and a gentle breeze blows here.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 1
 D0
 ~
 ~
@@ -697,7 +697,7 @@ the arch you are able to see a magnificent lush garden, anything you could
 possibly think of resides in this place, in the its center is a huge oak tree,
 it provides shade for anyone who sits under it.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 3
 D1
 ~
 ~
@@ -731,7 +731,7 @@ area, the sun cannot get through the leaves of this tree, it seems to have been
 placed here on purpose, a magical feeling is coming from the tree, it makes
 your body tingle.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 3
 D0
 ~
 ~
@@ -792,7 +792,7 @@ here are tall with a little fluff of leaves and branches at the very top.
 There are also very few people in this village, and there are less children in
 this village, it seems to be a farming village.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 1
 D0
 ~
 ~
@@ -809,7 +809,7 @@ are tall with a little fluff of leaves and branches at the very top.  There are
 also very few people in this village, and there are less children in this
 village, it seems to be a farming village.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 1
 D0
 ~
 ~
@@ -826,7 +826,7 @@ are tall with a little fluff of leaves and branches at the very top.  There are
 also very few people in this village, and there are less children in this
 village, it seems to be a farming village.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 1
 D0
 ~
 ~
@@ -843,7 +843,7 @@ are tall with a little fluff of leaves and branches at the very top.  There are
 also very few people in this village, and there are less children in this
 village, it seems to be a farming village.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 1
 D1
 ~
 ~
@@ -860,7 +860,7 @@ are tall with a little fluff of leaves and branches at the very top.  There are
 also very few people in this village, and there are less children in this
 village, it seems to be a farming village.  
 ~
-103 16 0 0 0 0
+103 16 0 0 0 1
 D0
 ~
 ~
@@ -877,7 +877,7 @@ road seems to lead off to a tall mountain.  The trees here are even more scarce
 then in the village, on the side of the road, there are many large boulders on
 the side of the road.  
 ~
-103 20 0 0 0 0
+103 20 0 0 0 2
 D0
 ~
 ~
@@ -894,7 +894,7 @@ taller and taller.  You wonder what the significance of the mountain could be.
 The boulders still line the road and there are less and less trees, the ground
 seems to be harder here as well.  
 ~
-103 20 0 0 0 0
+103 20 0 0 0 2
 D0
 ~
 ~
@@ -910,7 +910,7 @@ Namek Road~
 barely see the top of it, and yet there is a tree here and there, and the
 boulders are still on the side of the road.  
 ~
-103 20 0 0 0 0
+103 20 0 0 0 2
 D0
 ~
 ~
@@ -943,7 +943,7 @@ Flying Up the Mountain~
 still far away, it might be easier to go back down.  @gIt seems to be getting a
 little warmer the further you go up.  
 ~
-103 4 0 0 0 0
+103 4 0 0 0 8
 D4
 ~
 ~
@@ -960,7 +960,7 @@ Flying Up the Mountain~
 this height, cawing and fluttering about.  @gIt seems to be getting a little
 warmer the further you go up.  
 ~
-103 4 0 0 0 0
+103 4 0 0 0 8
 D4
 ~
 ~
@@ -977,7 +977,7 @@ Flying Up the Mountain~
 but is not fully visible yet, it is still a little bit away.  @gIt seems to be
 getting a little warmer the further you go up.  
 ~
-103 4 0 0 0 0
+103 4 0 0 0 8
 D4
 ~
 ~
@@ -994,7 +994,7 @@ Flying at the Top of the Mountain~
 the sun pounds down on you.  Towards the north is a large house, with a strange
 picture on the side.  
 ~
-103 4 0 0 0 0
+103 4 0 0 0 8
 D0
 ~
 ~
@@ -1058,7 +1058,7 @@ On either side of the gate are two large Dragons, both look so real it is eerie.
 The sound of voices comes from the other side of the gate, it seems there is a
 town there.  
 ~
-103 4 0 0 0 0
+103 4 0 0 0 3
 D1
 ~
 ~
@@ -1075,7 +1075,7 @@ A Dirt Path~
 and it feels like it too.  @gNo creatures or people seem to come here anymore,
 it is just one deserted road.  
 ~
-103 4 0 0 0 0
+103 4 0 0 0 3
 D1
 ~
 ~
@@ -1091,7 +1091,7 @@ A Dirt Path~
 and it feels like it too.  @gNo creatures or people seem to come here anymore,
 it is just one deserted road.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D2
 ~
 ~
@@ -1107,7 +1107,7 @@ A Dirt Path~
 and it feels like it too.  @gNo creatures or people seem to come here anymore,
 it is just one deserted road.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D0
 ~
 ~
@@ -1123,7 +1123,7 @@ A Dirt Path~
 a large lake that seems to fill a large area.  @gNo creatures or people seem to
 come here anymore, it is just one deserted road.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D0
 ~
 ~
@@ -1140,7 +1140,7 @@ strange smell to it, kind of sweet in nature yet powerful.  No creatures are
 here, not even a bird.  
 @n
 ~
-103 4 0 0 0 0
+103 4 0 0 0 3
 D1
 ~
 ~
@@ -1158,7 +1158,7 @@ cannot see in here because the tree cover is so thick the light cannot penetrate
 it.  The air here smells stagnant and cold.  Sounds fill the area, making it
 impossible to think.  
 ~
-103 1 0 0 0 0
+103 1 0 0 0 3
 D1
 ~
 ~
@@ -1174,7 +1174,7 @@ A Small Clearing~
 cylindricle rock lies in the center of this area, it seems to be the cause of
 the clearing.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D1
 ~
 ~
@@ -1191,7 +1191,7 @@ path are thick, causing the area to be dark.  Sounds emit from this area,
 causing
 an eerie feeling.  
 ~
-103 1 0 0 0 0
+103 1 0 0 0 3
 D0
 ~
 ~
@@ -1207,7 +1207,7 @@ A Large Clearing~
 The grass grows freely and stands about waist high on either side of a short
 dirt path leading to a large dark cave.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D1
 ~
 ~
@@ -1340,7 +1340,7 @@ A Flower Field~
 throught the flowers yet it seems the there is a path to the south leading you
 away from the flowers.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 2
 D0
 ~
 ~
@@ -1356,7 +1356,7 @@ Path To the Villa~
 perfectly round, and they glow beautifully.  The path goes south towards a small
 Villa.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 1
 D0
 ~
 ~
@@ -1372,7 +1372,7 @@ Infront of the Villa~
 door is slightly ajar, the path you stand on has the same circular golden stones
 as to the north.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 1
 D0
 ~
 ~
@@ -1560,7 +1560,7 @@ Going To the Cave~
 here, it is a calm serene place, and the smell of apples lingers in the air all
 around you.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D0
 ~
 ~
@@ -1576,7 +1576,7 @@ An Apple Orchard~
 it is stronger here then it would be anywhere else.  Apple Trees grow wildly
 here, and there is no other tree to be seen.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D2
 ~
 ~
@@ -1592,7 +1592,7 @@ End of an Apple Orchard~
 it is stronger here then it would be anywhere else.  Apple Trees grow wildly
 here, and there is no other tree to be seen.  To the north is a lot of brush.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D0
 ~
 ~
@@ -1608,7 +1608,7 @@ Start of the Brush~
 seems to be a path leading straight through it, the sounds of people come from
 the other side of the brush.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D0
 ~
 ~
@@ -1624,7 +1624,7 @@ Path Through the Brush~
 walking, the brush on both sides of you looks to be dangerious.  @g It looks as
 if there are multiple animals caught in the brush on both sides.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 3
 D0
 ~
 ~
@@ -1640,7 +1640,7 @@ A Dangerous Path~
 seems as though it has grown there over the years, and it grows here as well,
 but not as much, for it seems to have been trodden down by people.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 2
 D2
 ~
 ~
@@ -1656,7 +1656,7 @@ Journeys End Inn~
 the door shows you that this place has been closed for many years.  The windows
 are broken, and a few are just missing.  
 ~
-103 0 0 0 0 0
+103 0 0 0 0 1
 D1
 ~
 ~

--- a/lib/world/wld/104.wld
+++ b/lib/world/wld/104.wld
@@ -37,7 +37,7 @@ break through the trees, but is unsuccessful.  The morning dew still sits on the
 forest floor, adding the this serene setting, the trees creep up towards the
 sky, large branches sticking out of its trunk, blocking the sky from view.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D0
 ~
 ~
@@ -67,7 +67,7 @@ seem to hold onto their spirits, these trees seem to be gentle, but at the same
 time they seem to be sinister, their branches seem to lash out and try to catch
 you in their grasp.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D2
 ~
 ~
@@ -83,7 +83,7 @@ place.  Some large branches cover this place, and multiple animal tracks are
 imprinted into the ground here.  Towards the top of the trees, the scratching of
 little squirrels feet bounces off the trees surrounding this place.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D1
 ~
 ~
@@ -106,7 +106,7 @@ shines in from the trees around you, not letting in a lot of light though.  The
 rustling of leaves comes to your ears in the area around you, adding to the
 feeling of being uncomfortable.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D0
 ~
 ~
@@ -126,7 +126,7 @@ were no trees overhead, this is not like the other parts of the forest, it is
 mostly clear, and it seems to have been forced to be this way.  The wind
 whistles through here, rustling leaves and moving branches all around.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D1
 ~
 ~
@@ -163,7 +163,7 @@ trees swaying branches.  A small stream flows gently into the forest.  Small
 fish can be seen in the stream, bolting up and down the stream, distorting the
 image af the pebbles.  The grass is soft and the color is perfect.  @n
 ~
-104 16 0 0 0 0
+104 16 0 0 0 2
 D3
 ~
 ~
@@ -178,7 +178,7 @@ or a rope.  Large plastic bottles cover the ground, and some foam coolers every
 now and then.  A piece of broken wood lies in a large brush pile, it seems to be
 connected to the brush.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D2
 ~
 ~
@@ -197,7 +197,7 @@ sits at the back of the room where the items are and a Elven man sits behind it.
 Light flows in through a small window on the side of the room, it seems to have
 no glass so it a small breeze comes in through it.  @n
 ~
-104 12 0 0 0 0
+104 12 0 0 0 3
 D0
 ~
 ~
@@ -216,7 +216,7 @@ to just rest.  The air is fresh, and the sounds of animals also fills your ears.
 Tall grass grows all around the lake, and large boulders are also here.  It is
 mysterious how they got here, air also has a moist smell in it.  
 ~
-104 20 0 0 0 0
+104 20 0 0 0 3
 D0
 ~
 ~
@@ -234,7 +234,7 @@ To the north is another forest, dark shadows cover it's entrance.  Even larger
 skeletons cover the ground, some human, and some are unknown.  A cold feeling
 emits from the forest, adding an uncomfortable feeling to this area.  @n
 ~
-104 20 0 0 0 0
+104 20 0 0 0 3
 D0
 ~
 ~
@@ -261,7 +261,7 @@ emit from the house, and a horrid smell also comes from the house.  An old
 rusted well sits in front of the house, it seems to have been protected from the
 tree by the house.  
 ~
-104 4 0 0 0 0
+104 4 0 0 0 3
 D0
 ~
 ~
@@ -276,7 +276,7 @@ gate.  At the top of the gate is some weird insigne, this is also on either side
 of the gate.  At the gates entrance the wooden platform stops and the ground
 turns to rock.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 1
 D1
 ~
 ~
@@ -294,7 +294,7 @@ to the north the road continues, and it also continues to the south.  Noise
 emits from people walking around on this road, they seem to be in a hurry, and
 don't want to talk to anyone.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 1
 D0
 ~
 ~
@@ -317,7 +317,7 @@ house are made of pine wood, each step has been carefully cut, and carefully put
 in to its place.  The door stands open, letting in the fresh air from the
 outside.  @n
 ~
-104 0 0 0 0 0
+104 0 0 0 0 1
 D0
 ~
 ~
@@ -336,7 +336,7 @@ cover the wall towards the back.  Some large swords are placed neatly in a
 little case, also hanging on the wall.  A large round oak table sits in the
 center of the room, with one lone chair sitting at it.  @n
 ~
-104 8 0 0 0 0
+104 8 0 0 0 1
 D2
 ~
 ~
@@ -355,7 +355,7 @@ now and then.  A sign is stuck into the ground on the side of the road, it seems
 to be a direction sign.  A warm feeling seems to be coming from all around you.
 It seems to be coming from the towns people.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 1
 D1
 ~
 ~
@@ -373,7 +373,7 @@ others tall.  But every person seems to be Elven.  A warm feeling comes from the
 area around you.  The people seem to be giving this feeling off.  The cobble
 stone road is freshly polished and looks to be brand new.  
 ~
-104 0 0 0 0 0
+104 0 0 0 0 1
 D0
 ~
 ~
@@ -392,7 +392,7 @@ inside of it it has very few maps.  But there are many sheets of parchment.  A
 very beautiful young looking elf sits behind the glass desk, making what seems
 to be a map.  @n
 ~
-104 28 0 0 0 0
+104 28 0 0 0 1
 D2
 ~
 ~
@@ -406,7 +406,7 @@ lies to the west, it seems to be gaining a lot of attention.  A small breeze
 blows through this part of town.  Another sign has been placed neatly on the
 wall beside the buildings opening.  @n
 ~
-104 0 0 0 0 0
+104 0 0 0 0 1
 D0
 ~
 ~
@@ -426,7 +426,7 @@ and it turns out to be coming from a small cobble stone fire place off in the
 other corner of the room.  Each stone has been placed on this fireplace with
 extreme care.  @n
 ~
-104 8 0 0 0 0
+104 8 0 0 0 1
 D0
 ~
 ~
@@ -445,7 +445,7 @@ the room.  Lining the walls is a small assortment of armour, it seems that this
 shop has just opened.  Although there is not much armour, it seems to be
 extremely expensive.  @n
 ~
-104 8 0 0 0 0
+104 8 0 0 0 1
 D2
 ~
 ~
@@ -464,7 +464,7 @@ A large golden statue of some old looking elf is in front of this house.
 Beautiful pine steps are leading up to his house, and the door is nowhere to be
 seen, it seems it has been taken off.  @n
 ~
-104 0 0 0 0 0
+104 0 0 0 0 1
 D0
 ~
 ~
@@ -486,7 +486,7 @@ center of the room.  Heat emits from another well built looking cobble stone
 fireplace.  High in the rafter you notice another red glowing orb.  This orb
 adds another reddish tint, but the color is darker.  @n
 ~
-104 28 0 0 0 0
+104 28 0 0 0 1
 D0
 ~
 ~
@@ -1148,7 +1148,7 @@ A New Zone Description Room~
 @W.''\  /'. .'  \__.`)@y  |- .'|@W .''\  /'.  .'  \__.`_
 @W    '.   `       |'  @y  `\-/@W(                      \@n
 ~
-104 132 0 0 0 0
+104 132 0 0 0 8
 S
 #10460
 Path Through the Forest~
@@ -1156,7 +1156,7 @@ Path Through the Forest~
 The earth is compact and the no shuberry grows near this place. The sky above
 can be seen, but it looks as if the sky fades into the trees ahead. @n
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D0
 ~
 ~
@@ -1173,7 +1173,7 @@ straight path. The brush looks like it is growing away from the road, as if
 some sort of magic is causing it to retreat. The Sky is not able to be seen,
 and the sounds of the forest have become silent now.
 ~
-104 0 0 0 0 0
+104 0 0 0 0 3
 D2
 ~
 ~
@@ -1223,7 +1223,7 @@ cleaned it for months.  Large tools scatter the desk off in the corner, and many
 piles of papers with writing on them scatter this desk as well.  The ceiling 
 above is nothing but a thick looking glass with bars filling in for support.@n
 ~
-104 4 0 0 0 0
+104 4 0 0 0 1
 D2
 ~
 ~

--- a/lib/world/wld/106.wld
+++ b/lib/world/wld/106.wld
@@ -186,7 +186,7 @@ beyond the gate and walls.  You remember rumors of the city being overthrown by
 a new political faction.  But who listens to politics.  "Poli" meaning many,
 "tics" meaning blood sucking insects.    
 ~
-106 0 0 0 0 0
+106 0 0 0 0 3
 D0
 ~
 ~
@@ -265,7 +265,7 @@ or possible overthrowing.  Many cunning politicians have plans for this city.
 A gravel path continues east out the gate.  The north is blocked by a tall
 cliff face.    
 ~
-106 0 0 0 0 0
+106 0 0 0 0 3
 D3
 ~
 ~
@@ -341,7 +341,7 @@ ill and rumors abound.  Everything from him being poisoned to an illness sent
 from the Gods because of the Mayor's betrayal to the upkeep of the citizens.  
 A thick forest can be seen to the west.    
 ~
-106 0 0 0 0 0
+106 0 0 0 0 3
 D1
 ~
 ~

--- a/lib/world/wld/107.wld
+++ b/lib/world/wld/107.wld
@@ -61,7 +61,7 @@ changes through weather.  The surroundings show nothing but broken wood and
 moss, eminating a foul smell that gathers into your nostrils and greens your
 thoughts into what may lay ahead of this damned place.    
 ~
-107 1 0 0 0 0
+107 1 0 0 0 1
 D0
 ~
 ~
@@ -195,7 +195,7 @@ decay of the swamp.  A few small stone buildings can be seen struggling to
 remain above the murky waters.  To the north an entire building looks almost
 untouched by the surrounding swamp.    
 ~
-107 8 0 0 0 0
+107 8 0 0 0 6
 D0
 ~
 ~
@@ -216,7 +216,7 @@ rotting overgrowned weedgrass.  A strange stairway of the thick fog looks solid
 enough to walk on.  It rises high above you into a low hanging cloud of white
 vapor.    
 ~
-107 0 0 0 0 0
+107 0 0 0 0 6
 D0
 ~
 ~
@@ -246,7 +246,7 @@ The walls of rock are the only remains of an unkown civilization that has been
 buried and forgotten in the realm of the undead.  To the south you can see a
 faint trail that looks drier than the surrounding area.    
 ~
-107 0 0 0 0 0
+107 0 0 0 0 6
 D0
 ~
 ~
@@ -264,7 +264,7 @@ ceaseless scream in the distance.  The clouds overhead are motionless.  They
 look superficial, the only movement is that of a thin layer of fog rising off
 the murky water.    
 ~
-107 8 0 0 0 0
+107 8 0 0 0 6
 D1
 ~
 ~
@@ -282,7 +282,7 @@ sound.  The waters are an unhealthy shade of black and grey.  Making it
 impossible to judge the depth or see what lies underneath.  A few ripples in
 the water are the only sign of life in this hell hole.    
 ~
-107 12 0 0 0 0
+107 12 0 0 0 6
 D0
 ~
 ~
@@ -299,7 +299,7 @@ fingers trying to claw their way out of their swampy graves.  Large pools dark
 water reflect the strange unchanging sky above.  Small trailers of fog rise off
 the warm water and dissipate into the cool, still air.    
 ~
-107 0 0 0 0 0
+107 0 0 0 0 6
 D1
 ~
 ~
@@ -316,7 +316,7 @@ than reality.  Filthy water, dead trees, rotting debris floating motoinless in
 the still waters.  A large sinkhole has collapsed here.  Revealing a dark
 cavern below.    
 ~
-107 0 0 0 0 0
+107 0 0 0 0 6
 D1
 ~
 ~
@@ -333,7 +333,7 @@ Fluted columns of marble and granite stand naked with no roof to cover them.
 A once marvelous cobblestone road has been desecrated and broken by years of
 neglect.  The remnants of a few small buildings still remain.    
 ~
-107 1 0 0 0 0
+107 1 0 0 0 7
 D1
 ~
 ~
@@ -482,7 +482,7 @@ emitting rank gasses from decaying matter.  Sinkholes threaten to swallow the
 few remaining dead trees and trespassers that remain in the area.  The silence
 is broken only by an occasional shriek or moan from deep within the wastelands.
 ~
-107 8 0 0 0 0
+107 8 0 0 0 6
 D0
 ~
 ~
@@ -765,7 +765,7 @@ expanding it's diameter century over century.  Absolutely no light penetrates
 into this cavern trapping humid coldness in the air and a nerve racking
 silence.    
 ~
-107 357 0 0 0 0
+107 357 0 0 0 9
 D1
 ~
 ~

--- a/lib/world/wld/115.wld
+++ b/lib/world/wld/115.wld
@@ -7,7 +7,7 @@ faint sound of water running near by . Here lies a dirt path leading to the
 north.  To the east is a small garden.  To the west there are trees and a
 forested path.  
 ~
-115 32768 0 0 0 0
+115 32768 0 0 0 3
 D0
 ~
 ~
@@ -288,7 +288,7 @@ Forested Path~
 the trees to the north you can see the southern wall of an old monastery.  To
 the east and west the path continues.    
 ~
-115 32768 0 0 0 0
+115 32768 0 0 0 3
 D0
 ~
 ~
@@ -916,7 +916,7 @@ Entrance to the Battlegrounds~
 monastery but older in many ways.  It looks as if this building wasn't quite
 completed before it was ransacked by someone.    
 ~
-115 32772 0 0 0 0
+115 32772 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/117.wld
+++ b/lib/world/wld/117.wld
@@ -23,7 +23,7 @@ Pathway~
 with flowers of all colors.  The path takes you through a small forest of red
 leaved trees.  The towers are visible to the north.  
 ~
-117 4 0 0 0 0
+117 4 0 0 0 3
 D0
 ~
 ~
@@ -51,7 +51,7 @@ guards seem to be checking citizens as they enter.  There is a pathway that
 leads east to the second and seemingly taller tower.  This tower seems to be
 much wider than the other tower though.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D0
 ~
 ~
@@ -150,7 +150,7 @@ from one tower of Los Torres to the next.  The path has been travelled on by
 numerous people though it is still in very good shape.  The forest seems endless
 when peered into from here.  This area seems like a nice place to relax.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D1
 ~
 ~
@@ -610,7 +610,7 @@ some strange reason.  Citizens continue to walk past doing their own things and
 occasionally tripping on the various cracks in the path.  There seems to be a
 path to the south past the trees.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D1
 ~
 ~
@@ -645,7 +645,7 @@ why it could be such a bizarre color.  There are many brown footprints along the
 white tile, and the forest is still visible from here.  The sound of rummaging
 animals has been greatly overpowered by the sound of chatting people.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D0
 ~
 ~
@@ -685,7 +685,7 @@ forest is only slightly visible from here, and the tile of the path is clean and
 beautiful flowers line the sides.  The looming gray stone tower is to the north
 and the town plaza is to the south.  
 ~
-117 4 0 0 0 0
+117 4 0 0 0 1
 D0
 ~
 ~
@@ -711,7 +711,7 @@ spruced here and there with windows made of crystal clear glass.  The white
 pathway is kept nice and tidy for the citizens passing through.  The forest of
 red continues north even though the path ends here.
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D0
 ~
 ~
@@ -1243,7 +1243,7 @@ the statue downstairs is for.  There are little extended balconies to relax on
 to the north and to the south.  Other than that, the only place left to go is
 all the way back down.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D0
 ~
 ~
@@ -1271,7 +1271,7 @@ North Balcony~
 calm and there is an endless view of red trees from here.  The forest seems like
 it has so many mysteries...  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D2
 ~
 ~
@@ -1294,7 +1294,7 @@ town below is visible.  Citizens are talking, though the noise doesn't seem to
 echo all the way up to here.  There are a couple chairs here so that people can
 relax in them and take in the view.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 1
 D0
 ~
 ~
@@ -1362,7 +1362,7 @@ Path Behind the Tower~
 path, and to the south is the small opening that the firelace opened up.  The
 forest continues indefinitely in all directions otherwise
 ~
-117 0 0 0 0 0
+117 0 0 0 0 3
 D0
 ~
 ~
@@ -1379,7 +1379,7 @@ except for the tiny row to the south.  The light is totally blocked out from the
 thick canopy, and so is any vision upward.  It is now clear why this spot isn't
 visible from the towers.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 3
 D2
 ~
 ~
@@ -1462,7 +1462,7 @@ things attacking animals, and making them run around.  One stump off of the
 'path' is rather large compared to the other tree stumps.  There is a blockade
 of trees that seems to block any further movement.  
 ~
-117 68 0 0 0 0
+117 68 0 0 0 3
 D0
 ~
 forest~
@@ -1492,7 +1492,7 @@ the community.  A sign etched into a tree trunk reads 'Red Assassins'.  The tree
 trunks stretch up for a long distance and suddenly disappear within an
 impossibly thick canopy.  
 ~
-117 1 0 0 0 0
+117 1 0 0 0 3
 D0
 ~
 ~
@@ -1525,7 +1525,7 @@ side of the path are withered away and a bit dead but the source of the problem
 is not clear.  There is a small squirrel's nest in the branches of a lively tree
 placed over a peculiar patch of yellow sand on the ground.  
 ~
-117 65 0 0 0 0
+117 65 0 0 0 3
 D1
 ~
 ~
@@ -1585,7 +1585,7 @@ outside Los Torres is visible from here!  The 'wall' is enforced with rocks and
 covered with leaves to hide it from anyone seeing it.  The hole is strategically
 placed to maybe spy on anyone walking past.  
 ~
-117 0 0 0 0 0
+117 0 0 0 0 3
 D3
 ~
 ~

--- a/lib/world/wld/118.wld
+++ b/lib/world/wld/118.wld
@@ -857,7 +857,7 @@ with glossy sealant so that it shines as though marble.  Creeping plants wind
 their way around each wooden post, bright fuschia and pink clematus flowers
 blossming abundantly.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 5
 D1
    A clear swimmingpool shimmers gently as the watery surface stirs, green
 leaves from the surrounding trees twirling in the air.
@@ -879,7 +879,7 @@ deeper, a small metal ladder attached to the side at the deepest end.  Green,
 blooming plants grow all around, large trees overhanging so that their trailing
 branches caress the water with each breeze.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 6
 D0
    Mountain landscape stretches all around, the gentle babbling of a small
 stream breaking the silence of the air.
@@ -916,7 +916,7 @@ clouds.  Soft open breeze carries the green scent of growth and life, new grass
 and dark fragrant pine trees.  Beautiful untouched landscape spans all around,
 the grassy paths sparkling softly with a sprinkling of fresh dewy tears.  
 ~
-118 4 0 0 0 0
+118 4 0 0 0 5
 D1
    This large oakdoor is as magnificent as the expensive house that lies beyond
 it, carved with beautiful patterning and polished until smooth and glossy.  
@@ -940,7 +940,7 @@ warm and soft one moment before changing to frosty chill the next.  Little
 sparks flicker randomly in the air, murmuring as they linger, only to fade and
 die like half spoken words.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
    A quaint English house lies to the north, a little cobblestone road winding
 its way to the modest front door.
@@ -976,7 +976,7 @@ into a garage at the side.  The sounds of birds chirping can be heard all
 around, and the subtle tinkling of a windchime though the air is still and
 breathtakingly cold.  To the north, a wooden door guards the way.
 ~
-118 0 0 0 0 0
+118 0 0 0 0 1
 D0
    This painted wooden door is relatively unnoteworthy, apart from its bright
 blue colour.  Time and dampness are already making their presence known through
@@ -1005,7 +1005,7 @@ plastic covering every window, and trees growing closely around as though
 huddled in some secret understanding.  A dark black door guards the way to the
 west.
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D1
    A white dome-shaped structure can be seen, adorned with pale green leaves and
 large red blossoms.
@@ -1361,7 +1361,7 @@ the breeze.  A row of bright yellow daffodils dance innocently to the east like
 golden bursts of sunfire, dark red roses spreading like a wound to the west,
 scarlet petals dripping slowly onto the ground as the flowers wilt.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 1
 D0
 ~
 ~
@@ -1395,7 +1395,7 @@ little brick houses can be seen, wisps of smoke unfurling lazily in the crisp
 air.  Distant smokestacks rise high above the horizon, the twinkling of car
 headlights passing through the shadowy air like shooting stars.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 1
 D1
    This large wooden window looks as though it is normally propped open, chips
 of paint peeling off the window frame around.  
@@ -1541,7 +1541,7 @@ A Massive Garden~
 grasses dried brown by the dry climate.  Only the flourishing yellow heads of
 dandelions brighten the place with colour.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -1561,7 +1561,7 @@ A Massive Garden~
 broken bicycles.  The grasses too seem stained with the colour of bleeding
 metal, the copper colour making the place seem even more dry and desert-like.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D2
 ~
 ~
@@ -1579,7 +1579,7 @@ uncertainly in the air, tiny seedlings and leaves wafting dreamily about.  The
 hard ground is slightly cracked, blistering with dryness benath the thick matted
 carpet of dead and dying grass.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D1
 ~
 ~
@@ -1597,7 +1597,7 @@ off to the east surrounded by flat brown grasses.  Few flowers grow here, only
 scattered weeds and a few dark shrubs, most of the land too dry to support much
 growth.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2011,7 +2011,7 @@ trickling along the grassless ground, making it glisten and shine even more.
 The surface slopes gently upward to the south, curving again abruptly down so
 that only horizon can be seen.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 4
 D1
 ~
 ~
@@ -2028,7 +2028,7 @@ On the Tip of a Hill~
 it an almost purposefully polished appearance.  The gently curving surfaces are
 flawless and almost reflective, covered in a fine sheen of moisture.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 4
 D2
 ~
 ~
@@ -2044,7 +2044,7 @@ A Sloping Ridge~
 colour veining through the rock as though mineral rich waters once ran in
 rivulets here, the tinted surface eroded until glossy and flawless.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 4
 D0
 ~
 ~
@@ -2068,7 +2068,7 @@ A Sloping Ridge~
 south, rosy hues of purple mixing with the cool grey.  Splotches of deeper
 colour blossom here and there, permanent stains on the smooth stony canvas.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 4
 D0
 ~
 ~
@@ -2093,7 +2093,7 @@ its surface as if brine water flowed through here at some point.  Perfectly
 eroded, the chalk-like blemishes are all that spoil the smoothness, dulling the
 natural shine of the stone.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 4
 D1
 ~
 ~
@@ -2106,7 +2106,7 @@ here, a faint vibration throbbing through the rock from some unseen source.  A
 feeling of heat rises in the air, the very surface of the stone hot to the touch
 as if warmed from within.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 4
 D3
 ~
 ~
@@ -2118,7 +2118,7 @@ A Grave Plain~
 breeze has stirred it.  No grass, rocks, or other features of any kind can be
 seen, just the ground untouched and bare like a vast sandy canvas.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2139,7 +2139,7 @@ of unused parchment.  Void of all plantlife and rockery, the only things
 noticeable are the slight ripples that work through the fine earth with each
 breeze.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2159,7 +2159,7 @@ A Grave Plain~
 smooth, pale soil.  Gentle heat wafts from all around, a thick muggy humidity
 lingering in the air and coating everything in sight with a subtle sheen.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2180,7 +2180,7 @@ and stubborn against the breezes, almost more like the spines of cacti than any
 green flora.  A deep shadow shrouds the place in gloom, the atmosphere clinging
 and moist.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2204,7 +2204,7 @@ Dark Grasses~
 crisp and dry though the surrounding air is hot and humid.  Thick black grasses
 stand rigidly, covered with a slick shine of moisture.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D2
 ~
 ~
@@ -2220,7 +2220,7 @@ Dark Grasses~
 stubbornly straining against the attempts of the breeze to move them.  Stifling
 muggy air swirls aimlessly about, leaving glistening droplets on every surface.
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2236,7 +2236,7 @@ Dark Grasses~
 too weary to stand tall.  The soft sandy soil is dark and ribbed, alive with the
 dancing shadows of the swaying plant life.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2252,7 +2252,7 @@ Dark Grasses~
 glossy with moisture and shining like black stalactites of oil.  An oppressive
 heat lingers in this place, a greasy film of wetness covering everything.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2276,7 +2276,7 @@ Dark Grasses~
 bend reluctantly to the wafting air.  Sticky and claustrophobic, the damp
 atmosphere seems to smother everything, filling the place with a tangy odour.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D1
 ~
 ~
@@ -2292,7 +2292,7 @@ Dark Grasses~
 seem to infuse this place with any life.  Muggy and clinging the air seems
 almost to coat everything with slime.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2308,7 +2308,7 @@ Dark Grasses~
 Sinewy grasses whisper mournfully, bent and stiff as though aging black ghosts
 that haunt the place.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2324,7 +2324,7 @@ A Grave Plain~
 glistening and stirring gently as the currents of air move, warmer air rising
 from the ground itself as if some heat source lay somewhere far beneath.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2344,7 +2344,7 @@ A Grave Plain~
 like gently rippled icing over the flat terrain.  A subtle heat stirs the air,
 making it shimmer and shift slightly as though part of some mirage.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2365,7 +2365,7 @@ continuous plane.  The air is warm and humid, the sticky atmosphere smelling
 vaguely of salt as if this were at the side of some ocean, though there is no
 sound of waves to be heard.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 2
 D0
 ~
 ~
@@ -2411,7 +2411,7 @@ smooth pebbles and the falling petals from nearby trees.  Clear mountain breezes
 wash cleanly over the land, filling the atmosphere with a peaceful, serene
 feeling; a beautiful jagged view of the mountainsides spreading out below.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 5
 D2
 ~
 ~
@@ -2450,7 +2450,7 @@ few people to be seen scurrying quickly about, faces down as they rush to their
 destinations.  All seems dim and dreary, the only warmth is the subtle glow of
 light coming from a shop to the east.  
 ~
-118 0 0 0 0 0
+118 0 0 0 0 1
 D1
 ~
 ~

--- a/lib/world/wld/12.wld
+++ b/lib/world/wld/12.wld
@@ -167,7 +167,7 @@ north.  Statues of Karileena the goddess of Honour and Justice, are lining the
 walls.  You realize this is where the exalted gods meet to discuss what course of
 action to take against offenders in the realms.    
 ~
-12 8 0 0 0 0
+12 8 0 0 0 9
 D0
 ~
 ~

--- a/lib/world/wld/120.wld
+++ b/lib/world/wld/120.wld
@@ -66,7 +66,7 @@ everywhere and the smell makes you want to puke.  Stairs lead up to Caesar's
 private box, a small ramp leads down to the playing field and a hallway 
 leads south.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D2
 You see a small hallway that leads to a larger area.
 ~
@@ -96,7 +96,7 @@ here are made of stone and are probably centuries old.  A few scratches on
 one of the benches catch your eye.  An acrid smell is coming from the east
 and a tunnel leads off to the north.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 The tunnel looks like it leads to another seating area.
 ~
@@ -121,7 +121,7 @@ bars, it hasn't been open for years.  Looking through the gate at the barren
 landscape that lies beyond, you can see why.  A dirt road leads off to the east,
 and a store is directly south.  
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D1
 Through the clouds of dust, you can make out a passable road.
 ~
@@ -197,7 +197,7 @@ on here; just bare dirty stone.  The view of the surrounding country is
 spectacular.  Unfortunately you can barely see the playing field.  There is
 a set of steps here, leading down.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D5
 Watch your step!
 ~
@@ -218,7 +218,7 @@ up in preparation for the games.  The dust rising from the parched earth makes
 you want to sneeze.  A short tunnel leads east and the thunder of pounding
 hooves and the clash of weapons can be heard coming from the south.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 2
 D1
 There is a large oval dirt-track in that direction.
 ~
@@ -257,7 +257,7 @@ The Jousting Arena~
 skewered by a gladiator's lance as he makes his charge.  A practicing
 area is due north.
 ~
-120 4 0 0 0 0
+120 4 0 0 0 2
 D0
 Through a small tunnel you can see athletes stretching and warming up for
 the games.
@@ -306,7 +306,7 @@ A Dirt Road~
    You are on a parched and dusty rural road which runs east and west.  There
 is a structure lying to the south.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 2
 D1
 Through the dust, you see a paved road.
 ~
@@ -394,7 +394,7 @@ prints everywhere, and you see a large cloud of dust approaching.  You had
 better move before you get run over.  A small tunnel leads west, you can see
 the crowd to the east.  You can hear loud snarls and roars coming from below.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 2
 D3
 You see athletes warming up and stretching.
 ~
@@ -433,7 +433,7 @@ statue of Caligula the Mad Emperor overlooks the area.  There are long
 lines standing to the east, and an acrid smell is coming from the west.
 A busy road lies to the south.
 ~
-120 4 0 0 0 0
+120 4 0 0 0 1
 D1
 The lines are very long and people look impatient.
 ~
@@ -461,7 +461,7 @@ The Main Highway~
    This is a well built and heavily traveled road running from east to west
 and there is a large structure built entirely of stone to the north.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 You can hear the roar of a large crowd of people coming from that direction.
 ~
@@ -529,7 +529,7 @@ areas, this place could stand extensive renovation and a thorough cleaning.
 This area extends to the south and a much more elegant seating area can be
 seen to the west.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D2
 The common seating area continues.
 ~
@@ -548,7 +548,7 @@ games.  Like the other commoners' areas in the coliseum, it could use
 extensive renovation and cleaning.  This area extends to the north and
 lots of noise can be heard coming from the south.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 The common seating area continues.
 ~
@@ -568,7 +568,7 @@ Emperor of a time long since passed, stands here looking out over the crowd.
 There is a passage to the north, the ticket booth is to the south and a gate 
 opening to the city lies to the east.
 ~
-120 4 0 0 0 0
+120 4 0 0 0 1
 D0
 You see rows upon rows of dilapidated wooden bleachers.
 ~
@@ -621,7 +621,7 @@ A Paved Road~
 looking estate to the south and to the north-west, off in the distance, you
 can see a very large stone structure.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D1
 The road leads off to the east.
 ~
@@ -653,7 +653,7 @@ situated to enhance and adorn the three statues of dedicated to gods Jupiter,
 Venus and Neptune.  A tranquil path leads east and west, there is a paved road
 to the north and an extravagant house lies to the south.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 2
 D0
 You see a paved road in the distance.
 ~
@@ -734,7 +734,7 @@ The Great North Gate~
 to be closed and locked against intrusion.  A large road muddy road runs
 through the gate and into the countryside.  Nero Drive runs south from here.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 The gate is made of solid iron and is well maintained.
 ~
@@ -760,7 +760,7 @@ Nero Drive~
 A great gate is directly north of here.  The Roman citizens are very friendly
 and tip their hats or say hello as you pass.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 To the north, you can see a gate leading out of the city.
 ~
@@ -785,7 +785,7 @@ to say hello.  Most of the people are either coming from or going to the
 town square.  Nero Drive continues to the north, and you can see a large
 open area to the south.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 Nero drive continues in that direction.
 ~
@@ -813,7 +813,7 @@ southeast, off in the distance, you can see the aqueduct and the buildings
 of the Roman government lie to the northwest.  Nero Drive leads north and
 south from here and Clay Avenue runs east.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 Nero Drive heads in the direction of the northern gate.
 ~
@@ -850,7 +850,7 @@ them are either coming from or going to the town square which lies to the
 north.  Nero Drive continues to the south.  There is an observation area
 overlooking the aqueduct to the east and a paved road leads west.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 The town square lies in that direction.
 ~
@@ -880,7 +880,7 @@ the city lies to the south and a small path goes west towards a nobleman's
 estate.  To the east, off in the distance, lies the great mountain.  It is
 rumored that the Gods watch over and protect the empire from there.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 Nero Drive leads in that direction.
 ~
@@ -905,7 +905,7 @@ closed and locked.  Looking through the bars, you see a heavily traveled
 road leading out of the city.  Nero Drive starts here and runs north and
 a wizard's shop lies to the east.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 Nero Drive leads towards the center of town.
 ~
@@ -1014,7 +1014,7 @@ Clay Avenue~
 heart of Rome.  There are large crowds of people to the west and the road
 continues to the east.  The aqueduct is directly south of here.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D1
 Clay Avenue continues in that direction.
 ~
@@ -1044,7 +1044,7 @@ hear the gurgle of water as it is channeled into the city.  Off in
 the distance, you can see the Mountain of the Gods.
 There is a sign mounted to the railing and a ramp leads west.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D3
 You can see a busy street in that direction.
 ~
@@ -1203,7 +1203,7 @@ Building.  There are several statues, none of any real significance,
 at the entrance to the building.  The main entrance to the building
 is at the top of the steps.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D4
 The steps lead into the Capitol Building.
 ~
@@ -1230,7 +1230,7 @@ through the heart of the city.  There are marble steps leading up.  To the
 south, off in the distance, you can see a large stone structure and a mountain
 that is partially obscured by the haze.  There is a general store to the north.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D0
 The general store lies in that direction.
 ~
@@ -1395,7 +1395,7 @@ eastern side of the city.  The gate is currently open and to the east,
 there is a heavily used road, made of packed clay, that leads out of Rome. 
 Another road leads westward into the city.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 1
 D1
 The clay road heads eastwards.
 ~
@@ -1571,7 +1571,7 @@ through the valley and enters a large stone structure that lies to the west.
 There are birds singing and every now and then a ripple breaks the surface
 of the stream.  You can see a path leading through the trees to the up.
 ~
-120 0 0 0 0 0
+120 0 0 0 0 4
 D0
 A small path winds its way through the trees.
 ~
@@ -1689,7 +1689,7 @@ abreast.  It is packed hard through heavy use.  To the west stands the
 Gates of Rome inviting you to enter and partake of all the glory and
 splendor that is Rome.
 ~
-120 8 0 0 0 0
+120 8 0 0 0 1
 D1
 ~
 ~
@@ -1705,7 +1705,7 @@ Clay Road~
 abreast.  It is packed hard through heavy use.  To the west, your eyes
 catch the splendors of a mighty city.
 ~
-120 8 0 0 0 0
+120 8 0 0 0 1
 D1
 ~
 ~
@@ -1720,7 +1720,7 @@ Clay Road~
    You travel upon an East-West road wide enough for 30 men to march
 abreast.
 ~
-120 8 0 0 0 0
+120 8 0 0 0 1
 D1
 ~
 ~
@@ -1736,7 +1736,7 @@ The End Of The Clay Road~
 here.  You feel a surge run through your body as you look East into the
 lands that Rome turned into its mighty empire.
 ~
-120 8 0 0 0 0
+120 8 0 0 0 1
 D1
 A dirt trail leads towards the desert to the east.
 ~
@@ -1758,7 +1758,7 @@ there is a city or settlement in that direction.
    You cannot see any breaks in the horizon of the sand which fills your
 vision as you look to the east, it seems to stretch forever.
 ~
-120 4 0 0 0 0
+120 4 0 0 0 1
 D1
 The expanse of the Great Eastern Desert opens up before you.
 ~

--- a/lib/world/wld/125.wld
+++ b/lib/world/wld/125.wld
@@ -6,7 +6,7 @@ shrills coming from within the city.  You think to yourself that you need to be
 ready for anything as you enter the gates.  An old sign is here, depicting a
 map of the city.
 ~
-125 4 0 0 0 0
+125 4 0 0 0 1
 D0
 Nothing.
 ~
@@ -50,7 +50,7 @@ Intersection of Trenton Avenue and Main Street.~
    You have entered what was once the great city of Hannah.  Main street leads
 to the north, while Trenton avenue leads east and west
 ~
-125 0 0 0 0 0
+125 0 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/140.wld
+++ b/lib/world/wld/140.wld
@@ -5,7 +5,7 @@ and to either side, blowing the dust into a blinding cloud.  The howling of the
 gusts and your own foot steps are all you can hear.  To your left a steep
 outcropping of rock blocks your way.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -42,7 +42,7 @@ The edge of the desert.~
 wind gusts blowing sand up into a blinding cloud.  In front of you a huge whirl
 wind of sand rages obscuring your vision.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -62,7 +62,7 @@ The edge of the desert.~
 wind gusts blowing sand up into a blinding cloud.  In front of you a huge whirl
 wind of sand rages obscuring your vision.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -83,7 +83,7 @@ and to either side, blowing the dust into a blinding cloud.  The howling of the
 gusts and your own foot steps are all you can hear.  To your right a steep
 outcropping of rock blocks your way.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -102,7 +102,7 @@ that storm out there really is?  Behind you the dust still rises in blinding
 clouds.  To your right you find a large smooth face of sand polished stone
 obstructing your path.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -124,7 +124,7 @@ your skin and the heat of the sun is almost unbearable.  You wonder how big
 that storm out there really is?  Behind you the dust still rises in blinding
 clouds.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -150,7 +150,7 @@ your skin and the heat of the sun is almost unbearable.  You wonder how big
 that storm out there really is?  Behind you the dust still rises in blinding
 clouds.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -177,7 +177,7 @@ that storm out there really is?  Behind you the dust still rises in blinding
 clouds.  To your left you find a large smooth face of sand polished stone
 obstructing your path.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -199,7 +199,7 @@ you.  You wonder if you will be able to breathe if this storm gets any worse.
 To your left cold rock blocks your way as far as you can reach in any
 direction.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -243,7 +243,7 @@ The blasted sands.~
 where you are going.  Your skin burns from the heat of the sun somewhere above
 you.  You wonder if you will be able to breathe if this storm gets any worse.
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -269,7 +269,7 @@ you.  You wonder if you will be able to breathe if this storm gets any worse.
 To your right cold rock blocks your way as far as you can reach in any
 direction.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -290,7 +290,7 @@ rock dominate the land before you and to either side.  You can see the heat
 rising in shimmering tendrils from the hills to the north, East, and West.  A
 cloud of dust and sand rises into the air to the south.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -311,7 +311,7 @@ rock dominate the land before you and to either side.  You can see the heat
 rising in shimmering tendrils from the hills to the north, East, and West.  A
 cloud of dust and sand rises into the air to the south.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -336,7 +336,7 @@ rock dominate the land before you and to either side.  You can see the heat
 rising in shimmering tendrils from the hills to the north, East, and West.  A
 cloud of dust and sand rises into the air to the south.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -361,7 +361,7 @@ rock dominate the land before you and to either side.  You can see the heat
 rising in shimmering tendrils from the hills to the north, East, and West.  A
 cloud of dust and sand rises into the air to the south.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -382,7 +382,7 @@ even higher.  To the south a desert of swirling sand and dust awaits more
 hopeless wanderers.  The wind gusts, moaning mournfully in your ears.  To the
 left you find yourself looking down a sheer cliff of red veined stone.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 4
 D1
 ~
 ~
@@ -398,7 +398,7 @@ The bad lands.~
 even higher.  To the south a desert of swirling sand and dust awaits more
 hopeless wanderers.  The wind gusts, moaning mournfully in your ears.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 4
 D0
 ~
 ~
@@ -422,7 +422,7 @@ The bad lands.~
 even higher.  To the south a desert of swirling sand and dust awaits more
 hopeless wanderers.  The wind gusts, moaning mournfully in your ears.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 4
 D0
 ~
 ~
@@ -447,7 +447,7 @@ even higher.  To the south a desert of swirling sand and dust awaits more
 hopeless wanderers.  The wind gusts, moaning mournfully in your ears.  To the
 right you find yourself looking into an impassable gorge of red streaked rock.
 ~
-140 0 0 0 0 0
+140 0 0 0 0 4
 D2
 ~
 ~
@@ -465,7 +465,7 @@ into the largest vortex of blowing wind and dust you have ever seen.  The wind
 roars and the sun beats down on you making you wonder if anything could
 possibly survive out here.    
 ~
-140 4 0 0 0 0
+140 4 0 0 0 4
 D0
 ~
 ~
@@ -487,7 +487,7 @@ into the largest vortex of blowing wind and dust you have ever seen.  The wind
 roars and the sun beats down on you making you wonder if anything could
 possibly survive out here.    
 ~
-140 4 0 0 0 0
+140 4 0 0 0 4
 D0
 ~
 ~
@@ -509,7 +509,7 @@ other direction.  The roar of the storm and the sound of your heart in your
 ears is deafening.  The blowing sand scours your exposed skin causing you to
 hunch your shoulders and seek shelter from the storm.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -527,7 +527,7 @@ The blowing sand scours your exposed skin causing you to hunch your shoulders
 and seek shelter from the storm.  You vaguely wonder how you are going to find
 your way through this stuff, and if you are strong enough to fight the winds.
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -553,7 +553,7 @@ The blowing sand scours your exposed skin causing you to hunch your shoulders
 and seek shelter from the storm.  You vaguely wonder how you are going to find
 your way through this stuff, and if you are strong enough to fight the winds.
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -579,7 +579,7 @@ The blowing sand scours your exposed skin causing you to hunch your shoulders
 and seek shelter from the storm.  The winds pull you to the north and west
 making it impossible to go in any other directions.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -596,7 +596,7 @@ balance.  Clouds of choking dust and sand fill your nostrils and throat making
 it almost impossible to breathe.  The wind pulls you to the North and West
 While to the South you can feel the same natural forces ravaging the land.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -618,7 +618,7 @@ still so strong that you don't dare raise your head to see what may be in that
 direction.  The tornado pulls you to the East and West and you can tell there
 is no better weather to the South.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -644,7 +644,7 @@ still so strong that you don't dare raise your head to see what may be in that
 direction.  The tornado pulls you to the East and West and you can tell there
 is no better weather to the South.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -668,7 +668,7 @@ In the storm.~
 dropping off while powerful winds pull you to the North and South.  Everything
 around you seems to be made of heat, pain, and deafening sound.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -689,7 +689,7 @@ a definite drop in the force of the gusts to the east.  To the North and South,
 the winds pull you toward more blinding sunscorched desert.  While to the west
 you find yourself unable to fight through the power of the storm.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -711,7 +711,7 @@ towering walls of wind and sand that are the funnel of this tornado.  You
 wonder what could be on the other side of those walls and if you should go back
 into them to find out.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -737,7 +737,7 @@ towering walls of wind and sand that are the funnel of this tornado.  You
 wonder what could be on the other side of those walls and if you should go back
 into them to find out.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -762,7 +762,7 @@ a definite drop in the force of the gusts to the east.  To the North and South,
 the winds pull you toward more blinding sunscorched desert.  While to the west
 you find yourself unable to fight through the power of the storm.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -782,7 +782,7 @@ In the storm.~
 Cold rock walls block your way to the north and East, while powerful winds pull
 you to the South and West.  You wonder if you will ever return from this trek.
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D2
 ~
 ~
@@ -799,7 +799,7 @@ is your imagination or not, but it seems like there is a moaning sound coming
 from the North.  However all you can really think about is the horrible heat
 and roar of the Storm.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D0
 ~
 ~
@@ -824,7 +824,7 @@ clothes and skin.  For all its force, the wind does not cool you off a bit.
 The storm continues to rage around you, but there seems to be a drop in the
 gusts to the South.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D1
 ~
 ~
@@ -845,7 +845,7 @@ to the South and East.  The force of the storm is so strong to the West that
 you can't move in that direction.  To the North, you encounter smooth stone
 walls.  The sound of sand scratching on rock fills your ears.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 2
 D1
 ~
 ~
@@ -896,7 +896,7 @@ The city opening.~
 low buildings that might be houses.  But what really draws your eye are the
 wyverns.  They are everywhere.  You wonder what you have stumbled across here.
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -914,7 +914,7 @@ The large reptilian citizens of this city move by you paying no attention to
 the insignificant creature in their domain.  The stone of this place is the
 same dull gray as the outer tunnels.  What a drab place to live.    
 ~
-140 4 0 0 0 0
+140 4 0 0 0 1
 D0
 ~
 ~
@@ -941,7 +941,7 @@ gates set into the stone wall there.  Some very large and well armored wyverns
 stand in front of the gates: guards?  The citizens keep their heads down as
 they walk through this part of the city, as if not wanting to be recognized.  
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -959,7 +959,7 @@ Two huge wyverns stand in front of the gates to the East.  One of them raises a
 giant claw and motions you to move on.  You realize that all the citizens of
 the city have disappeared leaving you alone before these massive creatures.  
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -982,7 +982,7 @@ road runs East and West to intersections.  As you are looking around one of the
 city guards plods by and gives you a glare from deep-set red eyes.  You begin
 to wonder if you should be here at all.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1000,7 +1000,7 @@ into the wall to the South not to be trampled.  Spike Road runs to the north,
 And Scale way extends to the East.  This entire city is very quiet as if the
 wyverns are communicating through some other means than speech.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1022,7 +1022,7 @@ A sign with a picture of a black staff covered in flames hangs over the door.
 The citizens seem to shy away from the door as if in fear.  Now what could make
 these huge beings afraid?    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1044,7 +1044,7 @@ wyvern child peeks at you from around a corner and then pulls its head back
 when it sees you looking at it.  There seems to be a store of some sort to the
 South East.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1069,7 +1069,7 @@ most of the traffic seems to be to the East at a large intersection.  To the
 west there is a small cave cut into the wall of the main cavern, While the
 walls of buildings form the North and South sides of the street.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1087,7 +1087,7 @@ low buildings you assume to be stores.  A gust of wind from the south blows the
 musky sent of the inhabitants of this city to you, reminding you of what an
 alien society you are really in.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1112,7 +1112,7 @@ activity.  The road runs North and South, While to the East and West you see
 the backs of the low stone buildings that these wyverns seem to favor.  The
 citizens still ignore you as if you weren't even there.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1129,7 +1129,7 @@ West to Fang street and Claw road.  With nothing else to look at you glance up
 to where the roof of the huge city cavern should be.  Far above the darkness
 continues and you wonder just how large this cavern really is?    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1147,7 +1147,7 @@ the long low buildings of the city.  You find yourself having to jump aside to
 avoid being crushed by a pair of workers carrying a long package by you.  A
 third citizen walks by and glares at you but says nothing.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1174,7 +1174,7 @@ a picture of a dragon diving into a barrel.  Many citizens enter and leave the
 building.  One of them leaves carrying a huge barrel.  He bumps into you and
 sends you sprawling, but doesn't seem to notice.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1195,7 +1195,7 @@ take little interest in this part of the city.  There looks to be a small cave
 cut into the rock wall to the North east.  There is a flash of movement from
 the street ahead of you and then it vanishes.  Is someone following you?    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1213,7 +1213,7 @@ can see a line of buildings running from East to West.  The streets here are
 larger and the buildings are more ornate.  Perhaps this is a more affluent part
 of the city?    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1240,7 +1240,7 @@ buildings to the north are the last line of shops in the main cavern.  You
 begin to wonder how these creatures were able to build such a large city when
 there seems to be no craftsman among them.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1258,7 +1258,7 @@ clearly see that the cavern wall opens into a long high tunnel.  In the center
 of the square is a large statue of Ferret the mighty Dragon.  The people that
 pass by all bow respectfully to the image of the all-mighty God.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1286,7 +1286,7 @@ it.  To the East there is a sign with a dragon breathing flames and dripping
 blood.  Citizens walk in out of both stores still saying nothing to you or
 anyone else.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1311,7 +1311,7 @@ cave opening to the West.  A guard marches by and growls at you deep in its
 throat.  Apparently this part of the city is off limits to most people.  The
 street itself is hemmed in by the sides of buildings to the North and South.  
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1329,7 +1329,7 @@ What could be of such value?  To the South and East you can look all the way
 down the streets to the opposite cavern walls.  With the size of the citizens
 it's no wonder they have such a large home.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1353,7 +1353,7 @@ Spike road.~
 quietly walk by in all directions.  There looks to be a small cave off to the
 north west from here.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1372,7 +1372,7 @@ might be the front of a store.  Something flies above you in the darkness
 blowing the sent of ancient dust and mold to you but when you look to see what
 it is nothing is there.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1391,7 +1391,7 @@ the side of the street.  Looking South you can see all the way to the end of
 Spike, where the guards headquarters is.  To the East is the front of a shop
 where several youths practice wielding weapons.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1415,7 +1415,7 @@ these reptiles seem to live in.  A guard wearing a huge crested helm plods by
 and spits at your feet.  There is a distinct feeling of menace about this
 place.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1440,7 +1440,7 @@ has invaded their privacy.  Looking South you can see some sort of statue in a
 small plaza.  Dragon drive extends East and West, while Claw road goes further
 South toward the entrance to the cavern.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1466,7 +1466,7 @@ Directly in front of you is an arched entrance into a long tunnel.  Young
 wyverns enter and leave the tunnel and you can hear the sounds of combat far to
 the North.  For your sake you hope they keep ignoring you.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1487,7 +1487,7 @@ north West a large tunnel opens up easily accommodating several 15 foot long
 citizens abreast.  East and West Dragon drive runs the width of the main city
 cavern.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1508,7 +1508,7 @@ small wyvern house.  Fang street runs the length of the city to the South,
 While to the West you can see two stores and a large cave opening in the North
 wall.  This city seems so inhospitable should you keep traveling here?    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1529,7 +1529,7 @@ citizens around here seem to be carrying weapons or wearing some kind of armor.
 The road you are on runs north and South following the curve of the main
 cavern.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1549,7 +1549,7 @@ sounds of battle and magic can be heard from that direction as well as
 chanting.  The smell of roasting meet comes from the door to the West and your
 mouth begins to water.  To the South is the End of Claw road.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1573,7 +1573,7 @@ chamber that emanates a feeling of magical energy.  The citizens and youth who
 walk through here all bow respectfully to the statuary, acknowledging their
 long lost ancestors as they pass by.    
 ~
-140 112 0 0 0 0
+140 112 0 0 0 1
 D0
 ~
 ~
@@ -1609,7 +1609,7 @@ gray stone floor is splattered with blood from accidental cuts and gashes.
 The room itself is a round arena filled with practice dummies and targets.  A
 huge plaque on one wall holds the names of all the graduates of the guild.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D3
 ~
 ~
@@ -1627,7 +1627,7 @@ large statue of their dragon God.  Smoke from burning braziers fills the room
 with a musky scent and candles cast a flickering glow on the smooth stone
 walls.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1641,7 +1641,7 @@ small alcoves around the room.  As you get a better view of the interior of the
 room you are aware of all the eyes, seen and unseen that focus on you.  The
 urge to climb out of this chamber to some place well-lighted is very strong.  
 ~
-140 96 0 0 0 0
+140 96 0 0 0 1
 D4
 ~
 Stone~
@@ -1658,7 +1658,7 @@ knights, Khelben, Lord of the Elements.  Set off in a depression in the floor
 is a old wyvern repairing the dented training armors of the students.  These
 warriors look very professional.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D5
 ~
 ~
@@ -1672,7 +1672,7 @@ and chant with holy symbols and books of wisdom in hand.  Despite the combative
 nature of wyverns, this room feels peaceful, an odd feeling given the general
 air of this city.    
 ~
-140 24 0 0 0 0
+140 24 0 0 0 1
 D0
 ~
 ~
@@ -1696,7 +1696,7 @@ The Viewing.~
 the holy viewing room where gods and mortals write their messages to each
 other.  In one corner a priest stands looking at the board.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D2
 ~
 ~
@@ -1709,7 +1709,7 @@ podium at the front of the hall.  In one corner a few old city officials are
 discussing some point of judicial law in hushed tones, while at one side of the
 hall a few citizens examine the board for news.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1726,7 +1726,7 @@ the items of this store without paying should know the owner does not need them
 to defend himself or his store.  Those who doubt should attempt to walk off
 with a weapon while guessing how many pieces they will be left in soon.  "
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 Door~
@@ -1742,7 +1742,7 @@ portions of roasted meets.  There is a sign hanging over the bar that reads,
 dimly lit making it difficult to see the faces of those in the room.  You
 vaguely think that this would be a good place for an ambush.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 Door~
@@ -1757,7 +1757,7 @@ hanging on it and a low counter separates you from the goods.  A sign on the
 counter reads, "Thieves will become part of the merchandise, those with thick
 hides are particularly encouraged to join those displayed on the wall.  "
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 Door~
@@ -1772,7 +1772,7 @@ reads, "If you're here to buy or sell come right on in, if you're here to
 steal.  Please enjoy our security measures, we'll clean up what's left of you
 later.  "
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 Door~
@@ -1788,7 +1788,7 @@ magical tomes.  There is a sign hanging from the center of the roof.  It says,
 will need them to recover from the beating they will receive from the owner.  
 Please pay for all items and have a nice day.  "
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D3
 ~
 Door~
@@ -1802,7 +1802,7 @@ counter of glowing red stone blocks your way before you can get any closer than
 looking at these wonders.  A small sign on the counter reads "do not touch the
 merchandise.  Survivors will be prosecuted.  "
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D3
 ~
 Door~
@@ -1816,7 +1816,7 @@ runs the length of the room.  Barrels and all sorts of containers are hung on a
 rack on the other side of the counter.  A small sign reads, "do not drink
 without paying.  Violators will get there drink then be drowned.  "
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 Door~
@@ -1831,7 +1831,7 @@ The roof is polished gray rock set with crystals and precious stones.  To the
 West the gates look like a good way to get out of here, something you are
 continually thinking about now.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1852,7 +1852,7 @@ family history of the royal line of this city.  Large wyverns stand everywhere
 looking at you with distaste, "What are you doing here?  " One of them asks.  
 The roof is polished gray rock set with crystals and precious stones.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1869,7 +1869,7 @@ family history of the royal line of this city.  Large wyverns stand everywhere
 looking at you with distaste, "What are you doing here?  " One of them asks.  
 The roof is polished gray rock set with crystals and precious stones.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1888,7 +1888,7 @@ The roof is polished gray rock set with crystals and precious stones.  To the
 North a natural opening in the rock leads to a second chamber.  All you can see
 within are the backs of worshiping Wyverns.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1910,7 +1910,7 @@ Wyverns kneel all around the chamber bowing their necks toward the throne.
 The room is lit by a huge glowing gem set in the roof.  You wonder what kind of
 wealth it would take to create such a chamber.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D2
 ~
 ~
@@ -1924,7 +1924,7 @@ waiting their turn to register complaints stand in the center of this natural
 cavern.  There is a large arch to the North, which wyverns enter and leave one
 at a time.  To the East a second smaller arch leads back on to Scale way.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D0
 ~
 ~
@@ -1942,7 +1942,7 @@ walls.  The room is lit only by a single candle over the couch.  The light
 flickers making it look as if the pictures on the wall are coming to life.  To
 the south an arch leads back into the waiting area.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D2
 ~
 ~
@@ -1958,7 +1958,7 @@ the room with a smoke hole at the peek of the domed roof to clear the air.
 There are no decorations or other pieces of furniture.  These wyverns don't
 seem to need very much to live comfortably.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D3
 ~
 ~
@@ -1974,7 +1974,7 @@ the room with a smoke hole at the peek of the domed roof to clear the air.
 There are no decorations or other pieces of furniture.  These wyverns don't
 seem to need very much to live comfortably.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -1990,7 +1990,7 @@ the room with a smoke hole at the peek of the domed roof to clear the air.
 There are no decorations or other pieces of furniture.  These wyverns don't
 seem to need very much to live comfortably.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -2006,7 +2006,7 @@ the room with a smoke hole at the peek of the domed roof to clear the air.
 There are no decorations or other pieces of furniture.  These wyverns don't
 seem to need very much to live comfortably.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D3
 ~
 ~
@@ -2022,7 +2022,7 @@ the room with a smoke hole at the peek of the domed roof to clear the air.
 There are no decorations or other pieces of furniture.  These wyverns don't
 seem to need very much to live comfortably.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D3
 ~
 ~
@@ -2038,7 +2038,7 @@ the room with a smoke hole at the peek of the domed roof to clear the air.
 There are no decorations or other pieces of furniture.  These wyverns don't
 seem to need very much to live comfortably.    
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D1
 ~
 ~
@@ -2051,7 +2051,7 @@ for those less fortunate than themselves.  The walls of this room are covered
 with hooks and shelving for more valuable items while barrels and baskets
 litter the floor for more common gifts.
 ~
-140 0 0 0 0 0
+140 0 0 0 0 1
 D3
 ~
 ~

--- a/lib/world/wld/15.wld
+++ b/lib/world/wld/15.wld
@@ -7,7 +7,7 @@ west, you see only the walls of the rocky cliffs.  Off to the
 north a strange path seems to lead straight into the depths of
 the mountain.
 ~
-15 4 0 0 0 0
+15 4 0 0 0 4
 D0
 A strange path leads northwards.
 ~

--- a/lib/world/wld/150.wld
+++ b/lib/world/wld/150.wld
@@ -8,7 +8,7 @@ that the road seems to be perfectly smooth and perfectly straight.
 surrounds the road at this point.
 A traveller passes by and waves cheerfully at you.
 ~
-150 4 0 0 0 0
+150 4 0 0 0 1
 D1
 The King's Road continues in a straight line to the east towards a grand
 castle.
@@ -36,7 +36,7 @@ The King's Road~
    You stand in the center of the great King's Road.  The road is very well
 built, and goes in a straight line due east-west.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 1
 D1
 The King's Road continues in a straight line to the east.
 ~
@@ -54,7 +54,7 @@ The King's Road~
 skill of the builders is apparent, since it is impossible to notice
 any turn or irregularity in the road.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 1
 D1
 You see a castle in the far east.
 ~
@@ -75,7 +75,7 @@ by a deep moat, and its windows are just narrow slits for archers
 to shoot through.  To the north there is a drawbridge across the
 moat.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 1
 D0
 You see the drawbridge.
 ~
@@ -93,7 +93,7 @@ On The Drawbridge~
 you is a huge, double-doored gate.  It seems very strong.  You see some
 whirls in the moat.
 ~
-150 4 0 0 0 0
+150 4 0 0 0 1
 D0
 The gate has huge, but intricately carved hinges.  As the Castle itself,
 it seems designed not only for strength, but also for beauty.
@@ -1399,7 +1399,7 @@ a peaceful feeling come over you as you realize that mankind
 has not passed this way for some time.
    The faded trail appears to lead north and south.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 4
 D0
 The travel upon the King's Road can be heard off to the north.
 ~
@@ -1423,7 +1423,7 @@ used that it has almost completely grown over with vegitation
 from the woods here.  
    The faded trail appears to lead north and east.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 4
 D0
 The trail continues northwards.
 ~
@@ -1449,7 +1449,7 @@ from the woods here.
 a strange eerie silence seems to hang in the air, almost blocking
 out all the sounds that you can hear from the north and east.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 4
 D2
 The undergrowth begins to open up to the south and you can see what
 appears to be a small village to the south.  It is very quiet, almost
@@ -1476,7 +1476,7 @@ village either.  It is almost as still and silent as the woods
 to the north.
 There is a small sign lying by the side of the road here.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 2
 D0
 An trail leads into the heavy undergrowth to the north.
 ~
@@ -1516,7 +1516,7 @@ as if the village hides a secret which they do not want to be spread
 about.
    There is another house standing on the east side of the road.  
 ~
-150 0 0 0 0 0
+150 0 0 0 0 2
 D0
 The dirt road continues to the north.
 ~
@@ -1549,7 +1549,7 @@ a building to the east with a small sign hanging out front from a black
 and charred chain.
    The dirt road continues north and south.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 2
 D0
 The small dirt road continues towards the north.
 ~
@@ -1593,7 +1593,7 @@ decade ago, but the village seems to have been empty for almost
 that long.
    The dirt road leads away from the carnage to the north.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 2
 D0
 Just near the north edge of the pit a small and narrow trail leads
 away.
@@ -1666,7 +1666,7 @@ near what is left of the north wall seems to indicate that this was
 once a shop.
    The road lies to the west through the blackened wall.
 ~
-150 0 0 0 0 0
+150 0 0 0 0 2
 D3
 You can see the dirt road to the west.
 ~
@@ -1684,7 +1684,7 @@ all around you seems to be almost contrived, and doesn't seem natural
 for this kind of vegitation.
    The path continues west and you can see light to the east.
 ~
-150 9 0 0 0 0
+150 9 0 0 0 1
 D1
 The path continues towards a small intersection with a dirt road.
 ~
@@ -1704,7 +1704,7 @@ as if they didn't want to feel your presence.  The wood is almost totally
 silent and you wonder silently to yourself why this could be.
    The path appears to continue east and west.
 ~
-150 9 0 0 0 0
+150 9 0 0 0 1
 D1
 The path continues through the darkness.
 ~
@@ -1732,7 +1732,7 @@ far above your heads blocking out the sky.
 in colour.  This glow provides enough light for you to see with even
 though the sky above has been blotted out.
 ~
-150 8 0 0 0 0
+150 8 0 0 0 1
 D1
 A narrow path leads away into the darkness.
 ~

--- a/lib/world/wld/16.wld
+++ b/lib/world/wld/16.wld
@@ -5,7 +5,7 @@ of people must have marched along this trail.  It almost looks like an army was
 marched through here.  A lake shrouded in fog is to the west and the city wall
 is to the east.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -57,7 +57,7 @@ positioned over the main gate.  More guards and lookouts are keeping watch
 above you.  They must be awaiting an attack, but who or what could make it
 across that lake?    
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -73,7 +73,7 @@ Courtyard~
 into a smoke filled room.  The courtyard extends to the south and west while to
 the east a path runs along the castle wall.  
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -97,7 +97,7 @@ Courtyard~
 is screaming about the walking undead.  The guards look around nervously then
 club him in the head with the hilt of their swords, knocking him out.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -118,7 +118,7 @@ here asking for money.  You ignore him but then you look at his eyes.  He
 motions you over and you obey, but not of your own will.  He hands you a note
 and tells you to read it which you do without any questions.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -211,7 +211,7 @@ Center Lane~
 the battlements above you.  This area seems to be deserted.  The guards look
 down at you distrustfully.  You get the feeling that they don't want you here.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -313,7 +313,7 @@ sides of the road, with their coats of arms flapping in the breeze.  There are
 available slots for other coats of arms.  A small alley to the west leads into
 darkness.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -334,7 +334,7 @@ how honorable the people in this castle must be, you're sure there are thieves
 among them.  You stop in surprise as you see a tower appear to the west where a
 second before you hadn't seen anything.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -466,7 +466,7 @@ around nervously and don't seem to be enjoying their work very much.  You wonder
 whose land this really is.  The castle sits on an island to the east but you
 don't see any means to reach it.  The path continues north and south.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -483,7 +483,7 @@ footprints that sink deep into the mud.  Whoever went through here was either
 wearing a lot of armor or carrying a lot of weight.  The lake and the city wall
 are still forcing you north or south along the trail.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -500,7 +500,7 @@ over.  You reluctantly kneel down to hear what he has to say.  He immediately
 starts rambling on crazily about his dead friends that are coming back to kill
 him to get back the money he owes them.  You walk away in disgust.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -636,7 +636,7 @@ Center Lane~
 battlements above you stare down distrustfully.  An open doorway to the east
 carries the delicious smell of baking bread and roasted meat.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -737,7 +737,7 @@ Knights Way~
 the breeze.  You look at the coats of arms.  You recognize a few of the devices
 as belonging Gawaine, Tristram and, of course, Lancelot.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -846,7 +846,7 @@ end without falling asleep.  A guard whispers something to one of the
 lookouts, you catch a couple words, something about putting you to work in 
 the army.    
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D5
 ~
 ~
@@ -859,7 +859,7 @@ they are staring at, but all you see are open fields and a decrepit stone
 tower.  Nothing threatening.  You try to strike up a conversation with the 
 guards, but they ignore you.    
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D5
 ~
 ~
@@ -887,7 +887,7 @@ stop occasionally and look to the north in fear as if they expect the devil
 himself to suddenly appear.  The fields are neglected and it seems they are 
 just now starting to prepare it for planting.    
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -904,7 +904,7 @@ supply wagons sit by the side of the trail.  This army must have been moving
 fast to leave all this stuff behind.  The tracks look to be only a couple of
 hours old.  The city wall and the lake still force you north or south.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -921,7 +921,7 @@ lookouts.  They are standing a vigilant watch looking outwards, as if expecting
 an army to try to swim across the lake to attack the castle.  Everyone in this
 castle seems crazy.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D2
 ~
 ~
@@ -941,7 +941,7 @@ North Lane~
 walk by, one telling the other some outrageous story about the undead.  Then
 you realize he didn't seem to be joking.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -957,7 +957,7 @@ North Lane~
 they are saying.  You just catch a couple of words.  "We cannot keep this up.  
 We will all be dead soon."  Then they see you and order you to move on.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -973,7 +973,7 @@ North Lane~
 this castle and these people?  You try to ask someone but they look at you as if
 you're the stupidest person alive.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -989,7 +989,7 @@ North Lane~
 seen anyone smiling or any children running around playing.  This castle seems
 to be under a siege of some sort, but not physically.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1009,7 +1009,7 @@ North Lane~
 almost seamless.  It would almost seem that this castle was built with the 
 help of some very powerful magic.    
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1025,7 +1025,7 @@ North Lane~
 like a small stone building.  Very few people are out traveling this road.  You
 only see a few patrolman and peasants.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1041,7 +1041,7 @@ North Lane~
 chimney juts out of the southern wall and heat waves make the rocks around 
 it shimmer as if alive.    
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1058,7 +1058,7 @@ of the north and west walls a small tower sits above you on the
 battlements. Several figures are keeping a sharp look out.  You wonder for 
 what?    
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1092,7 +1092,7 @@ jobs, from their never ending battle of fighting for the rights of the common
 folk.  The various flowers and plants are very well tended and the scent of
 spring flowers is refreshing.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -1162,7 +1162,7 @@ Knights Way~
 large building to the north has its ornate double doors open wide, inviting you
 to enter.  A tower rises above you to the west.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -1244,7 +1244,7 @@ West Lane~
 Few people are walking the streets and even fewer are even acknowledging you.  
 Why is everyone so reclusive?
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D2
 ~
 ~
@@ -1321,7 +1321,7 @@ stench with it and you see vultures circling.  The lake is to the east and the
 path continues north and south.  Further to the north you see a tower and in the
 middle of the lake to the east sits a massive castle on an island.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -1337,7 +1337,7 @@ A Wide Dirt Path~
 tracks follow the trail.  To the north you see some foothills with mountains in
 the distance.  The city wall is to the east.
 ~
-16 4 0 0 0 2
+16 4 0 0 0 0
 D2
 ~
 ~
@@ -1354,7 +1354,7 @@ go in one direction.  This army has never come back through here.  The foothills
 to the north look treacherous.  To the south, small waves lap against the shore
 of the lake.  Through the fog blanketing the lake you think you see an island.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1371,7 +1371,7 @@ and opens into a field to the west.  The foothills to the north still look
 impassable.  You hear something to the west but you can't identify it from this
 far away.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1388,7 +1388,7 @@ are coming from the west.  It almost sounds like a battle is being fought.
 Through the fog to the south you finally can see the island and what appears to
 be a castle built on it.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1406,7 +1406,7 @@ were routed.  You start to notice that some of the corpses, about one of every
 ten, are in an advanced state of decomposition, while most of them are just now
 beginning to bloat from the sun.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1423,7 +1423,7 @@ starting to gather.  Strange, the decayed corpses seem to be untouched by the
 vultures, rats and other scavengers that feast on the fresher fare on this
 battlefield.  
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1440,7 +1440,7 @@ their uniforms while the decayed corpses wear clothes and armor that looks
 ancient and is practically falling off them.  Also the decayed corpses seem to
 be mutilated, most of them with their heads actually lopped off.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1457,7 +1457,7 @@ them.  Blood mixed with the dirt from the path covers your boots and the
 stench is beginning to overwhelm you.  The path continues east and west.  
 The lake to the south has a slight tinge of red too it.    
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1473,7 +1473,7 @@ Battle Field~
 overpowering you and you think about turning back.  You hear the clash of steel
 and screams of pain to the west.  A new battle must have just started.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1490,7 +1490,7 @@ slaughtering what's left of the army.  The zombies decimate the last of the
 infantry, turn around, and leave to the west.  Silence once again claims the
 battle field.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D1
 ~
 ~
@@ -1506,7 +1506,7 @@ Foothills~
 north. Bodies are everywhere, most of them from the army.  Hard to 
 believe the number of casualties those zombies inflicted.    
 ~
-16 4 0 0 0 4
+16 4 0 0 0 0
 D0
 ~
 ~
@@ -1635,7 +1635,7 @@ Northwest Tower~
 looking tower.  Fields stretch towards the south where the farmers, 
 peasants and serfs cultivate the fertile fields.    
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D5
 ~
 ~
@@ -1647,7 +1647,7 @@ West Lane~
 You sense strange powers radiating from the towers to the northeast, as if they
 were alive.  The dirt lane turns into cobblestone to the south.
 ~
-16 0 0 0 0 1
+16 0 0 0 0 0
 D0
 ~
 ~
@@ -1712,7 +1712,7 @@ Battle Field~
 above the foothills.  Bodies lie everywhere right up to the base of the tower.
 There must be over a thousand dead.
 ~
-16 0 0 0 0 2
+16 0 0 0 0 0
 D0
 ~
 ~

--- a/lib/world/wld/169.wld
+++ b/lib/world/wld/169.wld
@@ -6,7 +6,7 @@ bloodthirsty gibberlings. The area starts out in room 16999 (where it connects
 to the south road) and continues eastward to a mountain cave where you finally
 battle the gibberling chieftain and shaman. 
 ~
-169 0 0 0 0 0
+169 0 0 0 0 2
 S
 #16901
 A Mountain Trail~
@@ -15,7 +15,7 @@ east or west along the trail.  You can see the footprints of small animals and
 something else, here in the dirt.  This trail must be used more often than you
 suspected at first glance.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 2
 D1
 ~
 ~
@@ -34,7 +34,7 @@ south begins a steep drop away from the hills you are walking across, forming a
 valley, however the trees to the north and south are too thick for travel
 anyway.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 2
 D1
 ~
 ~
@@ -51,7 +51,7 @@ continues to the east and west.  The sounds of rustling leaves, and small
 animals in the brush scurrying about reminds you that dangerous creatures could
 be lurking nearby in the shadows, waiting for you to rest until they strike.  
 ~
-169 0 0 0 0 0
+169 0 0 0 0 2
 D1
 ~
 ~
@@ -68,7 +68,7 @@ and the brush is too dense to head north or south.  The only way to continue
 farther into the trees, is to climb a steep BANK covered in vines and tree
 roots, up into the hilly regions to the east.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 4
 D3
 ~
 ~
@@ -93,7 +93,7 @@ soil makes a naturul ladder of sorts, so you would have no trouble climbing
 down.  A small path to the south seems to have been intentionally cleared for
 travel through the unlevel terrain.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D2
 ~
 ~
@@ -111,7 +111,7 @@ cliff with them, over time.  Howling winds occasionally sweep down from the
 eastern mountains, further weathering the stones of the slope, and blowing a
 few more pebbles over the edge.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D0
 ~
 ~
@@ -131,7 +131,7 @@ point, it's apparent that you probably wouldn't survive a fall from this
 height.  The face of the rock appears to have enough deep, natural grooves to
 use as footholds, if you were to decide to climb it.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D3
 ~
 ~
@@ -148,7 +148,7 @@ boulders, which provides a momentary rest from the harsh eastern winds.
 However because of the amount of rocks blocking your path here, you can only
 travel north, or down, to a narrow cliff.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D0
 ~
 ~
@@ -164,7 +164,7 @@ A Mountainside~
 north-east, you can see more mountains on the horizon.  Ths South Road is also
 slighty visible as a small line in the trees, far down to the west.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D1
 ~
 ~
@@ -181,7 +181,7 @@ vegetation, overlooking a steep drop off the side of the mountain.  You have
 two choices to continue from here, up the face of the mountain, to the east, or
 down to the west, in the direction of the South Road, leading to the capitol.
 ~
-169 0 0 0 0 0
+169 0 0 0 0 2
 D1
 ~
 ~
@@ -198,7 +198,7 @@ through the rocky terrain, which is almost barren save for a few small plants
 here and there.  Small humanoid footprints in the soil, trace a winding trail
 up the western face of the mountain, continuing eastward.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D3
 ~
 ~
@@ -215,7 +215,7 @@ from a large cave which lies to the east, in the side of the mountain.  As
 harsh winds blow past you bearing a fine mist, it would probably be wise to
 continue onward, rather than stay here.    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D1
 ~
 ~
@@ -233,7 +233,7 @@ surface, making the cliff even more dangerous.  Through the deafening sound of
 the gusts in your ears, a kind of chattering noise, or perhaps even voices,
 hauntingly fades in and out of existence...  Or was it just the wind?    
 ~
-169 0 0 0 0 0
+169 0 0 0 0 5
 D1
 ~
 ~

--- a/lib/world/wld/17.wld
+++ b/lib/world/wld/17.wld
@@ -6,7 +6,7 @@ hooves turning it into a thick muddy slime.  Through the thick forest to the
 east you see the western wall of Bellau City.  Through a thin covering of trees
 to the west you see a massive body of water.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -63,7 +63,7 @@ it to the south or enter the courtyard to the west.  Out in the courtyard
 you see a couple groups of people talking amongst themselves.  Maybe they 
 can give you some answers to what's going on.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D2
 ~
 ~
@@ -84,7 +84,7 @@ branches off to the east.  Several people are standing around in the courtyard
 looking at the main gate, but no one is leaving.  You notice guards are blocking
 anyone from leaving the castle.  It looks like you might be stuck here.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -104,7 +104,7 @@ Courtyard~
 back and forth.  Everyone in the castle seems to be keeping secrets from each
 other.  They look in your direction and immediately stop talking.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -125,7 +125,7 @@ missing.  Only a few people are walking around through the courtyard and none of
 them are going towards the gate.  They all look at each other and especially at
 the guards distrustfully.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -215,7 +215,7 @@ walking along the lane to the north and south but they don't seem to have
 a purpose other than to be pacing, obviously waiting for something or 
 someone.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -297,7 +297,7 @@ Tourney Yard~
 one another for a claim to a seat on the round table.  You can make out several
 contests underway.  Perhaps you would like to joust?
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D2
 ~
 ~
@@ -315,7 +315,7 @@ Flanking the road are the standards of the other knights of the round table.  A
 strange peace fills the air here.  Knights Way continues to the north and the
 Tourney Yard of Camelot is to the south.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -339,7 +339,7 @@ Tourney Yard~
 one another for a claim to a seat on the round table.  You can make out several
 contests underway.  Perhaps you would like to joust?
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -373,7 +373,7 @@ look to be very proficient.  Several squires and lackeys look on in
 concentration, trying to memorize the complex forms the masterful knights 
 use to try to overcome each other.    
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -407,7 +407,7 @@ stone look like they could hold back any army, yet this castle already seems
 defeated.  You wonder at how any army could overtake the greatest kingdom and
 ruler ever.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -424,7 +424,7 @@ lake at the small ferry on the shore waiting to carry travellers across.
 Several Archers and guards keep a sharp lookout as if they are expecting 
 a full scale siege at any moment.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D5
 ~
 ~
@@ -437,7 +437,7 @@ Bellau City to the east and a thick forest to the south.  The lake around
 the castle is smooth as glass and reflects an inverse image of the castle.  
 The stairs lead back down.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D5
 ~
 ~
@@ -449,7 +449,7 @@ South Tower~
 the distance.  A guard ignores you, dismissing you as harmless, and resumes his
 watch.  You have no idea what he's looking for.  A set of stairs lead back down.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D5
 ~
 ~
@@ -461,7 +461,7 @@ Open Field~
 them.  The farmer stares at you in disgust as you walk by.  These people 
 don't seem to be very happy about working in these fields.    
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -480,7 +480,7 @@ right up against the western wall of Bellau City, and to the west, through a
 thin covering of trees, you see a large body of water.  Is it a lake or an
 ocean?  You're not sure.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -497,7 +497,7 @@ building to the west.  The shadows are deep in this corner of the castle
 and it seems like the beggars and unlawful merchants have taken over this 
 area.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -630,7 +630,7 @@ Center Lane~
 to the north.  They look to be mostly nobles and servants.  All of the 
 common folk must be out working the fields.  A tall wall is to the west.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -716,7 +716,7 @@ Tourney Yard~
 a squeal of delight from a spectator.  The black caped knight leans into his
 charge with his weight forward in a low stand on his stirrups.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -736,7 +736,7 @@ Tourney Yard~
 full armor and a bright orange plume.  To the right is a knight in chain mail
 and a trailing black cape.  Arthur signals the knights with a short wave.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -761,7 +761,7 @@ orange plummed knight contorts in his saddle at the last second, delivering a
 thrust high on the shield of the black caped knight.  The black caped knight
 connects with a hard shot to the center of the shield of the orange knight.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -800,7 +800,7 @@ a ball and chain, swinging it around with very little control.  The lead ball is
 too much for him and keeps pulling him off balance.  You decide to quickly move
 on before the inexperienced squire hurts himself or you.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -833,7 +833,7 @@ West Lane~
 the stone walls of a building in that direction.  Somebody still seems to be
 able to celebrate.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -889,7 +889,7 @@ ground here has been plowed and several serfs are dutifully picking rocks out of
 the field and throwing them into the lake.  You duck as they don't seem to care
 whether they hit the lake or you.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -907,7 +907,7 @@ began to reclaim the path as its own.  The western wall of Bellau City is still
 to the east and you hear the gentle lapping of waves on the shoreline to the
 west.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -925,7 +925,7 @@ north or west.  A beggar looks up at you, raising a small tin cup, a glimmer of
 hope in his eyes.  A set of stairs are carved into the wall to the west, leading
 up into the tower.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -946,7 +946,7 @@ the east or west.  Shadows cover a large portion of the road and you try
 unsuccessfully to peer into them.  Beggars seemed to have taken over this part
 of the castle.  This must be the poor sector.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -964,7 +964,7 @@ note that looks to be signed by the king himself.  He starts to tell you what
 it's about, but then a guard rounds a corner to the west and the merchant
 immediately walks away from you.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -981,7 +981,7 @@ position at the Round Table.  All you need to do is purchase the Holy Grail
 from him and present it to the king.  The merchant pulls out a tin cup you 
 saw a beggar using not ten minutes ago and asks for 2000000 gold.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -998,7 +998,7 @@ the center of the castle carries the smell of food and wine to you.  The lane
 you are on is empty except for a scattering of guards in the distance.  Where
 are all the common folk?
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1019,7 +1019,7 @@ traffic that would flow through a castle this size.  The few people that hurry
 past you don't even attempt to be polite to anyone else.  Though the road is
 wide and empty, they still shoulder you out of their way.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1036,7 +1036,7 @@ ordering people into his army to fight the northern army.  No one has come back
 from the battles.'  He emphasizes his words with a long stare that sets your
 nerves on end, then turns and walks away.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1053,7 +1053,7 @@ you as if measuring your abilities against his.  He writes something down on a
 piece of paper and hands it to a page that is walking by.  The guard looks back
 up at you and grins.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1070,7 +1070,7 @@ a merchant about some new tax he's supposed to be collecting.  The merchant
 seemed to think he wouldn't have to pay right up until the guard drew his sword.
 A set of stairs is carved into the wall to the west, leading up into the tower.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1158,7 +1158,7 @@ knight.  She quickly runs over to congratulate the black knight, hanging on to
 him like a leech.  The spectators cheer weakly, hurrying over to shake the
 knights hand.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1178,7 +1178,7 @@ Tourney Yard~
 yard.  The black knight circles and raises his lance in a salute to 
 Arthur.  A few people cheer, but most seem to be preoccupied.    
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1202,7 +1202,7 @@ Tourney Yard~
 quickly recovers and tosses her favor to the black knight.  The spectators that
 were cheering for the orange knight quietly disperse.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1239,7 +1239,7 @@ Practice Yard~
 all seem to be about equally experienced and it doesn't look like any one person
 will win.  You had better move on before they ask you to join in.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1272,7 +1272,7 @@ West Lane~
 leads up to the watchtower.  The noise from the building to the east is even
 louder here.  You don't see how anyone could possibly make so much noise.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1341,7 +1341,7 @@ castle.  You try to ask the peasants and farmers how to reach it but they ignore
 you.  A farmer is here driving a pair of oxen pulling a plow, furrowing one of
 the fields so it can be planted.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1359,7 +1359,7 @@ silence overcoming the woods.  You quicken your pace.  The western wall of
 Bellau City is to the east and the path turns to the west.  A large uprooted
 tree blocks the forest to the south.
 ~
-17 4 0 0 0 2
+17 4 0 0 0 0
 D0
 ~
 ~
@@ -1377,7 +1377,7 @@ is cloaked in a thick fog.  You see a large shadow on an island in the fog.  It
 looks to be a building of some sort but you can't see it clearly.  The path
 leads east and west.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1394,7 +1394,7 @@ the side of the path.  Those rumours about robbers and thieves hiding in these
 woods must be true.  You check the contents of your purse then move on.  The
 lake still blocks the north and the forest doesn't look very safe to the south.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1412,7 +1412,7 @@ one corpses eye socket.  You hear a crashing sound to the south as a large
 person or animal makes a run for cover.  You should follow the trail east or
 west.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1430,7 +1430,7 @@ A fortress sits on the island looking impregnable.  The trail continues
 east and west with the south still too thick to be worth travelling 
 through.    
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1448,7 +1448,7 @@ floor.  The lake to the north stretches for almost a mile before reaching
 the island.  The trail is opening up into a road once more and you see 
 people walking along it to the west.    
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1464,7 +1464,7 @@ A Light Forest~
 produce food for those who live on the island across the lake to the north.  
 The trail continues east and west, into the fields or back towards the forest.
 ~
-17 0 0 0 0 3
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1481,7 +1481,7 @@ being led to pasture, including some sheep and cows.  Peasants are toiling
 in the dirt and mud, planting crops.  The lake extends to the north and the 
 path goes east and west.    
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1497,7 +1497,7 @@ A Cultivated Field~
 rude!  You don't see how these people travel back and forth from the island.  
 There must be a ferry somewhere, but you can't see it.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1514,7 +1514,7 @@ before you.  It would almost look like they are trying to build up a stock
 of food, maybe they're expecting a siege.  The fields continue along the 
 path to the east and west.    
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D1
 ~
 ~
@@ -1588,7 +1588,7 @@ noblemen and knights walk barefoot in the grass discussing chivalry and wars to
 come.  Everyone seems to be avoiding the subject of the present war, which you
 would think would be the major topic of all the conversations.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1604,7 +1604,7 @@ Court of Camelot~
 thrives and the high ideals of chivalry breathe.  You have a commanding 
 vantage of the Tourney Yard of Camelot to the north from here.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1624,7 +1624,7 @@ Court of Camelot~
 the air, all for a chance of earning the kings favor.  Ladies-in-waiting play
 their love games with young knights and squires.
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1654,7 +1654,7 @@ impressive sword battle you have ever seen.  This knight expertly disarms all
 three knights within seconds.  Your jaw drops in admiration.  The knight bows
 deeply and all the squires cheer, 'Lancelot, Lancelot!'  
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~
@@ -1678,7 +1678,7 @@ Southwest Tower~
 view. Guards solemnly stand their watch, keeping an eye out for the 
 farmers and peasants tending the fields over the lake to the west.    
 ~
-17 0 0 0 0 1
+17 0 0 0 0 0
 D5
 ~
 ~
@@ -1758,7 +1758,7 @@ Open Field~
 it's going to rain.  The trail turns north along the shoreline of the lake.  
 You still can't see any possible way to reach the island.
 ~
-17 0 0 0 0 2
+17 0 0 0 0 0
 D0
 ~
 ~

--- a/lib/world/wld/175.wld
+++ b/lib/world/wld/175.wld
@@ -137,7 +137,7 @@ The River Quickens~
 to make your way back upstream.  The brick walls around you become coarse and
 poorly cut as you move downstream.    
 ~
-175 72 0 0 0 0
+175 72 0 0 0 6
 D1
 To the east, the indoor river turns towards the north.
 ~
@@ -163,7 +163,7 @@ The River Continues~
 see what looks like the exit of a cave's mouth up ahead.  The walls have
 degenerated into uncut stone.    
 ~
-175 8 0 0 0 0
+175 8 0 0 0 6
 D0
 To the north lies the exit from the hallway (tunnel?) you are in, and the river turns to the east.
 ~
@@ -176,7 +176,7 @@ A Bend to the East~
 However, the banks of the river are too steep to climb, and you are forced
 along a tight bend to the east.    
 ~
-175 0 0 0 0 0
+175 0 0 0 0 6
 D1
 To the east, the river pours into a lake.
 ~
@@ -189,7 +189,7 @@ Out on the Lake~
 shimmering white light, and far to the east you can see a door-sized mirror
 hovering vertically above the water.    
 ~
-175 0 0 0 0 0
+175 0 0 0 0 6
 D0
 To the north the flickering white light grows stronger. It seems to be congregating about a point.
 ~
@@ -212,7 +212,7 @@ Beneath you, water laps gently through the void of brightness, and to the south
 you hear the sounds of a lake.  To the west, you can hear the muffled bickering
 of two guards.    
 ~
-175 0 0 0 0 0
+175 0 0 0 0 6
 D2
 ~
 ~
@@ -229,7 +229,7 @@ The Mirror on the Lake~
 symbols.  Within the frame ripples quicksilver, and your warped reflection
 stares back at you.  The mirror could be easily walked through.    
 ~
-175 0 0 0 0 0
+175 0 0 0 0 6
 D2
 The mirror completely restricts your sight to what may possibly lie beyond.
 ~
@@ -272,7 +272,7 @@ The Flowing River~
    The river soon turns out to become to powerful an opponent to battle, and it
 unceremoniously forces you back to the east.    
 ~
-175 0 0 0 0 0
+175 0 0 0 0 6
 D1
 The lake opens before you to the east.
 ~

--- a/lib/world/wld/186.wld
+++ b/lib/world/wld/186.wld
@@ -4,7 +4,7 @@ The Entrance To The Newbie Zone~
 been looking for.  Well, when you've readied yourself you can enter
 to the north.
 ~
-186 4 0 0 0 0
+186 4 0 0 0 1
 D0
 You see the start of the newbie zone.
 ~

--- a/lib/world/wld/187.wld
+++ b/lib/world/wld/187.wld
@@ -5,7 +5,7 @@ of music and laughter can be heard off in the distance.  The top of a large
 tent can be seen to the south.  The path continues south with the western
 highway to the north.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D2
 ~
 ~
@@ -51,7 +51,7 @@ over the sounds of the field.  A large colorful tent can be seen off in the
 distance to the southeast, with its multi-colored flags blowing in the wind.  
 The path continues to the west and leads off to the north.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -67,7 +67,7 @@ Circus Path~
 can be heard a bit louder here.  A few people can be seen now as more of the
 circus comes into view.  The path leads south as well as to the east.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D1
 ~
 ~
@@ -84,7 +84,7 @@ A small line can be seen to the south as people line up to enter the circus.
 The sounds of the circus are in full swing,  bringing a smile to your face.  
 The path continues to the north as well as to the south.    
 ~
-187 4 0 0 0 0
+187 4 0 0 0 2
 D0
 ~
 ~
@@ -101,7 +101,7 @@ built here to keep the line going in an orderly fashion.  There is a welcomer
 here, welcoming you to the Circus of Wonders.  The path continues to the north
 and west through the arch.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -119,7 +119,7 @@ the sounds of the circus are all around you.  There is a game stall directly to
 the north and a game stall to the south too.  The path continues to the west
 and to the east.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -202,7 +202,7 @@ the air.  To the north you see a dark colored tent with lights flickering
 inside.  A small sign hangs on the flap of the tent.  The path continues on to
 the south and east.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -264,7 +264,7 @@ North of the Circus~
 passing without bumping each other.  You can hear faint animal noises that are
 carried along by the wind.  The path leads to the west and south.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D2
 ~
 ~
@@ -281,7 +281,7 @@ there is a run down shack, boards missing and windows broken.  The door is off
 its hinges and hangs precariously by what looks to be a nail.  The path
 continues on to the south from here.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -333,7 +333,7 @@ see the Big Top and a few animal cages.  You can still hear the sounds of
 laughter and singing all around you.  The path continues to the south and
 north.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -366,7 +366,7 @@ air...  Laughter, singing and animals.  To the east you see some animal cages
 and to the southeast you see the massive tent with its banners flying wildly in
 the wind.  The path runs northerly from here.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -383,7 +383,7 @@ Lions, elephants and monkeys can be heard though you are not certain where the
 sound comes from.  The sounds seem to echo and meld together creating a
 frightful noise.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -417,7 +417,7 @@ mewlings can be heard while to the south the cage is quiet, only the stench
 catches your attention.  To the west you see the Big Top and westerly will take
 you further down the path.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D0
 ~
 ~
@@ -469,7 +469,7 @@ banner red and white pennants flap wildly in the breeze.  Laughter and cheering
 fills the air as well as the occasional roar of lions.  You can enter the big
 top to the east and to the south you see an elaboratly decorated wagon.    
 ~
-187 0 0 0 0 0
+187 0 0 0 0 2
 D1
 ~
 ~

--- a/lib/world/wld/19.wld
+++ b/lib/world/wld/19.wld
@@ -108,7 +108,7 @@ and the general decay of time.  It appears as though there were indeed paths
 here long ago, but water has saturated the ground, leaving nothing but
 featureless mud.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    The ground seems to slope downwards in this direction, making it look
 potentially difficult or impossible to get back up.  
@@ -151,7 +151,7 @@ Squelching Ground~
 slightest weight leaves deep imprints that quickly well back up with sloshing
 mud and the few sickly bits of plant life that grow here.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    The ground dips suddenly, substantial flooding and algae rendering it very
 slippery indeed.  
@@ -179,7 +179,7 @@ and casting the boggy ground in shadow.  The air is cooler here, the stone
 itself emitting an almost unnatural chill in contrast to the warmth of the
 surroundings.  
 ~
-19 1 0 0 0 0
+19 1 0 0 0 2
 D1
    The ground seems flatter and more stable toward this direction, an upright
 wooden stick breaking the smoothness of the horizon.  
@@ -213,7 +213,7 @@ Drowned Land~
 heat of some underground current.  Large blisters swell from the ground, popping
 with a hiss and releasing hot, swirling steam into the foggy air.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    It looks as though a large log has sunk into the area to the north, making it
 at least stable to walk on.  
@@ -241,7 +241,7 @@ giving the impression that this place has not recovered from some ancient
 battle.  Glimpses of metal can be seen half-buried in the ground, the armour and
 weapons of some long-decayed army.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    A darkness and chill seem to emanate from this direction, a great rock
 breaking the horizon far to the north.  
@@ -274,7 +274,7 @@ The rust has leached into the water, discolouring it deep red and filling the
 air with the overwhelming stench of decay and the sickly metallic scent of
 blood.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    A rhythmic blast of heat comes from this direction, cloudy steam obscuring
 the view of what lies beyond.  
@@ -314,7 +314,7 @@ Slippery Slope~
 Sloping steeply down from the south, thin rivulets of water trickle their way
 lazily down, accumulating in a watery pool at the base.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D2
    The way south looks too steep and too slippery to even begin trying to climb.
 ~
@@ -339,7 +339,7 @@ Scattered Rocks~
 treacherous path for walking.  Thin layers of slime glisten on the sharp rocks,
 along with various other old and unidentifiable stains.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    More scattered broken rocks can be seen trailing off to the north, water
 deepening steadily around them.  
@@ -386,7 +386,7 @@ soil it nevertheless is so large that it almost completely blocks further
 advancement.  Tiny fungi sprinkle the rotting wood and surrounding mud, products
 of its continuing decomposition.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D1
    Little stony peaks rise from the slippery mud here, providing a somewhat
 stable, albeit dangerous footpath.  
@@ -414,7 +414,7 @@ now it is just a watery bog, its high sloping sides sodden with slime from
 rotting vegetation and the wild overgrowth of algae and desperate creeping swamp
 vines.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    The way to the north grows darker and deeper, a strange ominous feeling
 hanging over the area like an invisible shadow.  
@@ -435,7 +435,7 @@ Dark Waters~
 of scum that floats everywhere.  Insects dart quickly here and there, apparently
 fleeing from the more ominous shadows that slide just beneath the surface.  
 ~
-19 4 0 0 0 0
+19 4 0 0 0 2
 D2
    The way south looks very slippery indeed, difficult to climb out of but not
 impossible.  
@@ -463,7 +463,7 @@ stirred by some unseen current.  Strange things surface with the movement,
 glimpses of shiny metal and splintered bone are all that mark this place as the
 grave it has become.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    The vast splayed roots of a giant tree stand upturned in the air, blocking
 any view of what lies beyond.  
@@ -497,7 +497,7 @@ as though this tree died years ago.  Dark streaks marr the wood, evidence
 perhaps of long past lightning storms, or the use of powerful magic in this
 area.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    This giant tree's trunk continues on into the north, sloping slightly
 downward as it becomes increasingly submerged in the mud.  
@@ -531,7 +531,7 @@ Scorched Trunk~
 huge reaching branches hold it from complete submersion.  Black unnatural burn
 marks weave their way like rotting vines all along the ancient bark.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    Huge splaying branches reach out in every direction, preventing further
 advancement.  
@@ -570,7 +570,7 @@ Stony Path~
 into the air as it laps around this small trail of island rocks, the only path
 through this watery part of the swamp.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D2
    The trail of jagged rocks continues to the south, the stones becoming
 suddenly larger and less natural as though broken off from some designed
@@ -597,7 +597,7 @@ Puddle of Algae~
 water.  Plant life of various kinds tangle and intertwine into each other
 beneath the water, making it very easy to become caught.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D1
    The bleak surface of the dark water is broken here and there with the peak of
 a jagged rock, leading off further to the east.  
@@ -619,7 +619,7 @@ hole leading into darkness beneath, as though some hollow tree has become buried
 just below the surface, the sound of thick mud dripping within a concealed space
 below.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    Thin, mossy trees wave wearily, blocking any further view of what lies to the
 north.  
@@ -732,7 +732,7 @@ creak and groan, swamp moss spreading slowly as if to consume them.  Thin
 grasses lean pathetically against the lanky trunks, almost like weary children
 clinging to their mothers.  
 ~
-19 4 0 0 0 0
+19 4 0 0 0 3
 D0
    A large gathering of trees can be seen extending to the north, a small gap
 opening the way.  
@@ -770,7 +770,7 @@ A Broken Bridge~
 almost natural mosaic walkway through the watery slime.  No river runs through
 here though the presence of this ancient bridge indicates that once there did.
 ~
-19 4 0 0 0 0
+19 4 0 0 0 2
 D1
    The sloping curve of a buried tree can be seen, rising like another small
 wooden bridge out of the watery ground.  
@@ -791,7 +791,7 @@ Sunken Road~
 no naturally formed path and an indication that long ago these grounds saw dry
 land, though now the smooth road is pitted with fungus and shelled creatures.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    The ground slopes downward, jagged rocks standing like little islands amongst
 the murky waters.  
@@ -825,7 +825,7 @@ Peak of the Rock~
 been a spectacular view if not for the waves of heat that cause the air to
 shimmer and swim, making everything seem eerily unreal.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
 ~
 ~
@@ -843,7 +843,7 @@ crevices and jagged stones that break the surface.  To the east and the west,
 large cavernous mouths protrude, though the hollows within appear to be
 underwater.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    A sunken path leads treacherously to the north, looking as though it was
 originally a continuation of the same path that extends to the south.  
@@ -875,7 +875,7 @@ Flooded Cave~
 be seen is slick with swamp slime and mosses, the odd glittering piece of armour
 shining like stars from the inky depths below.  
 ~
-19 13 0 0 0 0
+19 13 0 0 0 9
 D3
    Open air breathes gently from the west, natural light rippling vaguely on the
 surface of the breaking waters.  
@@ -901,7 +901,7 @@ Underwater Enclosure~
 swirling about and creating the apparent illusion of dark shadows and shapes
 swimming cautiously about.  
 ~
-19 13 0 0 0 0
+19 13 0 0 0 9
 D1
    Murky water and spiked rocks travel in a vague north to south path just
 outside the enclosure.  
@@ -916,7 +916,7 @@ of slate and chunks of stone mixing with the wreckage to create an unstable
 surface for walking on, the slick overgrowth of plant life making it even more
 treacherous.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    The path continues wet and treacherous to the north, smooth paved surfaces
 crumbled into broken pieces of stone and grit.  
@@ -1073,7 +1073,7 @@ sand so that everything beneath the surface is cloudy.  Only the feel of laid
 stone and grit indicates the path that lies here, a slight mist hovering over
 the surface of the muggy water.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    A small enclosure can be seen to the north, tiny wisps of smoke escaping into
 the air.  
@@ -1117,7 +1117,7 @@ Wisps of smoke and glowing embers cling to life as the recently used campfire
 slowly dies away.  Various cooking utensils and simple clay pots lie soiled and
 strewn about.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D2
    Muddy, grimey water swirls lazily away, stirring up the gravelly ground as it
 trickles noisily.  
@@ -1150,7 +1150,7 @@ Grassy Hole~
 lengths and echoing slightly as they hit rock surface below.  A deep black hole
 gapes widely in the ground, concealed perfectly until almost falling into it.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    Copious amounts of smoke fill the air thickly, staining the ground and plant
 life darkly black and blocking any further view.  
@@ -1282,7 +1282,7 @@ abandoned path.  From a large crack in the ground, dark smoke billows slowly up
 into the sky, shrouding the place in darkness and creating the claustrophobic
 feeling of being unable to breathe.  
 ~
-19 1 0 0 0 0
+19 1 0 0 0 2
 D0
    The water runs deeper to the north, shimmering fog wafting restlessly and
 clouding any further view.  
@@ -1317,7 +1317,7 @@ giving easily beneath and sending clouds of darkness up into the water.  Broken
 stalks litter the bottom, and deep footprints can be seen imprinted in the
 watery ground, indicating that this way is well travelled.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    Deep waters and eerie blue mists swirl silently around, both almost purposely
 hiding the way from view.  
@@ -1345,7 +1345,7 @@ clouding everything so that only ghosts and shadows can be seen moving about in
 the periphery of vision.  The air is hot and stifling, but the cloudy moisture
 leaves a bone-chilling cold on every surface.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    Some sort of entrance can be seen through the brush, a black stair descending
 into darkness.  
@@ -1378,7 +1378,7 @@ Eerie Wetlands~
 die away as the bluish haze around this place swirls ever thicker.  The water
 slides easily, thick algae blocking any view as to what lies beneath.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D2
    A well travelled way lies to the south, broken reeds and muddy footprints
 left as recent evidence.  
@@ -1405,7 +1405,7 @@ Absolute Darkness~
 life swirling about.  The blackness seems all-encompassing, nothing visible in
 any direction, just the slimey touch of unseen creatures brushing past.  
 ~
-19 13 0 0 0 0
+19 13 0 0 0 9
 D4
    Faint shafts of natural light penetrate the darkness, the stalks of gently
 swaying reeds only just visible through the murkiness.  
@@ -1429,7 +1429,7 @@ Endless Marshlands~
 shadows potentially only the product of imagination.  Almost untouched, the
 quiet water and still reeds can be seen for miles.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D1
    Chilly air breezes from the west, damp and clinging miserably to everything
 like a cold sweat.  
@@ -1456,7 +1456,7 @@ Endless Marshlands~
 here.  Desperate creeping plant life, hovering insects and scummy algae-infested
 water appears to be all there is.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
    A vast and confusing landscape stretches to the north, heavy fog making it
 difficult to see any straight path through.  
@@ -1497,7 +1497,7 @@ Endless Marshlands~
 wearily back and forth, and almost eternally around in the swirling mists
 everything seems to look exactly the same.  
 ~
-19 4 0 0 0 0
+19 4 0 0 0 2
 D1
    A vast and confusing landscape stretches to the east, heavy fog making it
 difficult to see any straight path through.  
@@ -1524,7 +1524,7 @@ Endless Marshlands~
 wearily back and forth, and almost eternally around in the swirling mists
 everything seems to look exactly the same.  
 ~
-19 4 0 0 0 0
+19 4 0 0 0 2
 D0
    A vast and confusing landscape stretches to the north, heavy fog making it
 difficult to see any straight path through.  
@@ -1567,7 +1567,7 @@ odd green shoot of a struggling youngster colouring the gloominess, and the
 scent of new plant life freshening the air, even as fungi consume the rotting
 elders.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 3
 D1
    Swaying branches trail leisurely over the murky waters, the sounds of
 rustling and crow's screeching carrying on the air.  
@@ -1595,7 +1595,7 @@ slimy swamp algae covering them with slick green ooze.  Spindly desperate
 branches grasp blindly at the air like the skeletal fingers of some long buried
 giant.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 3
 D0
    Thick, brittle treetrunks continue on and around to the north, the sounds of
 wildlife crunching through the leaves.  
@@ -1617,7 +1617,7 @@ mournful screeching of crows can be heard from the swaying branches above.
 Most of the trees here are dead, only one or two trailing green leaves into the
 watery surroundings.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 3
 D0
    A vast array of dried branches forms a canopy overhead, a mighty tree
 standing proudly to the north, even as it decays.  
@@ -1638,7 +1638,7 @@ Circle of Trees~
 creating a skeletal leaf-less canopy.  The persistant creep of swamp vines and
 moss coats nearly the entire trunk, as though the bog were trying to reclaim it.
 ~
-19 0 0 0 0 0
+19 0 0 0 0 3
 D0
    Tangled tree roots stretch out to the north, creeping through the treacherous
 mud as though grasping for safety.  
@@ -1680,7 +1680,7 @@ Drowned Path~
 pool.  Dirt and grit settle slowly at the bottom, covering partially what appear
 to be the carefully set slate tiles of an ancient road running north and south.
 ~
-19 0 0 0 0 3
+19 0 0 0 0 2
 D0
    A small junction lies ahead, this path meeting with a larger west-to-east
 trail.
@@ -1713,7 +1713,7 @@ Circle of Trees~
 they seem to be well-tended.  Leaning in on each other, their green waving
 branches seem to rustle uncomfortably, whispering quietly with each other.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 3
 D0
    A greenish film of water and slime coats a long-neglected path to the north.
 ~
@@ -1739,7 +1739,7 @@ Circle of Trees~
 trunks.  The beautiful crimson leaves of a black gum tree seem almost to light
 the area as a burning fire illuminates night.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 3
 D0
    Younger saplings grow to the north, slender green branches and fresh budding
 leaves adding a sense of freshness to the atmosphere.
@@ -1762,7 +1762,7 @@ enclosed within the trunks of the surrounding trees.  A smoking fire lingers
 here, some burned carcass giving off the smell of cooked flesh.  Before the
 altar, a large metal grid is embedded into the ground.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 3
 D0
    A small water-logged path leads northward, flanked on either side by closely
 hovering trees.
@@ -1805,7 +1805,7 @@ surface of these dark waters.  Small fish dart nervously about, hiding instantly
 at the sight of any shadow, and bulrushes sway gently, spreading ripples
 throughout the pool.  
 ~
-19 4 0 0 0 2
+19 4 0 0 0 6
 D1
 ~
 ~
@@ -1822,7 +1822,7 @@ Bend in an Ancient Path~
 coated slightly with the glassy sheen of an inch or two of clear running water,
 the carefully laid mosaic stones and coloured glass can clearly be seen.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
 ~
 ~
@@ -2398,7 +2398,7 @@ drifting away to join the wandering mist that swirls forlornly about.  Tall
 withered grasses whisper amongst themselves as they bend, almost seeming to
 deliberately make way for passage.  
 ~
-19 0 0 0 0 0
+19 0 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/2.wld
+++ b/lib/world/wld/2.wld
@@ -6,7 +6,7 @@ travelers would better avoid coming here.  However, things in the west change
 dramatically.  The shouts of soldiers in training can be heard.  The road
 continues to the north and south.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -64,7 +64,7 @@ warehouse is made from sturdy timber with a set of wide double doors that appear
 to open outwards.  Wagon tracks lead right up to the warehouse.  This must be
 where traders come to unload their supplies.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -81,7 +81,7 @@ are to the south and east.  The financial holdings of the city are said to be
 hidden somewhere within this building.  Of course only a fool would try to
 steal from a bunch of thieves.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -103,7 +103,7 @@ Mattresses that are shredded to pieces by rats and mice line one wall.  A small
 washbasin, stool and bench are the only other luxuries these overworked brutes
 own.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -124,7 +124,7 @@ This is where the lieutenants of the army relay their plans to the sargeants to
 carry them out.  You can work your way between the benches to the south, east,
 or north.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -145,7 +145,7 @@ to polish the kitchen.  A small scullery filled with messy pots gives the room
 a charred smell.  Large ovens line the east wall and are cold for the time
 being.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -166,7 +166,7 @@ through the Warriors Quarter.  Very few people are around, but plenty of
 soldiers rush about.  One might wonder why anyone would sign up for the army
 after all the stories flying around.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -182,7 +182,7 @@ The Northern Temple Circle~
 towering high above, shimmering in the light.  The road continues to the south
 and east.  A stairwell leads up onto the top of the inner city wall.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -203,7 +203,7 @@ It looks like it leads into the temple.  The smell of some sort of vile
 concoction emanates from a building to the south.  The sound of someone chanting
 can be heard coming from within.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -224,7 +224,7 @@ into the temple of Sanctus.  The road continues to the east and west.  A small
 building to the south has boxes and envelopes stacked on both sides of the
 entrance.  The sound of someone cursing can be heard coming from within.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -246,7 +246,7 @@ road that looks to wind around the temple.  To the north nothing can be seen but
 open road.  Everything around is silent, making the area seem abandoned and
 alone.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -272,7 +272,7 @@ south is a building with barred windows and a reinforced door that currently
 stands open.  A sign above the door informs passing people that it is the Bank
 of Sanctus.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -294,7 +294,7 @@ sound of running water to the south and the squeak of a water pump can only mean
 one thing.  It must be the infamous Sanctus Water Hole run by none other than
 Hazel herself.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -315,7 +315,7 @@ intersection just up ahead.  A set of stone stairs leads up into the
 northeastern lookout tower of the inner city wall.  From there guards can
 oversee the entire Thieves Quarter.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D2
 ~
 ~
@@ -336,7 +336,7 @@ to see if they might be able to swindle some of your gold.  Most look with
 disappointment as everyone knows few adventurers are rich these days.  The
 avenue follows along the inner city wall to the north and south.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -354,7 +354,7 @@ in a mansion, not a warehouse.  Several benches line the walls.  It almost
 looks like some type of waiting room the thieves use to impress would be
 traders.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -371,7 +371,7 @@ pump with fresh running water are kept in this room.  Too bad none of the
 workers seem to have ever touched any of them.  Leave it to the thieves to hire
 workers to do any manual labor.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -388,7 +388,7 @@ It's structure, ranking system, history, and future developments are all taught
 to the recruits who usually fall asleep during the lectures, until they are
 taken outside to be "woken up.  "
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -409,7 +409,7 @@ and winning wars few people realize that recruits go through some educational
 training as well.  They are taught the basics of reading and writing and
 strategy to help them become better fighters and better citizens.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -430,7 +430,7 @@ have taken years to construct it.  The inner city wall to the east is made of
 the same material.  That must have been one of the many foul jobs given to new
 recruits.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -448,7 +448,7 @@ Few people roam the streets and the area has a very peaceful feeling.  The sound
 of muttering voices seems to be coming from within or on top of the wall to the
 west.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -465,7 +465,7 @@ one works their way to the counter.  Several kettles are boiling over woodless
 fires that put off no smoke.  The yellow fog overflows the top of one of the
 kettles, giving the room an awful aroma.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -477,7 +477,7 @@ Post Office~
 postal service of Sanctus is heavily overworked it seems.  Somewhere amidst the
 piles of mail someone can be heard snoring.  Maybe not overworked, just lazy.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -490,7 +490,7 @@ small lit candles surround the place in a blanket of light.  A soft humming
 noise can be heard coming from within the depths of the temple.  An adventurous
 traveler would certainly be drawn to go and have a look.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -507,7 +507,7 @@ tediously counting a few thousand coins spread out on the table before him.
 This bank is well known for the security it enforces to ensure safe storage of
 the cities gold.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -521,7 +521,7 @@ water.  The DRIP, DRIP, DRIP would drive a normal person crazy, but not Hazel.
 She loves her water.  A set of stairs behind the counter leads to what appears
 to be Hazel's living quarters.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -538,7 +538,7 @@ be heard as some guards must be making their rounds on top of the wall.  This
 road winds around the Temple of Sanctus allowing one to enter from either the
 north or south.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -555,7 +555,7 @@ obvious reasons and most people are too wary of their gold to chance an
 encounter with a pickpocket.  A large warehouse to the east and the inner city
 wall to the west guides the avenue to the north or south.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -572,7 +572,7 @@ the board.  A bunch of chairs and benches are arranged in rows facing the
 board.  Looks like someone is preparing for a meeting.  Maybe you can sit in
 and learn a few things.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -593,7 +593,7 @@ haphazardly all over it.  The type of writing that only the person who made it
 can really comprehend what it means.  This must be where some of the planning
 for the city takes place.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -614,7 +614,7 @@ army.  Many sleepless nights have always been spent in this room during small
 skirmishes that almost break out into an all out war.  Chairs line the walls
 and a large table fills the center of the room.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -627,7 +627,7 @@ The Latrine~
 couple of pots lie on the floor and a bucket of water sits on the table.  Very
 rudimentary, but functional, which seems to be the unsung motto of the army.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -640,7 +640,7 @@ the Warriors Quarter and Clerics Quarters meet.  The Western Road runs from the
 temple to the west gate.  Very few people are about, mostly just soldiers on
 patrol.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -657,7 +657,7 @@ Sanctus can only be entered from the north or south.  A small shed of some sort
 has been erected to the east.  It was recently made from wood and appears to
 have been constructed in a hurry.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -678,7 +678,7 @@ vests.  An old salty sailor sits in the back carving out what must be a canoe
 from a huge oak.  He looks about as tough as they come.  He inspires the urge to
 look for a parrot and peg leg.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D3
 ~
 ~
@@ -691,7 +691,7 @@ to those who are less fortunate.  Racks and shelves line the walls to supply
 ample storage for those who wish to donate.  This is the ideal place to be a
 good citizen and leave something for the poor.
 ~
-2 12 0 0 0 0
+2 12 0 0 0 1
 D1
 ~
 ~
@@ -708,7 +708,7 @@ room containing a beautiful stone fountain is visible, tempting travelers to
 drink from it.  The polished floor is made from smooth marble, and looks
 flawless.  A lot of time and effort must have been put into this temple.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -733,7 +733,7 @@ white marble rise up to the ceiling which looks to be pure hammered gold.
 Several cushions and benches line the walls to allow a place for people to wait
 before the daily services.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D2
 ~
 ~
@@ -750,7 +750,7 @@ Everything a person could imagine.  All used to make some of the finest clothes
 in the realm.  Every type of clothing can be found here.  Anything that can't be
 seen, Carla can make.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D1
 ~
 ~
@@ -763,7 +763,7 @@ venture out into the city.  The Tower of Sanctus shines brightly, its white
 marble reflecting all light that strikes it.  The Tower is rumoured to be a
 combination of magic and perfect architecture.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -784,7 +784,7 @@ any light that shines at it, the smooth white walls seem almost magical.  To the
 south the avenue reaches an intersection.  The meeting of the Thieves Quarter
 and the Magi Quarter.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -801,7 +801,7 @@ expect in a bank, not in a warehouse.  The vault looks impossible to pick and
 considering who made it you bet only the person with the key could ever get
 into it.  A large ornate rug covers the floor.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -814,7 +814,7 @@ of coin counting apparatus.  Unfortunately, no money has been left out.  Even
 under the tables and in the corners.  The room is very clean and organized just
 right.  If you moved something I bet people would know.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -827,7 +827,7 @@ kept open, the tall wooden beams are reinforced with metal bars.  Guards can be
 heard high above, lookouts to warn in the case of an attack.  The town looks
 very safe and secure from here.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -852,7 +852,7 @@ one can see the Warriors Barracks and to the south the Hall of Clerics.  The
 road consists of hard packed dirt with a few ruts from wagons.  The hustle and
 bustle of the city can be heard all around.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -869,7 +869,7 @@ the army to the north while a smaller building to the south appears to be part
 of the clerics' quarter.  The temple rises high above to the east.  Here, one
 could leave the protection of the city and go west through the gate.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -886,7 +886,7 @@ Temple is where people go to pray to the gods, they are guaranteed safety
 within certain rooms of the temple.  A safe haven is very rare in the realm
 these days.  That is why Sanctus was created.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -912,7 +912,7 @@ could ever batter down this wall.  Looking up, one can see a portculis built
 into the wall.  Its probably best not to wonder what would happen if it were to
 suddenly let go and come crashing down.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -929,7 +929,7 @@ Sanctus to the western gate and beyond the protection of the dome.  Few people
 travel beyond the dome because they fear the gateways between worlds may open
 at anytime.  Only brave adventurers dare travel far beyond the city walls.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -955,7 +955,7 @@ should be promptly answered.  If the board is not the right place for a
 particular problem to be solved, it is possible to go to the post office and
 mail a god.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D1
 ~
 ~
@@ -968,7 +968,7 @@ own reflection perfectly.  Not a single marr or scratch on it's flawless
 surface.  The echo of people walking inside the temple can be heard, though not
 pinpointed.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -993,7 +993,7 @@ this spot is where Rumble and Ferret began restoring order to the world.  Many
 tales abound about this fabled temple and its founders.  Most are just that,
 tales, but many hold truths beyond what even the storytellers realize.  
 ~
-2 24 0 0 0 0
+2 24 0 0 0 1
 D0
 ~
 ~
@@ -1024,7 +1024,7 @@ true.  Several benches can be seen to the north.  The sound of running water can
 be heard to the west.  To the south people can be seen, busy in prayer, while to
 the east a small room lies, full of several people gossiping.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1049,7 +1049,7 @@ This board is used for no other reason than to socialize with one another.
 Various boards can be found throughout the realm.  This one can be viewed by
 anyone.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D3
 ~
 ~
@@ -1062,7 +1062,7 @@ travelling for those wishing to visit the temple from the farmlands.  The
 farmlands are known to be one of the most stable regions outside the protection
 of the dome.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1087,7 +1087,7 @@ wall is so thick that no matter the time of day shadows still lurk everywhere
 under here.  A portculis is built into the ceiling high above.  Must be the
 controls for it are on top of it.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -1104,7 +1104,7 @@ to the Temple of Sanctus.  North lies the Thieves Quarter while to the South one
 can enter the Magi's Quarter.  This road bustles with activity as people go
 about their daily lives.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1129,7 +1129,7 @@ Quarter and their warehouse.  South is the Magi's Mansion and the Magi's
 Quarter.  To the east one can exit the city through the Eastern Gate.  The
 infamous Temple of Sanctus can be seen rising from the center of the city.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -1146,7 +1146,7 @@ entire city spreads out to the west.  The safety of the city is preferred by
 almost everyone.  But, some people choose to live outside the east gate where
 there are very few troubles or mishaps.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -1163,7 +1163,7 @@ residential district.  This area is known for it's relative safety.  Very few
 problems arise from beyond the east gate.  The city of Sanctus lies to the west.
 To the east one can see the remains of an old gatehouse.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D3
 ~
 ~
@@ -1181,7 +1181,7 @@ chairs a writing pad, inkpen and ink blotter.  This is where the high
 councillors spend their nights.  They live a life without possession or
 desires.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D2
 ~
 ~
@@ -1194,7 +1194,7 @@ in small pots lining the walls.  A large wooden box crafted like a chair with a
 hole cut in the top must be the only bathroom in the entire Hall of Clerics.  
 You can hear something moving around below you.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D2
 ~
 ~
@@ -1207,7 +1207,7 @@ Warriors Quarter, go east into the Temple of Sanctus or west to the western
 gate.  A large building and the inner city wall on each side of this north south
 street leaves little room for walking.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1224,7 +1224,7 @@ town folk.  Everything, well almost everything, can be found within these walls
 to support the town.  Women lugging sacks full of groceries arrive from the east
 and pass down the street.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1245,7 +1245,7 @@ and vegetable stands line both walls.  This shop seems to carry everything,
 except bread and meat.  Must be the baker, butcher, and grocer have an
 understanding.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D3
 ~
 ~
@@ -1258,7 +1258,7 @@ on.  Several candles line the walls.  Large murals dominate the wall and
 ceiling above a small altar.  Those who are feeling pious may come here to give
 thanks to their gods.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1275,7 +1275,7 @@ unusually quiet.  It appears people are in prayer inside.  The center of the
 temple lies to the north.  The white marble floor, walls, and ceilings of the
 temple are spotless.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1300,7 +1300,7 @@ walls, filling the alter and even hanging from the ceiling by chandeliers.  The
 candles are scented, leaving a faint aroma of spring flowers.  Cushions of
 various colors cover the floor in precise rows.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1317,7 +1317,7 @@ Furrier is trying to blanket the disgusting smell from the tanning process.
 This guy can make almost anything from a good fur hide.  He is very skilled and
 his prices are not too outrageous.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D1
 ~
 ~
@@ -1330,7 +1330,7 @@ This circle lies just inside the market center of Sanctus.  The stores have all
 taken up shop surrounding the Temple.  They originally were afraid the outer
 city could be overrun, but now they are just too lazy to move.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1352,7 +1352,7 @@ Eastern Road or head further north into the Thieves Quarter.  This Quarter of
 the city is very well maintained, decorative streetlamps line both sides of the
 wide street.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1369,7 +1369,7 @@ Green, and one Yellow.  The closets are filled with robes and small sandals,
 all of the same three colors.  You have trespassed on three of the five orders
 of the Master Magi.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D2
 ~
 ~
@@ -1382,7 +1382,7 @@ northern walls.  Filled with robes of Red and Black.  The floor is covered in a
 thick maroon run that cushions your every step.  The Master Magi must live in
 this room.  Better not be caught trespassing.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D2
 ~
 ~
@@ -1397,7 +1397,7 @@ and cushions allow comfortable places to relax and peruse the many novels.
 Light from lanterns hanging overhead fills the room as if it was broad
 daylight.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1418,7 +1418,7 @@ overweight cooks are sampling their favorite dishes as they prepare for the
 next meal.  They look at you just daring you to try and take some of their food
 that they spent hours preparing.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1439,7 +1439,7 @@ audience with any who request it.  To the east the inner city wall looks about
 as impenetrable as any wall ever seen.  Clerics Avenue continues north and
 south.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1456,7 +1456,7 @@ displayed in one window depicts several precious gems and minerals.  The Temple
 Circle continues north and south.  The cobblestone streets are bordered by the
 inner city wall to the west and various stores and shops to the east.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1477,7 +1477,7 @@ some steel bars.  Must be the jeweler has had problems with thieves.  Several
 nuggets of strange minerals are display on shelves all around.  Lucky is the
 individual who can find some of these valuable items to sell.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D3
 ~
 ~
@@ -1490,7 +1490,7 @@ Everything from rabbit, to cow, to goodness knows what.  One of the pieces looks
 an awful lot like a cat.  Any meat a person may need, this guy sells it.  Blood
 covers the counter and the small cutting area behind it.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D2
 ~
 ~
@@ -1503,7 +1503,7 @@ Sanctus.  The white marble walls have been polished smooth.  A small road to the
 south leads to the Cleric's and Magi's quarters of the city.  The scent of
 flowers fills the air with a soothing aroma.
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1520,7 +1520,7 @@ woman behind the counter is pounding relentlessly on a stubborn hunk of dough.
 Those arms on her are similar to those of the smithy.  Various baked goods fill
 the entire room.  Baked fresh daily of course.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D2
 ~
 ~
@@ -1538,7 +1538,7 @@ buckets around the store.  The items look second hand, but they would all serve
 their purpose.  A few other customers wander the store.  They can't seem to find
 what they are looking for either.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -1550,7 +1550,7 @@ The Eastern Temple Circle~
 mining equipment.  The cobblestone road is blocked to the east by the inner city
 wall and several stores crowd against the Temple of Sanctus to the west.  
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1571,7 +1571,7 @@ obvious that they must be magical in nature since no oil you've ever seen burns
 that color.  The beautiful cobblestone road meanders north and south.  The Magi
 Mansion to the east looks glorious.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1588,7 +1588,7 @@ the hundreds of volumes of books it holds.  These are the chronicles of the
 Magi.  Within them they hold the secrets of their mystical art.  A large sign
 above the bookshelf warns anyone from attempting to touch the books.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1609,7 +1609,7 @@ silverware and spotless wine glasses all fill the majestic table.  Enough for
 seven settings.  Two of the place settings are turned upside down.  Servants
 rush about their work around you.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1630,7 +1630,7 @@ problems.  The High Council will then vote and decide on a way to settle the
 matter.  Their word is final and none ever disobey them.  They are respected
 for their intelligence and wisdom.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1647,7 +1647,7 @@ other.  The Hall is the only form of justice within the city besides the army.
 Everyone respects the High Council for their devotion and wisdom towards what
 is right.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1665,7 +1665,7 @@ three times the average man's height and one can not tell how thick it must be.
 YouThe sound of clanking armor can be heard, along with idle chat as guards on
 the wall above you make their rounds.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1682,7 +1682,7 @@ The south and west inner city walls merge here.  A set of stone stairs lead up
 into a small lookout post high above.  The street turns here, wrapping around
 the Temple of Sanctus.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1703,7 +1703,7 @@ of the inner city.  Small shops line the road to the north.  The Tower of
 Sanctus, with its single tall spire reaching to the heavens, looks magnificent.
 A style of workmanship that has never been surpassed.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -1720,7 +1720,7 @@ swaying above the door in the breeze depicts a hunk of meat crossed with a
 butcher's axe.  An intersection can be seen just to the east where one can exit
 the inner city or enter the temple.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1742,7 +1742,7 @@ The Southern Temple Circle Intersection~
 also possible to travel along the Temple Circle east and west.  To the south one
 can exit the inner city and work their way into the magi or clerics' Quarters.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1767,7 +1767,7 @@ feelings of hunger.  To the west can be seen an intersection that can lead into
 the temple to the north or exit the inner city to the south.  The inner city
 wall stretches east and west along the Temple Circle.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1788,7 +1788,7 @@ of the inner city.  Small shops line the road to the north.  The Tower of
 Sanctus, with its single tall spire reaching to the heavens, looks magnificent.
 A style of workmanship that has never been surpassed.
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D1
 ~
 ~
@@ -1806,7 +1806,7 @@ good business and the overall wealth of the city seems to be geared mostly to
 the middle class.  Only a few have achieved poverty or great wealth within the
 city.    
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1827,7 +1827,7 @@ mansion to the east.  The magi have trained hard to become very powerful within
 the city and have begun living the life that shows it.  Unlike the clerics who
 do not believe in worldly possessions the Magi surround themselves with it.  
 ~
-2 0 0 0 0 0
+2 0 0 0 0 1
 D0
 ~
 ~
@@ -1844,7 +1844,7 @@ ceiling.  It depicts a battle with the Master Magi obliterating hundreds of
 demons by calling down lightning and hurling fireballs.  The demons look
 vaguely familiar, like something you remember from a dream.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1861,7 +1861,7 @@ where the servants and students sleep and, from the looks of the table and what
 is on it, gamble.  The table is full of chips and various headed die.  A deck
 of cards lies in the center of the table waiting to be dealt.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~
@@ -1878,7 +1878,7 @@ south.  The citizens of Sanctus come here to settle disputes by seeking the
 guidance of the High Council.  The High Council has come to be the law of the
 land here.    
 ~
-2 8 0 0 0 0
+2 8 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/200.wld
+++ b/lib/world/wld/200.wld
@@ -31,7 +31,7 @@ Capital while to the west the highway continues.  A gravelled path leads
 northward, away from this boring highway, towards some rocks a bit further
 north.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D3
 ~
 ~
@@ -43,7 +43,7 @@ Western Highway~
 be seen to the east.  The highway stretches from the west towards the gates.  
 A light forest to the north of pines and small saplings looks peaceful.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -59,7 +59,7 @@ Western Highway~
 the south as well as the highway continuing off to the east and west.  The
 forest to the north seems to thin out a little allowing entrance.  
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -75,7 +75,7 @@ Western Highway~
 the Capital and west deeper into the wilderness, plains to the south and thick
 forest to the north.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -91,7 +91,7 @@ Western Highway~
 west as well as to the east.  The forest to the north looks peaceful and
 inviting, though it seems too dense to enter.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -107,7 +107,7 @@ Western Highway~
 has thinned out and a large wooden building with smoke trailing out of a stone
 chimney is visible between the trees.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -124,7 +124,7 @@ is in disrepair, with shingles lying on the ground and a porch that looks like
 it could collapse any second.  A faded sign swings on rusty hinges that squeak
 annoyingly.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -148,7 +148,7 @@ Western Highway~
 west and to the east.  To the northeast a wooden building can be seen set back
 a little ways in the forest.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -164,7 +164,7 @@ Western Highway~
 to the east and west where the road continues on and to the south where the
 trees open up into a barren plain.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -180,7 +180,7 @@ Western Highway~
 south while the highway continues on to the east and to the west.  The road
 heads south through the plains.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -200,7 +200,7 @@ Western Highway~
 northwest to allow entry into the forest.  The plains to the south appear
 barren.  The highway continues onto the west and east.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -216,7 +216,7 @@ Western Highway~
 directly into the forest and disappears around a bend a short distance through
 the trees.  The more heavily travelled western highway continues east and west.
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -237,7 +237,7 @@ breeze blows to you from over the plains to the south.  It carries a slight
 hint of smoke with it, civilization must be near.  To the north a thick forest
 blocks your view.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -254,7 +254,7 @@ the Southwest.  To the north a thick grove of pines lays in deep shadow while
 to the south an open plain is broken by a few scattered hills.  The highway
 continues on to the west and east.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -270,7 +270,7 @@ Western Highway~
 south.  It appears to be heavily travelled and the wind carries the smell of
 smoke with it from the south.  The highway continues on to the west and east.
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -290,7 +290,7 @@ Western Highway~
 distance to the southeast.  The highway continues east or west.  To the west
 the sound of rushing water can be heard.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -307,7 +307,7 @@ flows beneath it slowly washing the remains of the bridge away.  Debris and
 sand has been scattered everywhere.  The river must have overflown and washed
 the bridge away.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 ~
@@ -320,7 +320,7 @@ travelled.  It seems to lead on to the north as well as to the south, where you
 can see the Western Highway.  The thick forest continues on both sides of the
 dirt road.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -336,7 +336,7 @@ Dirt Road~
 from seeing very far.  A few small animals scamper here and there around your
 feet.  The road continues to the north and south.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -353,7 +353,7 @@ travelled in that direction.  The thick coniferous forest seems to be starting
 to thin out into a variety of hard woods.  Young maple trees seem to be
 dominating this part of the forest.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -370,7 +370,7 @@ the path, hanging around you.  Thick underbrush has begun to form to the sides
 and the road looks unkept.  It is slowly being consumed by the forest around
 it.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -386,7 +386,7 @@ Dirt Road~
 animals stay just out of sight.  They seem unused to travellers and are very
 wary.  The trees continue to thin to the north.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -402,7 +402,7 @@ Dirt Road~
 saplings.  The path is barely distinguishable from the rest of the overgrowth.
 The smell of the forest is very strong.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -418,7 +418,7 @@ Dirt Road~
 The path continues north and south between the columns of thick trees and
 brush.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -435,7 +435,7 @@ cut down and fallen over the path, as if to block it.  The smell of fresh pine
 must mean they were cut recently.  Through the brush and trees to the north you
 can just barely make out what looks like a gate and a city wall.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D2
 ~
 ~
@@ -447,7 +447,7 @@ Dirt Road~
 north and the dirt road continuing to the south.  The forest around the road
 diminishes to plains the further south you travel.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -464,7 +464,7 @@ to the north.  Tall fields of wild grass, weeds, and other small brush borderw
 the road.  The fields have grown to about waist height and could be used easily
 to conceal oneself within.  The grass sways gently in the breeze.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -482,7 +482,7 @@ around a huge pile of rocks to the southeast.  The remains of a stone wall runs
 through the middle of the pile.  Once used to mark out boundaries between land
 owners.  Now it seems no one is farming on these plains.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D1
 ~
 undefined~
@@ -500,7 +500,7 @@ so close to the Capital.  Instead they appear empty and deserted.  Very little
 sign of travel or civilization can be seen, except for a plume of smoke rising
 far to the west.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -516,7 +516,7 @@ Dirt Road~
 north and also to the south.  The grassy plains sway gently in the breeze.  
 Occasionally the grass will rustle as some animal flees at your approach.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -532,7 +532,7 @@ Dirt Road~
 in places.  You guess the road isn't used very often.  The road continues off
 to the north and south.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -549,7 +549,7 @@ on the road.  The road continues to the north and south.  To the north a field
 of swaying grass stretches to a forest in the distance.  South the plain gives
 way to a light forest.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -565,7 +565,7 @@ Dirt Road~
 north.  The road curves around a large steep hill to the south.  The hill looks
 somewhat unnatural, and out of place.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -581,7 +581,7 @@ Dirt Road~
 and south.  You stand alongside a steep hill covered in grass and moss.  The
 hill rises so steeply above you that you doubt it could be climbed.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D2
 ~
 ~
@@ -597,7 +597,7 @@ Dirt Road~
 north and south.  A large hill directly to the west looms above you.  Strange,
 when the rest of the rolling hills around here are so small.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -613,7 +613,7 @@ Dirt Road~
 animals seem to be taking refuge in some of the small bushes to the side of the
 road.  The road continues off to the north and south.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -629,7 +629,7 @@ Dirt Road~
 south.  The brush is broken up by small trees which seem to grow even thicker
 further south.  To the north the road opens up into the plains.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -645,7 +645,7 @@ Dirt Road~
 The road bends to the west into a dense forest.  Their seems to be an absence
 of wildlife in this area, the forest is strangely silent.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~
@@ -658,7 +658,7 @@ Somewhere in the distance to the south-west you can make out some small streaks
 of smoke, as if coming from the chimneys in a small village, while to the
 north you see the busy Western Highway.    
 ~
-200 32768 0 0 0 0
+200 32768 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/201.wld
+++ b/lib/world/wld/201.wld
@@ -26,7 +26,7 @@ and impassable.  Shadows play in the darkness of these woods and no sound could
 be heard from within the trees.  The only exit is a narrow path that leads to
 the south.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 3
 D2
 A small path leads away from the forest so the south, where it splits into two.
 ~
@@ -40,7 +40,7 @@ On a Cliff by a Lighthouse~
 the coast.  Grasses sprout randomly around the area.  Looming from the west is
 an old lighthouse, and to the east a path leads towards a T-Junction.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 4
 D1
    The road splits into a T-junction.  
 ~
@@ -64,7 +64,7 @@ south.  Northwards, the path leads to the entrance of a dark, ominous forest.
 To the west, it continues to a silhouette of a tall building while to the south
 the path descends steeply to a sandy beach.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 2
 D0
    A narrow path leads to a gloomy looking forest.  
 ~
@@ -117,7 +117,7 @@ On the Coast of Konolua Beach @Y[DIG]@n~
 To the north is an upward going slope that ascends sharply.  To the west you can
 see the shore and to the south and east the coast continues on.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
 Up a Slope to a T-junction
 ~
@@ -153,7 +153,7 @@ waters.  The beach stretches all the way to the east, while to the west and
 south the water eventually leads to the sea.  A cliff stands tall as an obstacle
 to the North.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D1
    Konolua Beach
 ~
@@ -180,7 +180,7 @@ waves.  The beach lies to the east, while the deeper waters are generally to the
 west and south.  A solid, sturdy rock cliff prevents movement to the north and
 west.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 6
 D1
    To the Shores of Konolua Beach
 ~
@@ -207,7 +207,7 @@ the north is a cliff, densely covered with vines and other form of parasitic
 plants.  Against it is a small delapidated house - its windows are near falling
 apart.  To the south the beach gently descends to the shore.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
    A small house has been built here.  
 ~
@@ -250,7 +250,7 @@ and scree litters the area.  Continuing to the west and south, the beach
 continues on.  To the north a cliff stands firm, hindering any movement in that
 direction.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D1
 Konolua Beach
 ~
@@ -285,7 +285,7 @@ and other creatures had made their home under the rocks where predators such as
 seagulls cannot find them.  A small trial free of rocks leads to the west and
 south.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 5
 D2
 Konolua Seashore
 ~
@@ -306,7 +306,7 @@ In Shallow Waters~
 where it eventually leads to the wide ocean.  Bubbles are formed when the waves
 retreat from the shore, and bob non-chalantly on the waves.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 6
 D0
 Konolua Seashore
 ~
@@ -341,7 +341,7 @@ By the Seashore @Y[DIG]@n~
 beach and the azure, blue sea.  The beach extends to the north and east, while
 to the west and south shoal water merges the land and the sea together.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
 Konolua Beach
 ~
@@ -372,7 +372,7 @@ By the Seashore @Y[DIG]@n~
 Being closer to the sea, the winds are generally stronger here.  Sand dunes line
 the beach, forming adjacent to the direction of the wind.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
 Konolua Beach
 ~
@@ -403,7 +403,7 @@ By the Seashore @Y[DIG]@n~
 white sand.  Northwards takes you inland, while going east or west will take you
 to another shore of Konolua beach.  Southwards takes you into the sea.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
 Konolua Beach
 ~
@@ -433,7 +433,7 @@ By a Seashore @Y[DIG]@n~
 path leading into the ocean.  The beach continues north and west, and southwards
 leads to the beginning of the ocean.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
 Konolua Beach
 ~
@@ -470,7 +470,7 @@ beneath the surface can be seen as wavering shapes.  Northwards leads the way
 back to the shores of Konolua Beach, and to the west and south is the entrance
 to the ocean.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 6
 D0
 In Shallow Waters
 ~
@@ -499,7 +499,7 @@ In Shallow Waters~
 onto the beach before subsiding.  Konolua beach is to the north,while to the
 south the waters lead you deeper into the ocean.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 6
 D0
 Konolua Seashore
 ~
@@ -529,7 +529,7 @@ In Shallow Waters~
 it eventually leads to an open ocean.  To the east and west are more are shallow
 waters, which lines the edge of Konolua beach.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 6
 D0
 Konolua Beach
 ~
@@ -558,7 +558,7 @@ In Shallow Waters~
 light dancing on the sandbed.  To the north is the shore of Konolua beach while
 going to the south will take you to the ocean.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 6
 D0
 Konolua Seashore
 ~
@@ -588,7 +588,7 @@ In Shallow Waters~
 here is relatively deep, and currents are quite powerful here.  To the north is
 the safety of the seashore.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 7
 D0
 Konolua Seashore
 ~
@@ -618,7 +618,7 @@ In Deep Waters~
 great depths.  Northwards leads to shallower waters, while to the southwest as a
 spread of ocean.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 7
 D0
 In Shallow Waters
 ~
@@ -646,7 +646,7 @@ On a Sandy Path~
 waves coming from the east.  To the north is a grey, solemn cliff guarding
 Konolua beach while the path continues south.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 2
 D1
 The waves are strong here - forceful and unconquerable.
 ~
@@ -670,7 +670,7 @@ On a Sandy Path~
 and the north.  To the east and west are bodies of water, where the waves are
 coming in and lapping at the pathway.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 2
 D0
 On a Sandy Path
 ~
@@ -699,7 +699,7 @@ A Narrow Sandy Path~
 ocean leading to the north and the east.  The waves lap teasingly at the road,
 as if they were going to swallow it up anytime.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 2
 D0
 On a Sandy Path
 ~
@@ -728,7 +728,7 @@ On a Sandy Pathway~
 the sandy pathway here which leads to the west and the south.  Southwards, an
 arch stands like an entrance to a small island in the middle of the sea.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 2
 D0
 The waves are strong here - forceful and unconquerable.
 ~
@@ -758,7 +758,7 @@ sides of the small island with utmost fury.  To the north is a stone arch, where
 a route starts and ends at Konolua beach.  To the south the the land twists and
 turns with ascending gradient.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
 Stone Archs acting like a big gate is to the north.
 ~
@@ -788,7 +788,7 @@ Below the layers of stone of this area is a small cave, created by the constant
 erosion by the sea waves.  To the north the route is less steep as it descends
 to the base of cliff.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
 On a Small Island
 ~
@@ -817,7 +817,7 @@ At the Peak of the Cliff~
 the cliff.  Sleeping beneath the waters are lots of hidden reefs, and falling
 over the edge would mean instand death.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 5
 D3
 A path descending to the base of the cliff.
 ~
@@ -831,7 +831,7 @@ An Isolated Part of the Island~
 some logs - swept ashore by the waves.  The land continues to the north, while
 to the other directions are bodies of water.  
 ~
-201 4 0 0 0 0
+201 4 0 0 0 2
 D0
 To the base of the hill
 ~
@@ -867,7 +867,7 @@ In the Deep Ocean~
 ocean itself were breathing and alive.  To the northeast are safer waters, while
 going south and west will take you deeper into the ocean.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 In Shallow Waters
 ~
@@ -896,7 +896,7 @@ Giant waves reaches high up and comes crashing down upon you, forcing you
 beneath the ocean surface.  Underwater currents tries to pull you under and the
 frigid cold wind merciless
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 In the Raging Waves
 ~
@@ -961,7 +961,7 @@ middle of the sea.  Here, the waves are fierce and hungry, reaching out at you
 in an attempt you swallow you.  To the north, are shallow waters, while
 everywhere else are large bodies of ocean.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 In Shallow Waters
 ~
@@ -989,7 +989,7 @@ In the Ocean~
 look into the depths of the ocean, for the shifting bodies of the sea makes it
 difficult to.  To the north you can descry a small island.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 In Shallow Waters
 ~
@@ -1018,7 +1018,7 @@ In the Ocean~
 ocean.  North are safer and much calmer waters, while to the other directions
 the ocean continues.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 To Shallower Waters
 ~
@@ -1047,7 +1047,7 @@ In the Ocean~
 come in all direction, invoking the rage of the waves.  To the north the sea is
 calmer, while to the east, south and west the ocean continues.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 Shallower Waters
 ~
@@ -1112,7 +1112,7 @@ Giant waves reaches high up and comes crashing down upon you, forcing you
 beneath the ocean surface.  Underwater currents tries to pull you under and the
 frigid cold wind merciless
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 ~
 ~
@@ -1145,7 +1145,7 @@ Giant waves reaches high up and comes crashing down upon you, forcing you
 beneath the ocean surface.  Underwater currents tries to pull you under and the
 frigid cold wind merciless
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 ~
 ~
@@ -1178,7 +1178,7 @@ Giant waves reaches high up and comes crashing down upon you, forcing you
 beneath the ocean surface.  Underwater currents tries to pull you under and the
 frigid cold wind merciless
 ~
-201 0 0 0 0 0
+201 0 0 0 0 7
 D0
 ~
 ~
@@ -1328,7 +1328,7 @@ On a Sandy Bay~
 Covered with washed up pieces of broken wood and miscellaneous junk items dumped
 onto it, the area is fully of rubbish peeking out from the sand.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D0
    A dead end
 ~
@@ -1354,7 +1354,7 @@ appears to be empty, and heavily populated by tropical plants and vicious vines.
 Speckles of broken rocks and stones lie here, and several marks are shown in the
 sand.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D2
 ~
 ~
@@ -1379,7 +1379,7 @@ At the Scene of a Shipwreck~
 wooden planks are here, as well as a ship, torn by ocean reefs and left
 discarded here.  
 ~
-201 0 0 0 0 0
+201 0 0 0 0 2
 D1
    On a Sandy Shore
 ~
@@ -1411,7 +1411,7 @@ In a Small Underwater Tunnel @C[SURFACE]@n~
 in the water.  The only exit out is to surface, or to go deeper into the tunnel
 north.  
 ~
-201 360 0 0 0 0
+201 360 0 0 0 9
 D0
    The circular tunnel leads north.  
 ~

--- a/lib/world/wld/220.wld
+++ b/lib/world/wld/220.wld
@@ -433,9 +433,9 @@ plastic forks, spoons and thin saucers float around on the surface.
 There are metal utensils sunk to the bottom, though they are covered 
 in @Ggreen @gmold@y.  Unrecognizable chunks of food are also drifting past.@n
 ~
-220 8 0 0 0 0
+220 8 0 0 0 6
 D2
-@DA big cutting board lies to the south.  @n
+	DA big cutting board lies to the south.  	n
 ~
 ~
 0 0 22014

--- a/lib/world/wld/232.wld
+++ b/lib/world/wld/232.wld
@@ -11,7 +11,7 @@ Near the buildings, you see statues of many forms, these statues seem to be
 untouched by time.  At a close glance of the statues, you can make out the Gods
 Rumble, Welcor, Ferret, Detta, Heiach, Shamra, Relsqui, Elaseth, and Fyre.
 ~
-232 144 0 0 0 0
+232 144 0 0 0 1
 D0
 ~
 ~
@@ -51,7 +51,7 @@ it looks like someone took their time to make traveling easy.  The smell of
 fresh baked bread seems to be coming from the north.  To the west you see a
 large fountain.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -72,7 +72,7 @@ are walking on air.  The buildings to the north and south have great Murals on
 them.  You stand back to look at the lovely pictures and wonder where it all
 happened.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -94,7 +94,7 @@ Terringham road~
    This well pathed road seems to have a split in it.  You can go east, west or
 south.  To the north is a wall.  You can see a gate to the far east.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -113,7 +113,7 @@ Terringham road~
    You have come to a cross road.  To the east you see a large gate.  To the
 north, south and west you see a large stretch of road.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -137,7 +137,7 @@ East gate~
 gates.  The guards here make it a point to keep mean old nasty mobs from coming
 inside.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D3
 ~
 ~
@@ -165,7 +165,7 @@ Star trail~
 You get an uneasy feeling from the west, but it somehow calls to you.  The way
 west is well lit.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -228,7 +228,7 @@ Star trail~
 cats roaming the streets looking for somthing to eat.  There are only two exits
 that you can see one going north and the other going South.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -245,7 +245,7 @@ When you walk through the town you get a feeling of profound pride that your
 little town has done so well in the years since it was created.  The only exits
 are North and South .
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -260,7 +260,7 @@ Star trail~
    This is the northeastern corner of the city.  It is very quiet here and has a
 drawing on the group.  The only exits are West and South.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D2
 ~
 ~
@@ -276,7 +276,7 @@ Rumble road~
 clanging still chimes in your ears from the west.  The exits that you can see
 are to the West and North .
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -325,7 +325,7 @@ Terringham avenue~
 the street.  To the North is the Nothern Gate.  Other exits lead to the South,
 East and West.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -349,7 +349,7 @@ North gate~
 entrance to the city.  These guards look very strong and should not be messed
 with.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D2
 ~
 ~
@@ -361,7 +361,7 @@ Rumble road~
 gates to the north east.  The only discenable exits are to the east and the
 west.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -377,7 +377,7 @@ Rumble road~
 the north and south side looms in front of you with no way to leave except east
 or west.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -392,7 +392,7 @@ Rumble road~
    The smooth paved street glides on towards the northwest corner of town.  To
 the north you see a tall wall, while there are exits east, west and south.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -440,7 +440,7 @@ Rumble road~
 traffic as this street would normally have.  To the south you can travel down
 the western wall and to the east you go towards the Northern gate.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -455,7 +455,7 @@ West drive~
    You are walking along the west wall of the spectacular city.  The walls are
 whitewashed and very smooth with no artistic talent to them at all.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -471,7 +471,7 @@ West drive~
 walking on air.  The walls are very tall and have little on them that would not
 give you any indication of where you are located.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -524,7 +524,7 @@ Magic shop~
 throughout this room.  The items here are not limited to mages alone.  A recall
 is recommended for everyone, so don't hesitate to buy them.  
 ~
-232 8 0 0 0 0
+232 8 0 0 0 1
 D3
 ~
 ~
@@ -535,7 +535,7 @@ Terringham street~
    You have come to a crossroad.  To the west you see a large gate.  You also
 see exits to the north, south, and east.  The road here is in great condition.
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -558,7 +558,7 @@ West gate~
    You have entered an area that is guarded well.  There are two guard shacks
 here, just inside of the gate.  The guards watch you suspiciously.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -570,7 +570,7 @@ West drive~
 untouched.  There are no paintings and no wagons lining the streets.  You can go
 East or North.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -601,7 +601,7 @@ West drive~
 that hang down in your face.  It doesn't look like any caretakers come this way.
 The exits go North and West.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -634,7 +634,7 @@ West drive~
 down and some you must push out of the way.  The only exits that you can see are
 North and East.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -649,7 +649,7 @@ South park~
    The road here seems to fade out.  To the east you can see the road, and to
 the west you notice that a jungle or something starts to form.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -665,7 +665,7 @@ South park~
 done, maybe it isn't.  To the North you can hear some clanging.  The only other
 exits are to the East and West.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -685,7 +685,7 @@ A side road~
 something.  You also hear the sound of someone chopping up wood....  Which is a
 weird sound to hear in the City.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -700,7 +700,7 @@ Weapons Shop~
    You see many arms hung up along the wall.  Some items glow and attract the
 attention of everyone.  The prices are steep for the glowing items.  
 ~
-232 8 0 0 0 0
+232 8 0 0 0 1
 D2
 ~
 ~
@@ -712,7 +712,7 @@ South park~
 strain.  The sun seems to beat down more on this part of town than the others.
 Available exits are to the east and west.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -728,7 +728,7 @@ Terringham way~
 To the South you hear boots clanging on the ground and orders being shouted.  
 The other exits are to the East, West and South.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -779,7 +779,7 @@ South park~
 The street is well maintained by a street worker that is here cleaning up the
 street.  The only exits are to the East and the West.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -795,7 +795,7 @@ South park~
 looks like there has been blood spilled here before and someone didn't do there
 job to clean it up.  The other exits are East and West.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -810,7 +810,7 @@ South park~
    You are standing at the SouthEastern corner of the city.  The walls are high
 and almost metallic smooth.  The only exits you can see are North and West.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -826,7 +826,7 @@ Star trail~
 have pictures that stand out more than normal paintings do.  The only exits you
 can see are North and South.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -849,7 +849,7 @@ Star trail~
 see some houses, but the access is blocked off to you.  To the north you can see
 the main street leading from the east gate.  To the south you see a trail.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -864,7 +864,7 @@ An alley~
    This is not your typical alley.  This alley seems to be peaceful and glows
 with a brilliant blue.  You notice a sign on a wall.  
 ~
-232 20 0 0 0 0
+232 20 0 0 0 1
 D0
 ~
 ~
@@ -884,7 +884,7 @@ An alley~
 hassles.  To the west is the don room, to the north is your exit back to the
 city.  
 ~
-232 16 0 0 0 0
+232 16 0 0 0 1
 D0
 ~
 ~
@@ -901,7 +901,7 @@ items here are up for grabs.  Feel free to take what you need.  Please don't
 take everything, let the others get some equipment too.  If there are 3 swords
 here..  Don't take all 3, you can't use 3 swords.  Please be curtious.  
 ~
-232 20 0 0 0 0
+232 20 0 0 0 1
 D1
 ~
 ~
@@ -912,7 +912,7 @@ The board room~
    This is where the mortal board sits.  Please read this board everyday.  It
 may contain new information.  Feel free to make notes on this board.  
 ~
-232 24 0 0 0 0
+232 24 0 0 0 1
 D0
 ~
 ~
@@ -925,7 +925,7 @@ buildings to either side are quite striking as they have been painted with
 pictures of dragons fighting knights.  The only noticeable exits are to the
 north and south.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -940,7 +940,7 @@ Terringham way~
    This is the main street.  To the south is the gates.  There is a crossroads
 which lead to one of the off streets.  The last exit is North.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -960,7 +960,7 @@ A side street~
 something.  You notice that it seems very warm here.  This definately would not
 be a good place to rest, if need be.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -976,7 +976,7 @@ The armoury~
 leather to full plate.  If you need a special item, you have to ask for it.  It
 is not displayed in the open.  
 ~
-232 152 0 0 0 0
+232 152 0 0 0 1
 D2
 ~
 ~
@@ -988,7 +988,7 @@ Terringham street~
 importance.  To the South you see a sign over the exit that says Board room.  
 You can see a large fountain to the east.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -1007,7 +1007,7 @@ Terringham street~
    The road here leads east and west.  The walls to the north and south, sport
 some fabulous pictures.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1033,7 +1033,7 @@ Terringham street~
 untouched, and the lighting here seems to be a bit poor.  It looks as if someone
 tried to rush their job.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -1049,7 +1049,7 @@ Terringham avenue~
 paintings on them.  To the south you notice a large fountain.  To the west you
 see the Bank of Terringham.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1075,7 +1075,7 @@ Terringham Bank~
 you use this bank often.  We would hate to see an accident and you rejoin the
 game with no money.  The commands are easy.  Dep $$$$.  With $$$$.  Or Bal.  
 ~
-232 12 0 0 0 0
+232 12 0 0 0 1
 D1
 ~
 ~
@@ -1087,7 +1087,7 @@ Terringham avenue~
 The road looks like someone took their time to make travelling easy.  To the
 south is the bank and to the east you can smell the scents of leather and oils.
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1106,7 +1106,7 @@ Terringham avenue~
    The smooth easy going road continues north to south.  You notice exits to the
 east and west.  Which path shall you take?  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1130,7 +1130,7 @@ Terringham avenue~
 have paintings of the towns greatest heros.  The only visible exits are to the
 north and south.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1145,7 +1145,7 @@ An Alley~
    You hear something moving behind you, but cannot see anything or anyone.  
 You hear noises coming from the east.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -1161,7 +1161,7 @@ Guild row~
 from the south.  You can guess that these are the cleric guilds and the thieves
 guild.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1181,7 +1181,7 @@ Entrance to the Cleric Guild~
 expand their skills.  The guildmaster awaits your arrival, please don't
 hesitate.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D2
 ~
 ~
@@ -1197,7 +1197,7 @@ Entrance to the Thieves Guild.~
 expand their skills.  The guildmaster awaits your arrival, please don't
 hesitate.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1212,7 +1212,7 @@ Guild row~
    You have found the path to the warriors guild and the mages guild.  Which
 path do you take to reach your guildmaster?  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1232,7 +1232,7 @@ Entrance to the Warriors Guild~
 to expand their fighting skills and swordmanship.  The guildmaster awaits your
 arrival, please don't hesitate.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D2
 ~
 ~
@@ -1248,7 +1248,7 @@ Entrance to the Mage Guild~
 expand their knowledge in the lores of Arcane.  The guildmaster awaits your
 arrival, please don't hesitate.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D0
 ~
 ~
@@ -1280,7 +1280,7 @@ The Bakery~
 counter, surrounding this place.  You see all sorts of breads, pies and cakes.
 Which would you like for your travel.  
 ~
-232 136 0 0 0 0
+232 136 0 0 0 1
 D3
 ~
 ~
@@ -1291,7 +1291,7 @@ An Alley~
    You enter a very clean alley.  There is nothing here polluting the roads.  
 You hear faint noises coming for the west.  To the east is Terringham road.  
 ~
-232 0 0 0 0 0
+232 0 0 0 0 1
 D1
 ~
 ~
@@ -1306,7 +1306,7 @@ Clerics Guild~
    The Cleric Guildsmaster is here waiting to help you.  This room has a very
 peaceful feeling about it.  You feel enlightened when you enter here.  
 ~
-232 156 0 0 0 0
+232 156 0 0 0 1
 D5
 ~
 ~
@@ -1318,7 +1318,7 @@ Thieves Guild~
 knowing that something is afoot.  You listen carefully and Turn about real
 fast....  Your Guildmaster slips out of the Darkness.  
 ~
-232 28 0 0 0 0
+232 28 0 0 0 1
 D5
 ~
 ~
@@ -1331,7 +1331,7 @@ warrior practicing on these dummies.  He does not look like the type to be
 messed with.  The Warrior stops his training and advances towards you with a
 friendly smile, "Fresh meat" he says calmly.  
 ~
-232 28 0 0 0 0
+232 28 0 0 0 1
 D5
 ~
 ~
@@ -1343,7 +1343,7 @@ Mages Guild~
 mixed components.  This is a mage's dream house.  Your guild master sits behind
 a large desk studying a book.  
 ~
-232 28 0 0 0 0
+232 28 0 0 0 1
 D5
 ~
 ~
@@ -1355,7 +1355,7 @@ General Store~
 to go adventuring with is in here.  You have your sacks and bags and lanterns
 all right here.  Please come in and shop around.  
 ~
-232 8 0 0 0 0
+232 8 0 0 0 1
 D3
 ~
 ~

--- a/lib/world/wld/233.wld
+++ b/lib/world/wld/233.wld
@@ -5,7 +5,7 @@ and plants that should have been dead long ago.  A lot of the leaves on the
 trees are missing.  They appear to have been torn off.  Several large foot
 prints linger in the sand.    
 ~
-233 132 0 0 0 0
+233 132 0 0 0 2
 D1
 ~
 ~
@@ -33,7 +33,7 @@ Dragon Plains~
 into the sand, making it difficult for you to walk.  You can see a small stream
 to the south.  But is it really there, or is it a mirage?    
 ~
-233 64 0 0 0 0
+233 64 0 0 0 2
 D1
 ~
 ~
@@ -54,7 +54,7 @@ into the water and see several small pebbles drifting through the current of
 the stream.  You look ahead to see where the stream ends, and notice that it
 disappears into the ground.    
 ~
-233 256 0 0 0 0
+233 256 0 0 0 7
 D0
 ~
 ~
@@ -67,7 +67,7 @@ see the sand swallow the wood.  There is a slight incline here, causing some
 drifts of sand to roll across your feet.  You feel the wind pick up as you
 continue on your way.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -88,7 +88,7 @@ sand begin to fill in the large hole, threatening to trap you inside.  The
 sides of the huge hole are sturdy enough to climb out of, but you'd better
 hurry before you get burried alive.    
 ~
-233 64 0 0 0 0
+233 64 0 0 0 2
 D2
 ~
 ~
@@ -100,7 +100,7 @@ Sand Drift~
 hill, but not as steep.  Some dried up leaves lay at your feet, waiting to be
 blown away in the wind.  You hear some birds singing in the distance.    
 ~
-233 4 0 0 0 0
+233 4 0 0 0 2
 D1
 ~
 ~
@@ -120,7 +120,7 @@ Dragon Plains~
 blow through your hair, making your head tingle with relaxation.  There is a
 large tumbleweed being blown around by the breeze.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -136,7 +136,7 @@ Dragon Plains~
 yourself from the flying grains.  You notice some small footprints in the sand.
 They are much too small to be ones of a dragon.  What could they be from?    
 ~
-233 128 0 0 0 0
+233 128 0 0 0 2
 D1
 ~
 ~
@@ -152,7 +152,7 @@ Skeleton Shack~
 long dead.  The smell of decay fills your nostrils, almost making you gag.  A
 light covering of animal skin is on the the roof to help keep the rain out.  
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -181,7 +181,7 @@ An Abandoned Well~
 could get any water out of here, not that anyone would want to.  The bottom of
 the well is crawling with large black beetles.  Watch out, one might escape!  
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -278,7 +278,7 @@ Dragonscale Tunnel~
 stumble out of the tunnel and fall onto the sand.  You feel your body begin to
 sink into the sand.  Struggling would do you no good.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D2
 ~
 ~
@@ -1047,7 +1047,7 @@ Dragon Plains~
 in the dirt here.  There might be enough to gather and make a small fire.  It
 even looks as if other travellers have camped out here before.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1063,7 +1063,7 @@ Dragon Plains~
 should have been dead long ago.  The land here is very dry and humid.  You
 begin to wonder how anything could possibly grow here.    
 ~
-233 128 0 0 0 0
+233 128 0 0 0 2
 D0
 ~
 ~
@@ -1079,7 +1079,7 @@ Dragon Plains~
 should have been dead long ago.  The land here is very dry and humid.  You
 begin to wonder how anything could possibly grow here.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1095,7 +1095,7 @@ Dragon Plains~
 should have been dead long ago.  The land here is very dry and humid.  You
 begin to wonder how anything could possibly grow here.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1111,7 +1111,7 @@ Dragon Plains~
 should have been dead long ago.  The land here is very dry and humid.  You
 begin to wonder how anything could possibly grow here.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1127,7 +1127,7 @@ Dragon Plains~
 amounts of sand will ever cease.  You feel a small breeeze pick up, threatening
 to blow some sand in your eyes.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1143,7 +1143,7 @@ Sand Drift~
 your knees, making it very difficult for you to walk.  It will take a bit of a
 struggle to get free.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1159,7 +1159,7 @@ Sand Drift~
 feel your legs begin to itch.  Your feet seem to be going deeper into the sand.
 How is that possible?    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1175,7 +1175,7 @@ A Small Path~
 No tracks are visible along the beaten path and there is nothing but sand as
 far as the eye can see.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1191,7 +1191,7 @@ A Small Path~
 you would be better off walking through the sand.  The sand on both sides is
 very fine and makes strange sounds as you walk on it.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1207,7 +1207,7 @@ A Small Path~
 them snapping and crunching under your weight.  Many of the sticks have large
 thorns that look dangerous.  Be careful not to fall.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1223,7 +1223,7 @@ A Small Path~
 anywhere special, but it sure beats walking through the sand.  The path is out
 of place amongst the sand dunes.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1239,7 +1239,7 @@ Dragon Plains~
 vary in color and texture from almost white to a light brown.  Strange bits of
 scales seem to be intermixed.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1260,7 +1260,7 @@ and fall to the ground.  Grains of sand get shoved into your teeth, making you
 feel sick to your stomach.  Maybe you should start watching where you're
 walking.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1276,7 +1276,7 @@ Sand Drift~
 feel your legs begin to itch.  Your feet seem to be going deeper into the sand.
 How is that possible?    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1292,7 +1292,7 @@ Dragon Plains~
 beings, like yourself, creeping around.  It would be easy to become lost or
 disoriented.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1308,7 +1308,7 @@ Dragon Plains~
 ground, swirling around in the wind.  It appears to be almost dancing.  The
 rumors about dust devils may be true.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1324,7 +1324,7 @@ Dragon Plains~
 everything to its core.  The parched and dreary land is barren and scarred.  
 It hardly seems able to support any life.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D2
 ~
 ~
@@ -1336,7 +1336,7 @@ Dragon Plains~
 surroundings.  To the west you can see some sort of burial ground.  Maybe you
 should go have a look.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1352,7 +1352,7 @@ Indian Burial Ground~
 headed and not quite yourself.  Many small pebbles are on the ground, marking
 grave sites.  Be careful not to step on one!    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1369,7 +1369,7 @@ bones lying around.  You wonder how they could have gotten here.  You begin
 looking around, then you see the reason.  Numerous footprints from several
 large dragons have been smashed into the dirt, crushing some of the graves.  
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1385,7 +1385,7 @@ Indian Burial Ground~
 the thundering footsteps of a very large dragon.  Maybe it would be best to
 leave before you turn into someones lunch.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1401,7 +1401,7 @@ Indian Burial Ground~
 where all the dragons are.  The exit is coming up to the east.  Strange piers
 and poles stick up out of the ground in the distance.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1417,7 +1417,7 @@ Gates leading out of the Burial Grounds~
 you can see a large water hole.  You begin to wonder if its really there.  
 Stories of mirages abound in the taverns.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1433,7 +1433,7 @@ Dragon Plains~
 the east you can see a fairly large water hole.  Maybe you could get a drink
 there.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1453,7 +1453,7 @@ Water Hole~
 The water looks clean and drinkable.  Sparse vegetation surrounds the limited
 water supply.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D2
 ~
 ~
@@ -1469,7 +1469,7 @@ Water Hole~
 water thinking about yout long lost childhood.  So many old memories flood your
 mind, making you feel light headed.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1485,7 +1485,7 @@ Water Hole~
 rather murky and wouldn't be very good for drinking.  Something must have
 stirred it up recently.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1501,7 +1501,7 @@ Dragon Plains~
 the distance you can see a few buildings.  What are buildings doing here?  
 They appear to have been destroyed.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1517,7 +1517,7 @@ Dragon Plains~
 the remains of a ransacked village.  Wisps of smoke still rise up from the
 charred remains of what must have been houses.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1534,7 +1534,7 @@ can see several large footprints in the dirt, most likely from a dragon.
 Piles of rubble are everywhere.  You can see a skeleton under one of the piles.
   
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1551,7 +1551,7 @@ race through your mind.  You see several people, probably ones who lived in
 this village, being eaten by the dragons.  You begin feeling sick to your
 stomach.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1567,7 +1567,7 @@ Ransacked Village~
 You feel that you're at the end of the village.  You can see the plains to the
 east.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1583,7 +1583,7 @@ Dragon Plains~
 of battles that took place here fill your mind.  You realize how lucky you are
 to still be alive.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D1
 ~
 ~
@@ -1599,7 +1599,7 @@ Dragon Plains~
 here alone.  No other signs of life exist and the footprints are quickly being
 covered by the blowing sand.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D2
 ~
 ~
@@ -1615,7 +1615,7 @@ Dragon Plains~
 small trees and shrubs.  The heat seems to lessen and a cooler breeze rustles
 through the vegetation.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~
@@ -1631,7 +1631,7 @@ Dragon Plains~
 you've come.  You feel a great sense of accomplishment.  Maybe the journey
 wasn't so bad after all.    
 ~
-233 0 0 0 0 0
+233 0 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/234.wld
+++ b/lib/world/wld/234.wld
@@ -1006,7 +1006,7 @@ Inside Lake~
 water level barely covers the bottom of your feet.  You can see some ripples
 forming in the southwest.    
 ~
-234 8 0 0 0 0
+234 8 0 0 0 7
 D0
 ~
 ~
@@ -1026,7 +1026,7 @@ Inside Lake~
 rapidly.  There are some wakes coming from the south.  You wonder if you
 disturbed something.    
 ~
-234 8 0 0 0 0
+234 8 0 0 0 7
 D0
 ~
 ~
@@ -1050,7 +1050,7 @@ Inside Lake~
 The color of this @Ylake@n is undeterminable.  However, you do notice a small
 wake coming from the south east.    
 ~
-234 8 0 0 0 0
+234 8 0 0 0 7
 D0
 ~
 ~
@@ -1074,7 +1074,7 @@ Indoor Lake~
 arena.  How did this Lake get here?  It must have been made by someone or
 something.  This is definately not natural.    
 ~
-234 8 0 0 0 0
+234 8 0 0 0 7
 D0
 ~
 ~
@@ -1289,7 +1289,7 @@ The Source~
 to believe that there must be something alive in here.  You hear an odd noise.
   
 ~
-234 8 0 0 0 0
+234 8 0 0 0 7
 D0
 ~
 ~

--- a/lib/world/wld/236.wld
+++ b/lib/world/wld/236.wld
@@ -26,7 +26,7 @@ is large enough for several carriages to go through it at once.  It's very nice
 masonry work and you can't help thinking about how old it looks.  A sign has
 been posted near the entrance.    
 ~
-236 0 0 0 0 0
+236 0 0 0 0 5
 D0
 A large stone portal, rising from the cave floor
 and in a wide arch above you. In the middle the arch is more than 20' high.
@@ -329,7 +329,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway turns a perfect right angle turn to the north and east here.  Perfect
 walls block your progress to the west and south.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -443,7 +443,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway splits here and branches north, east and west.  To your south another
 perfect wall blocks passage.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -492,7 +492,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway turns a perfect right angle turn to the north and west here.  Perfect
 walls block your progress to the east and south.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -514,7 +514,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway leads north and south here.  Perfect walls block your progress west and
 east.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -536,7 +536,7 @@ darkness might have given you a clue.  To your north a wooden door with a
 sturdy lock blocks your exit, while you may descend into the mines by going
 down.  A large crane has a very large basket hanging from it over the hole here.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 5
 D0
 A wooden door, almost always closed to keep the noise from the mines in.    
 ~
@@ -576,7 +576,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway leads north and south here.  Perfect walls block your progress west and
 east.  To your northeast you hear the sound of pickaxe against rock.
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway widens somewhat.
 ~
@@ -597,7 +597,7 @@ small chairs by another, and a small stove in the farthest corner.  To the east
 a small portal, about three feet tall, leads into darkness, and north of here a
 wooden door leads out to the hallway.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 A wooden door leads out of the dwarven home.
 ~
@@ -617,7 +617,7 @@ portal before you realise the place you've fought so hard to get into is
 nothing but a wardrobe for the dwarfs living in this home.  The only way out
 is back west.    
 ~
-236 521 0 0 0 0
+236 521 0 0 0 1
 D3
 The portal looks just as small from this side.
 ~
@@ -632,7 +632,7 @@ hold runs over the edge and through a hole in the floor.  You pause once again
 to marvel at the cleverness of the stonewright who made this once upon a time.
 You can leave the well by going north.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 Up north you see the nice, but also quite boring masonry of the hallways.    
 ~
@@ -649,7 +649,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway leads north and south here.  Perfect walls block your progress west and
 east.  From your northeast you hear the sound of bubbling water.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -671,7 +671,7 @@ helps you to not think of the terrible weight of the mountain above you.  To
 your east the tunnel widens and looks more used than the ones to the south and
 north.  Another perfect wall blocks the way west.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -698,7 +698,7 @@ helps you to read the sign above the door to the south.  It says 'Beware Of
 Falling Rocks - Use Helmets In The Mine' The wide hallway continues to the west
 and east, and from behind the door to the south you can hear miners at work.  
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The wide hallway continues.
 ~
@@ -725,7 +725,7 @@ makes you feel safe.  To the east and west the wide hallway continues, to the
 south narrows down a little, and to the north a perfect wall blocks your
 progress.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The wide hallways continues.
 ~
@@ -752,7 +752,7 @@ two stones.  Every three feet a torch lights up the corridor and the light
 makes you feel safe.  The wide hallway continues in all directions except
 south, where you see a wooden door.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The wide hallway continues.
 ~
@@ -785,7 +785,7 @@ makes you feel safe.  The wide hallway continues to your west and gets a little
 narrower to your east.  You can hear the sound of running water from the well
 to your south.
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The hallway narrows down a bit.
 ~
@@ -813,7 +813,7 @@ hallway continues north and south here and a somewhat wider hallway leads west.
 A perfect wall blocks your progress to the east.  West of here you hear the
 sound of bubbling water.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -840,7 +840,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway leads north and south here.  Perfect walls block your progress west and
 east.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -858,7 +858,7 @@ A dwarven home~
 the living area to the east is all that's here.  The floor, walls, and ceiling
 are also unremarkable.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 A portal leads back to the living area.
 ~
@@ -896,7 +896,7 @@ two stones.  Every three feet a torch lights up the corridor and the light
 makes you feel safe.  The wide hallway continues north and south, the east and
 west being blocked by perfect walls.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The wide hallway continues.
 ~
@@ -916,7 +916,7 @@ chairs around it in another.  Judging from the smell, the dwarf who lives here
 doesn't care too much for water, not for taking baths, anyway..  A wooden door
 leads north from here.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 A wooden door leads to the hallways.
 ~
@@ -931,7 +931,7 @@ around it in another.  Judging from the smell, the dwarf who lives here doesn't
 care too much for water, not for taking baths, anyway..  A wooden door leads
 north from here.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 A wooden door leads into the hallways.
 ~
@@ -948,7 +948,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway leads north and south here.  Perfect walls block your progress west and
 east.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The hallway continues.
 ~
@@ -970,7 +970,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway turns a perfect right angle turn to the south and east here.  Perfect
 walls block your progress to the west and north.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The hallway continues.
 ~
@@ -992,7 +992,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway leads east and west here.  Perfect walls block your progress north and
 south.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The hallway widens somewhat.
 ~
@@ -1014,7 +1014,7 @@ two stones.  Every three feet a torch lights up the corridor and the light
 makes you feel safe.  The wide hallway continues north and east of here, and a
 somewhat narrower hallway leads west.  To the south you see a wooden door.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The wide hallway continues.
 ~
@@ -1046,7 +1046,7 @@ two stones.  Every three feet a torch lights up the corridor and the light
 makes you feel safe.  East of here, the hallway narrows down a bit, but
 continues to the west and north.  A perfect wall stops you from going north.  
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The hallway narrows down a bit.
 ~
@@ -1073,7 +1073,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway continues to the east, and widens a bit to the west.  North and south
 are wooden doors.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 A wooden door leads to a dwarven home.
 ~
@@ -1105,7 +1105,7 @@ helps you to not think of the terrible weight of the mountain above you.  The
 hallway leads east and west here, and to the south you see a wooden door, while
 north a perfect wall blocks your progress.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The hallway continues.
 ~
@@ -1133,7 +1133,7 @@ hallway turns a perfect right angle turn to the west and south here.  A perfect
 wall blocks your progress to the east.  You could, on the other hand, go north
 into a small dark opening in the north wall.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 You can't see much inthere, but you realise you'll have to crawl on your hands
 and knees to get through.    
@@ -1167,7 +1167,7 @@ makes you feel safe.  To your west a block of pure white marble blocks the
 hallway.  A short inspection reveals it to be a thick magical doorway.  A light
 push makes it turn aside.  You can also follow the wide hallway to the east.  
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The wide hallway continues.
 ~
@@ -1191,7 +1191,7 @@ two stones.  Every three feet a torch lights up the corridor and the light
 makes you feel safe.  The wide hallway continues to your west and east, while
 to the north and south perfect walls block your path.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The wide hallway continues.
 ~
@@ -1213,7 +1213,7 @@ two stones.  Every three feet a torch lights up the corridor and the light
 makes you feel safe.  The wide tunnel turns a perfect right angle here, going
 west and south.  Perfect walls block your path to the north and east.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D2
 The wide hallway continues.
 ~
@@ -1231,7 +1231,7 @@ A dwarven nobles' home~
 from the rich decoration of the walls, the larger than average bed and the
 large ironbound chest in the corner.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 A portal leads to the living area.
 ~
@@ -1248,7 +1248,7 @@ general vocabulary of the dwarves.  Since it isn't, they simply refer to it as
 'the ministers house'.  A portal leads to the sleeping room to the west, while a
 wooden door leads back south.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D2
 A wooden door leads out into the corridors.
 ~
@@ -1268,7 +1268,7 @@ seems the small door to the east only blocks the worst of the wind, not the
 dust or the insects.  You don't see anything of value, but at least you are out
 of the terrible draft from the tunnel outside.    
 ~
-236 73 0 0 0 0
+236 73 0 0 0 1
 D1
 A small door leads out into the drafty tunnel.
 ~
@@ -1286,7 +1286,7 @@ only the dwarves can make them, and a strong wind pushes at you from the north.
 In the west wall a small wooden door leads to what you guess must be the
 dwarves' best suggestion of a tool shed.    
 ~
-236 265 0 0 0 0
+236 265 0 0 0 1
 D0
 You might be able to fight the wind, and move further north into the tunnel.
 ~
@@ -1316,7 +1316,7 @@ court, waiting to be inspected by the kings' watch.  To your east a large white
 marble block serves as a gate and to the east a just as large black granite
 slap serves the same purpose.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 You see the guards' barracks.
 ~
@@ -1349,7 +1349,7 @@ curtain.  The line of beds along the west wall and the small boxes set in front
 bears witness of strong disciplin.  This is a place for the best of the
 fighters among the dwarves - The kings' guard.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The barracks continue.
 ~
@@ -1369,7 +1369,7 @@ curtain.  The line of beds along the west wall and the small boxes set in front
 bears witness of strong disciplin.  This is a place for the best of the
 fighters among the dwarves - The kings' guard.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D2
 The barracks continue.
 ~
@@ -1384,7 +1384,7 @@ curtain.  The line of beds along the west wall and the small boxes set in front
 bears witness of strong disciplin.  This is a place for the best of the
 fighters among the dwarves - The kings' guard.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The checkpoint before the court is here.
 ~
@@ -1404,7 +1404,7 @@ curtain.  The line of beds along the west wall and the small boxes set in front
 bears witness of strong disciplin.  This is a place for the best of the
 fighters among the dwarves - The kings' guard.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The barracks continue.
 ~
@@ -1419,7 +1419,7 @@ it turn aside, you realise quickly that the door can be sealed airtight by
 removing the spells from the slab To your west a brightly lit corridor with
 intricant decoration leads towards the throne room.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 A large granite slab, black as night, blocks your path.  It seems to be
 hovering just barely of the ground, making it easy to turn aside.    
@@ -1439,7 +1439,7 @@ of here the corridor continues, but to the north a very nicely decorated wall
 blacks you path.  The door to your west is ajar, and through it you can see the
 sleeping room of the royal dwarven family.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 The intricantly decorated corridor leads toward the dwarven city.
 ~
@@ -1462,7 +1462,7 @@ Royal sleeping room~
 by s couple of very large beds.  This obviously is where the royal family
 sleep, when they sleep.  A wooden door leads back east.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 A wooden door leads east.
 ~
@@ -1476,7 +1476,7 @@ wooden and very nice door leads to the ministery of trade, the most important
 part of the dwarven kingdom.  To your east a portal open up to the shrine of
 Welcor, the dwarven deity.  South you spot the throne room.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The corridor continues.
 ~
@@ -1505,7 +1505,7 @@ funrniture is mansized, enabling both parts to sit back and relax when the
 important trade regulations are being discussed.  Currently, though no great
 discussion is taking place and nothing of much interest can be found here.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D1
 A wooden door leads beack to the corridor.
 ~
@@ -1521,7 +1521,7 @@ the colours seem to shift a bit, as if the stone were made from suspended
 flames.  In front of a the altar a silver chain shows just how near you're
 supposed to go.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D3
 A portal leads back to the royal court.
 ~
@@ -1550,7 +1550,7 @@ about the height if your chest.  You realise the throne has the obvious
 consequence that everyone has to look up, and consequently feel very small,
 when adressing the king.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D0
 The court continues.
 ~
@@ -1575,7 +1575,7 @@ Gemstones of different fashion, different kinds.  The loot is so large you
 can't grasp it all, ad decide to concentrate on the nearest corner to get an
 overview.  This is what you think can be translated into real money later.    
 ~
-236 8 0 0 0 0
+236 8 0 0 0 1
 D3
 The throne room is just outthere.
 ~
@@ -1590,7 +1590,7 @@ to the south you can barely make out the light from the torches within the
 dwarven city.  A strong draft tries to push you deeper into the tunnel,
 pressing on from the north.    
 ~
-236 265 0 0 0 0
+236 265 0 0 0 1
 D0
 North of here, the tunnel ends and you are under open sky.
 ~
@@ -1630,7 +1630,7 @@ past you into the mine.  Always when one goes down, another goes up, past you.
 You stare downwards, hoping to make out some sort of bottom below you.  You
 have no such luck.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D4
 A ladder stretches upwards toward the dwarven city..
 ~
@@ -1649,7 +1649,7 @@ see nothing but darkness, and looking down, nothing more can be seen.  It seems
 the ladders aren't so used anymore, since the baskets that are lowered into the
 mine can carry more than just gold and rocks.    
 ~
-236 841 0 0 0 0
+236 841 0 0 0 5
 D4
 The seemingly endless ladder continues.
 ~
@@ -1671,7 +1671,7 @@ certain there is a long walk to get to the top of this ladder.  But a very
 brief fall to the bottom.  Baskets pass you by sometimes, some with metals,
 others with people in them.    
 ~
-236 841 0 0 0 0
+236 841 0 0 0 5
 D4
 The seemingly endless ladder leads up into the unknown.
 ~
@@ -1692,7 +1692,7 @@ can't avoid when mining after precious metals.  A ragged opening in the
 northern wall leads into the darkness of the mines.  An extremely large basket
 is hanging from a rope through the opening in the ceiling.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D0
 The mine continues.
 ~
@@ -1719,7 +1719,7 @@ you'd die if you fell in.  A small shelf along the east wall lets you walk
 past it, but walk carefully.  The slightest slip would cost you your life.  
 You may also go south from here.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D0
 You may be able to cross the pit to the north by walking along the eastern
 wall.  But be careful - a fall into the darkness would surely kill you.    
@@ -1739,7 +1739,7 @@ deep pit.  You walk very close to the east wall, to avoid tripping and falling
 into the pit.  While you can't see the bottom of the pit you are certain that
 certain death awaits you in the depths.  The ledge continues north and south.
 ~
-236 265 0 0 0 0
+236 265 0 0 0 5
 D0
 A mine tunnel has been dug into the side of the pit wall. You may enter it here.
 ~
@@ -1765,7 +1765,7 @@ as you can see, the dwarves has struck another vein of ore, leading east from
 here.  The original tunnel continues north and south from here, while a side
 tunnel branches off, following the new vein eastwards.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D0
 The mine tunnel continues.
 ~
@@ -1790,7 +1790,7 @@ bracers made from solid oak.  The face of the rock bears the markings of many a
 pick, and the mine continues northward, following the vein deeper into the
 mountain.  You may go south too, but tread carefully.    
 ~
-236 265 0 0 0 0
+236 265 0 0 0 5
 D0
 The mine tunnel continues.
 ~
@@ -1809,7 +1809,7 @@ vertical stripe at about chest height.  Various mining tools and drills suggest
 you've just arrived at a bad time, seeing no one mining the ore.  The tunnel
 continues south from here.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D2
 The mine tunnel continues.
 ~
@@ -1823,7 +1823,7 @@ Also it twists and turns to follow the ore vein.  The reddish-brown and silvery
 white color on the walls suggest an ore with both titanium and iron.  The
 tunnel continue south and west from here you see the main tunnel.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D2
 The side tunnel leads into total darkness.
 ~
@@ -1842,7 +1842,7 @@ tunnel is unsupported and you feel a little unsafe, considering the chance of a
 cave-in.  All over the mine floor large rocksa have been left where they fell,
 and you feel moreare about to fall down.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D0
 The side tunnel leads towards the main mine tunnel here.
 ~
@@ -1869,7 +1869,7 @@ bell has been connected to the small pile of ore that's stacked here.  You
 immidiately realize that as soon as you touch the pile, the miners will be on
 your neck.  The tunnel leads north from here.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D0
 The tunnel leads north from here.
 ~
@@ -1883,7 +1883,7 @@ you saw at the armourers stall in the trade halls.  The ore is so fine you can
 actually see the glimmer of iron, not just the reddish lump you see everywhere
 else.  The tunnel leads west from here.    
 ~
-236 9 0 0 0 0
+236 9 0 0 0 5
 D3
 The tunnel leads west from here.
 ~
@@ -1913,7 +1913,7 @@ smashing your skull. Your body continues to fall, for several minutes,
 hitting the sides of the pit, until it is reduced to a bloody pulp,
 bearing no resemblance to a person.
 ~
-236 196 0 0 0 0
+236 196 0 0 0 5
 S
 T 23617
 #23685
@@ -1922,7 +1922,7 @@ At the end of the tunnel~
 have nowhere to go except back through the tunnel.  The only other option is to
 jump...    
 ~
-236 64 0 0 0 0
+236 64 0 0 0 5
 D2
 A small tunnel opens up in the side of the mountain.  The walls are perfectly
 smooth and a strong draft at the entrance makes you onder where it all goes.  

--- a/lib/world/wld/237.wld
+++ b/lib/world/wld/237.wld
@@ -8,7 +8,7 @@ is needed.  The dwarves are interested in trade, and without roads there will
 be no trade.  The road continues southward, while north of here you see a cave
 opening.    
 ~
-237 0 0 0 0 0
+237 0 0 0 0 5
 D0
 ~
 ~
@@ -51,7 +51,7 @@ drop leads into certain death.  The road is quite wide and heavily used by
 carridges, soldiers and the occasional road worker.  North from here you see
 some sort of opening in the mountain.    
 ~
-237 0 0 0 0 0
+237 0 0 0 0 5
 D0
 ~
 ~
@@ -70,7 +70,7 @@ keeps you from going that way.  However a set of steps has been hacked into the
 stone of the boulder to the south, allowing you to get to the small wooden
 building on top of it.    
 ~
-237 0 0 0 0 0
+237 0 0 0 0 5
 D0
 ~
 ~
@@ -93,7 +93,7 @@ you see the reason for going so near the edge; A colossal rock has once tumbled
 down the mountain, and hit the road where it lay once - close to the side of
 the mountain.    
 ~
-237 0 0 0 0 0
+237 0 0 0 0 5
 D1
 ~
 ~
@@ -110,7 +110,7 @@ dropped where the road once were.  This part of the road has been made around
 it, and is therefore a little narrower.  This also means you are walking
 dangerously close to the edge of a cliff, several hundred feet high.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D0
 ~
 ~
@@ -130,7 +130,7 @@ enourmous boulder, about the size of a house which totally blocks the road
 where it once were, near the side of the cliff.  The road continues north and
 east around the boulder.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D0
 ~
 ~
@@ -151,7 +151,7 @@ of the boulder you can see a small wooden building, which seem to house some
 kind of lookout post.  The rockface to both north and east is smooth, and
 cannot be climbed here, though.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D2
 ~
 ~
@@ -215,7 +215,7 @@ eastern cliffwall, some logs have been fastened with boards and a thick rope
 leads northward from here.  You hope noone pulls the rope while you're standing
 here.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D0
 ~
 ~
@@ -237,7 +237,7 @@ rockslide onto YOU!  And you can't even escape westwards, without falling a
 hundred feet to the valley below.  You'd better move on, north ar south from
 here.  
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D0
 ~
 ~
@@ -255,7 +255,7 @@ smooth rock wall blocks any access, while west the road stops at the edge of
 the shelf along the mountain, letting you fall several hundred feet to the
 bottom, should you go outthere.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D0
 ~
 ~
@@ -274,7 +274,7 @@ the shelf along the mountain, letting you fall several hundred feet to the
 bottom, should you go outthere.  South of here a promontory from the main
 mountain makes the road turn.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D0
 ~
 ~
@@ -292,7 +292,7 @@ you step one step off the ledge south or west of here.  This also means that
 you can go into the foothills of the promontory, by leaving east or continue
 into the mountains by going north.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D0
 ~
 ~
@@ -312,7 +312,7 @@ You figure you must be high indeed as you know the distance to be nearly a days
 travel.  The well-tended road is impossible close to the edge here, and you
 watch your step carefully, so as to not fall from the ledge.  
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D1
 ~
 ~
@@ -332,7 +332,7 @@ east from here.  All thoughts of leaving the path are forgotten as you look
 over the southern edge into a deep valley and north a blank rock wall blocks
 your progress.  The road is obviously the only way ahead.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D1
 ~
 ~
@@ -351,7 +351,7 @@ a landslide.  Though the way looks unstable and dangerous, it should still be
 passable.  The road itself has been seen to recently, and not a single stone is
 out of place.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 5
 D1
 ~
 ~
@@ -373,7 +373,7 @@ north.  The road is well-tended, not a single bit of grass peeks out from the
 cracks.  The road leads north and south here, and being the only interesting
 thing around here, you decide to stick to it.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 4
 D0
 ~
 ~
@@ -393,7 +393,7 @@ long ago learned to be meticulous about their work, making a name in the stone
 and steel business.  You decide to stay on the north and south leading road,
 while watching the scenery around from a distance.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 4
 D0
 ~
 ~
@@ -411,7 +411,7 @@ road is rising slightly towards the north, heading into the mountain range you
 can see to your far north.  The road leaves no doubt about its origin, made
 from granite, and tended beyond belief, it's a masterpiece in itself.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 4
 D0
 ~
 ~
@@ -430,7 +430,7 @@ south it continues over a hill toward the eastern highway.  The road itself is
 an exhibition of engineering in itself.  Totally smooth, and perfectly
 straight.  Just what any dwarf would want to show off with.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 4
 D0
 ~
 ~
@@ -449,7 +449,7 @@ the T-crossing where the trade route meets the Highway.  The granite road feels
 comfortably smooth to walk on, so you are certain the hills to your north are
 easily crossed with this kind of foundation.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 4
 D0
 ~
 ~
@@ -468,7 +468,7 @@ southward, across the plains.  The grasslands around you are unsafe, as several
 places quicksand is hidden under a thin layer of grass.  After a short
 consideration you decide to stay on the road.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 2
 D0
 ~
 ~
@@ -489,7 +489,7 @@ the dwarves and the capital Aldin.  The occasional trader comes here, and some
 hide a smile as they see your amazement.  South of here the man-made eastern
 highway leads towards a city.    
 ~
-237 32768 0 0 0 0
+237 32768 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/238.wld
+++ b/lib/world/wld/238.wld
@@ -51,7 +51,7 @@ busted up crystal making it imposable to walk on the bottom of the lake.  Also
 algae floats towards the top of the lake making it hard to see up from the
 bottom of the lake.    
 ~
-238 64 0 0 0 0
+238 64 0 0 0 6
 D0
    Looking north is nothing but water.    
 ~
@@ -78,7 +78,7 @@ busted up crystal making it imposable to walk on the bottom of the lake.  Also
 algae floats towards the top of the lake making it hard to see up from the
 bottom of the lake.    
 ~
-238 32768 0 0 0 0
+238 32768 0 0 0 6
 D0
 Looking north nothing but fog can be seen
 ~
@@ -166,7 +166,7 @@ busted up crystal making it imposable to walk on the bottom of the lake.  Also
 algae floats towards the top of the lake making it hard to see up from the
 bottom of the lake.    
 ~
-238 64 0 0 0 0
+238 64 0 0 0 6
 D0
 Upon looking north you see nothing but tons of water.    
 ~
@@ -197,7 +197,7 @@ busted up crystal making it imposable to walk on the bottom of the lake.  Also
 algae floats towards the top of the lake making it hard to see up from the
 bottom of the lake.    
 ~
-238 32768 0 0 0 0
+238 32768 0 0 0 6
 D0
 Fog and mist can be seen in the distance.    
 ~
@@ -1191,7 +1191,7 @@ There are small trees scattered about below and a massive lake just south.
 You can see small fish swimming in the lake below.  As you look back you notice
 that you can go up into a cubby hole which is very large.    
 ~
-238 4 0 0 0 0
+238 4 0 0 0 4
 D0
 Looking north reveals the main floor entrance.
 ~
@@ -1419,7 +1419,7 @@ fact that you cannot walk you you have to fly.  There are birds and clouds
 drifting about in the distance.  The only thing you can see is clouds and the
 blue sky above.    
 ~
-238 0 0 0 0 0
+238 0 0 0 0 8
 D0
 Looking north you see what looks like what could be nearing the end of the hallway.
 ~

--- a/lib/world/wld/239.wld
+++ b/lib/world/wld/239.wld
@@ -78,7 +78,7 @@ and heat.  To the west can be seen some kragla birds waiting for something to
 die so that they may finally have a meal.  Eastward dunes of sand expand as far
 as the eye can see.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 2
 D1
    Sands of the Southern Desert
 ~
@@ -112,7 +112,7 @@ south the slopes rise gently to the Southern Mountains.  North is the beginning
 of the desert sands.  Westward and eastward are more hills all converging to
 the foot of the Southern Mountains.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 4
 D0
 Rutted path
 ~
@@ -152,7 +152,7 @@ those which are trodded here.  Climbing these slopes is tedious and tiring on
 the body, mind and soul.  Many adventurers have lost hope here of finding the
 path to the city of NewHaven.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 4
 D3
 Rutted Path
 ~
@@ -176,7 +176,7 @@ penetrates to ones bowels.  To the west and east are more hills.  The Great
 Southern Desert is to the north.  You can see the peaks of the Southern
 Mountains high up in the wispy clouds to the south.    
 ~
-239 64 0 0 0 0
+239 64 0 0 0 4
 D0
 ~
 ~
@@ -200,7 +200,7 @@ fatigue generating slopes that tear at the muscles in ones legs.  Some
 scorpions crawl under the rocks to seek shade and prey on the other denizens of
 the desert that hide there.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 4
 D0
 Rutted Path
 ~
@@ -240,7 +240,7 @@ foreboding Southern Desert.  To the south the hills become peaks of the Southern
 Mountains.  To the east and west are endless jagged hills and ravines of broken
 slate.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D0
 Slated Gorge
 ~
@@ -294,7 +294,7 @@ path leads down from the hills of the Southern Mountains to the north towards
 the Southern Desert.  It appears as if this faint trail may turn into a path
 that actually goes someplace.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D0
 Jutted Path Origin
 ~
@@ -312,7 +312,7 @@ Entrance to a Cave~
 The opening is slightly obscured but there is just enough room that someone
 might be able to squeeze thru to see what is inside if they dared.    
 ~
-239 12 0 0 0 0
+239 12 0 0 0 5
 D2
 To inside the cave
 ~
@@ -331,7 +331,7 @@ Hopefully, no big and scary ones have decided to live here.  Perhaps they may
 be coming back soon and kicking out intruders or eating them for lunch.  There
 is an entrance to the north and south.    
 ~
-239 9 0 0 0 0
+239 9 0 0 0 5
 D0
 Way to the entrance
 ~
@@ -367,7 +367,7 @@ west, while to the south can be seen the hills and summits, marking the beginnin
 of the Southern Mountains.  One can continue their travels to the east and west
 where the dunes are far enough apart to provide a path.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 2
 D1
    A pathless pile of sand to more desert
 ~
@@ -387,7 +387,7 @@ drying their skin in this miserable heat.  Rolling hills of sand surround the
 area.  Impassable hills of slate are to the north and south.  East and west are
 more dunes of sand.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 2
 D1
 Sands of the Southern Desert
 ~
@@ -415,7 +415,7 @@ on this path so some spots are cluttered with boulders of granite partially
 blocking it and other parts have wind hewn ruts that look like they were cut by
 some insane sculptor who was mad at the world.    
 ~
-239 4 0 0 0 0
+239 4 0 0 0 5
 D0
 Exit to lower end of the path.
 ~
@@ -436,7 +436,7 @@ it travels further along the Southern Mountains.  Upwards you can barely make ou
 some sort of ledge.  Slightly upward and to the west is a narrow crumbling path
 that looks too risky to attempt to traverse.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D0
 A steep boulder strewn path up the Southern Mountains.
 ~
@@ -463,7 +463,7 @@ every now and then there is some movement in the shifting dunes of sand.
 Barely visible, the peak of the mountain, which is still quite a way upward
 from here, is crowned by a few wisps of clouds.    
 ~
-239 196 0 0 0 0
+239 196 0 0 0 5
 D5
 Steep decline to the turn in the path
 ~
@@ -479,7 +479,7 @@ white, orange, brown and red.  The narrow ledge crumbles and every now and then
 rocks tumble down the sheer side so far that no one could hear the sound of
 their crash at the base of the towering peak.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D1
 Narrow ledge to the turn in the path.
 ~
@@ -499,7 +499,7 @@ howling around with a frost biting chill.  Here rises a purple granite side of
 the peak, which no one has bothered to name, perhaps they will name it after an
 adventurer, should they fall and die here.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D4
    Climb to the path around the ridge.    
 ~
@@ -519,7 +519,7 @@ below surrounded by dense woods to the south.  To the west you can make out a
 few roads going thru the woods and to the east the trail continues with the
 mountain base blocking the view directly below.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D1
    To a deep drift of snow.    
 ~
@@ -541,7 +541,7 @@ starts again a ways off to the east near a huge tree.  Below is the sheer side
 of the mountain and cannot be traversed.  To the north is the peak of the
 mountain which looks just as omnimous here as it did far below.    
 ~
-239 4 0 0 0 0
+239 4 0 0 0 5
 D3
    A winding trail around the peak.    
 ~
@@ -671,7 +671,7 @@ the side of the mountain.  To the west is a pile of rubble consisting of hides,
 tree trunks, bones of small animals and rocks.  East the trail continues down
 the path.    
 ~
-239 265 0 0 0 0
+239 265 0 0 0 4
 D0
 Path to a Small Cave
 ~
@@ -700,7 +700,7 @@ east-west direction.  To the west there is a short path which turns north into
 a huge pile of rubble.  To the east the path slopes downward towards a large
 pine tree.    
 ~
-239 265 0 0 0 0
+239 265 0 0 0 4
 D1
    Path to ponderosa pine
 ~
@@ -727,7 +727,7 @@ needled limbs sway gently in the breeze far far above.  To the west is a clay
 path with many footprints in it.  To the south a wooden plank path meanders
 down the slope.    
 ~
-239 129 0 0 0 0
+239 129 0 0 0 5
 D2
    Path to below the tree
 ~
@@ -781,7 +781,7 @@ dirty black fireplace in the center of the room.  Around the walls are slits in
 the sides that someone could look out of.  Leading up and down the tree are
 small footholds someone has used to climb the tree.    
 ~
-239 12 0 0 0 0
+239 12 0 0 0 5
 D4
    Ladder from outpost to up in a tree.    
 ~
@@ -824,7 +824,7 @@ ages ago but the branches still grow and are teeming with small animals of all
 types.  There is a sturdy ladder going up and down the tree trunk.  Another
 branch goes from the trunk of the tree to the east.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D1
    From up in a branch to out on a limb.    
 ~
@@ -1067,7 +1067,7 @@ been woven with magical spells of travelling, like they were in the days of
 old.  North the path continues up the trail towards the mountain peak.  Down
 the gently winding road makes it's way to the foothills of the mountains.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 4
 D0
 The path turns gently northward, to a giant ponderosa pine tree.    
 ~
@@ -1095,7 +1095,7 @@ all around the old and decaying ones as nature regenerates itself.  Up there is
 a turn in the path.  West the path slowly dwindles into a lightly wooded area.
   
 ~
-239 0 0 0 0 0
+239 0 0 0 0 5
 D3
    The path slopes downward into some rolling hills and forests.    
 ~
@@ -1123,7 +1123,7 @@ and an occasional deer can be seen grazing on the new grass and bark they can
 find as they forage for food.  East the path seems to widen and is paved with
 brick.  West the trial winds thru the foothills.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 4
 D1
    The path winds upward thru some light forests and hills.    
 ~
@@ -1145,7 +1145,7 @@ important or do they have enough supplies for their journey.  East the path
 continues to climb thru some light woods.  South the path disappears into the
 sands of the desert.    
 ~
-239 0 0 0 0 0
+239 0 0 0 0 4
 D1
    The path continues east thru some hills.    
 ~
@@ -1162,7 +1162,7 @@ chasm.  Periodically a loose rock or boulder dislodges from the side of the
 chasm and crashes below on the sides of the chasm walls resounding for a few
 minutes then no sounds can be heard as it's course takes it from the sides.  
 ~
-239 269 0 0 0 0
+239 269 0 0 0 4
 D0
    Path along the chasm.    
 ~
@@ -1182,7 +1182,7 @@ are growing stronger with each level lower.  There is a thin yellow powder on
 the path, probably condensation of the fumes upon its surface.  The path heads
 deeper into the chasm to the north and climbs up the chasm to the south.    
 ~
-239 265 0 0 0 0
+239 265 0 0 0 5
 D0
    Path along the chasm.    
 ~
@@ -1202,7 +1202,7 @@ the wall of the chasm to the west.  The sides of the chasm seem to glow with a
 soft yellow glow, providing a dull light to see the trail.  To the south the
 path slopes upward and gradually climbs the chasm.    
 ~
-239 268 0 0 0 0
+239 268 0 0 0 5
 D1
    Path to a travelers resting spot.    
 ~
@@ -1248,7 +1248,7 @@ hollowed out cubby holes with places for lanterns, but they are unnecessary
 because of the glow of the walls.  The combination of colors is nauseating and
 the smell here doesn't help.    
 ~
-239 392 0 0 0 0
+239 392 0 0 0 4
 D0
 Path to the entrance of the cave.
 ~
@@ -1490,7 +1490,7 @@ upwards to the west.  There is a fine glowing powder lighting the path with a
 eerie orange-red glow here.  A strong sulfuric smell drifts up from the chasm
 below.    
 ~
-239 12 0 0 0 0
+239 12 0 0 0 4
 D1
    Decending path into the chasm.    
 ~
@@ -1517,7 +1517,7 @@ their endless flight through the depths below.  To the west the path ascends
 with a dull red glow of mineral deposits from the fumes.  To the east is a
 gradual slope deeper into the chasm.    
 ~
-239 264 0 0 0 0
+239 264 0 0 0 4
 D1
    Path descending deeper into the chasm.    
 ~
@@ -1537,7 +1537,7 @@ favorite mineral, obsidian.  The path has a dull red glow from some powder
 caked along the chasm walls.  To the west the path ascends along the side of
 the chasm, lit with the scarlet glow.    
 ~
-239 264 0 0 0 0
+239 264 0 0 0 4
 D2
    An obsidian gate 8 metrons high, 4 metrons wide carved with drow runes.  
 There is a red rune in the center of the door which might be a keyhole.    
@@ -1568,7 +1568,7 @@ covered with bricks of shiny black obsidian.  The floor is covered with red
 glowing runes of drow origin and light the path.  There is a huge gate to the
 north.  The cave continues on to the south.    
 ~
-239 140 0 0 0 0
+239 140 0 0 0 4
 D0
    A huge obsidian door carved with drow runes.  The door is about 8 metrons
 high and there is a red rune in the center for a key.    
@@ -1594,7 +1594,7 @@ footprints going in all directions on the passage floor.  There is a soft light
 coming from the north end of the passage and darkness to the east.  Strange
 faint sounds of patting feet can be heard echoing from the darkness.    
 ~
-239 268 0 0 0 0
+239 268 0 0 0 2
 D0
 Towards a red glow in the passage.    
 ~
@@ -1674,7 +1674,7 @@ all around.  The walls are a conglomerate of adamite and obsidian rock and an
 evil force seems to raditate from them.  The floor has been hewn smooth by
 someone and seems to have no signs of wear.    
 ~
-239 265 0 0 0 0
+239 265 0 0 0 4
 D0
 A dark stale cave.
 ~
@@ -1695,7 +1695,7 @@ caverns, niches, slopes.  The floor is smooth here but the walls are sharp to
 the touch with shards of obsidian, adamite protruding from it.  Soft pattering
 sounds can be heard echoing off the walls from all around.    
 ~
-239 265 0 0 0 0
+239 265 0 0 0 4
 D0
 To another part of the cave.
 ~
@@ -1741,7 +1741,7 @@ towards the south but inside the the hallway there are no sounds.  The sounds
 and light seem to be absorbed by the mysterious stone the walls, ceiling, and
 floor are made of.    
 ~
-239 397 0 0 0 0
+239 397 0 0 0 4
 D0
 ~
 door~
@@ -2084,7 +2084,7 @@ radiate from the central chamber within the zone.  One can barely make out
 another chamber directly in the center which is suspended in space by the
 thousands of strands of spiderweb supporting it.    
 ~
-239 137 0 0 0 0
+239 137 0 0 0 5
 D4
 ~
 ~

--- a/lib/world/wld/240.wld
+++ b/lib/world/wld/240.wld
@@ -5,7 +5,7 @@ insignificant you must look.  Minotaurs walk past, most several feet taller
 than you.  The guards here seem to be looking for an excuse to kill something,
 or someone.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -43,7 +43,7 @@ which can accommodate their extended families.  They tend to get on well with
 anyone displaying similar qualities to their own.  You hope they will get along
 with you.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -59,7 +59,7 @@ Zyanya Way~
 feet tall.  Stories of minotaurs killing humans for sport abound.  But they
 were all just stories, right?    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -80,7 +80,7 @@ of the way of the minotaurs.  Their bodies are covered in a short dark fur.
 Minotaurs are not considered one of the smarter races, and tend be viewed as a
 race of bullies.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -96,7 +96,7 @@ Zyanya Way~
 tall, and weigh in excess of 400 pounds.  You follow a small street along the
 southern wall.  To the north you see a large structure.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -117,7 +117,7 @@ the stories well.  Generally sturdy, large and strong folk, they are mostly
 hard-working, assertive and uncompromising to the point of stubbornness, which
 can manifest as belligerence, boastful pride and a hot temper.
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -142,7 +142,7 @@ which can accommodate their extended families.  They tend to get on well with
 anyone displaying similar qualities to their own.  You hope they will get along
 with you.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -158,7 +158,7 @@ Zyanya Way~
 Human in body, these creatures have the heads of bulls, making them not very
 well suited towards beautypageants.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -174,7 +174,7 @@ Zyanya Way~
 enraged and wreak havoc if provoked.  You remind yourself to be very careful
 around these juggernauts.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -190,7 +190,7 @@ Zyanaya Way~
 provides quite a bit of warmth.  They trample past you with a certain
 determination that makes you feel uneasy.  They all look so...  Confident.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -207,7 +207,7 @@ race because of how they value strength.  This makes them very seclusive.
 Very rarely will a minotaur ever bee seen outside of the city.  Unless they are
 on a mission.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -223,7 +223,7 @@ Minotaur Home~
 in the middle of the room without any chairs.  This must be where the minotaurs
 come to sleep and eat.  They must live a very mundane and dull life.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -245,7 +245,7 @@ finest weapons in the realm are made.  A huge minotaur with arms larger than
 your waist hammers away at some yet to be recognizable hunk of metal.  Many
 items lay about you, ready for sale
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -258,7 +258,7 @@ in the middle of the room and bunks line all the walls.  They have no need for
 luxuries.  A large family must live in this house.  A small staircase winds its
 way to the second floor.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -280,7 +280,7 @@ intelligence.  They believe that the weak should perish and that might proves
 right.  It is to them, the natural process of life.  The street continues north
 and south.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -296,7 +296,7 @@ Training Grounds~
 showed no mercy to their fallen adversaries, often stampeding over the dead and
 dying bodies to pursue a new enemy.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -312,7 +312,7 @@ Training Grounds~
 fight to the death regardless of the circumstances.  Several minotaurs are here
 sparring with their deadly look axes and pole arms.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -333,7 +333,7 @@ with the head of a bull and the body of a human male.  Minotaurs revere
 physical strength above all else, and they believe that the strong should
 naturally rule the weak.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -349,7 +349,7 @@ Wasatch Lane~
 seems to be very chaotic and barbaric.  But, this is not the case.  They just
 have a very different way of approaching law enforcement and society.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -365,7 +365,7 @@ Whits Lane~
 one specifically.  Minotaurs believe themselves to be the "Master Race.  " They
 believe the gods chose them to control the weak and dishonorable.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -382,7 +382,7 @@ fearlessly charge headlong into their foes, seeking to spill entrails with
 their devastating horns.  This power makes Minotaurs respected and revered
 fighters throughout all of the realm.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -398,7 +398,7 @@ Market Street~
 Though crude and utilitarian.  Inhabited solely by minotaurs, it is ruled by
 Zarn, the minotaur Grand Master.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -419,7 +419,7 @@ They are ruthless, harsh, and stubborn, but they can be surprisingly
 intelligent.  As you enter the marketplace, you realize they are a society just
 like any other.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -440,7 +440,7 @@ marketplace.  You remember more of the minotuar history.  They are intensely
 proud creatures, half-human and half-cow, "bovine" is just about the worst
 insult anyone can hurl at a minotaur
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -465,7 +465,7 @@ their various fighting styles.  You could probably learn a thing or two by
 watching.  Because of their legendary stamina and massive builds most Minotaurs
 pursue a life of military service.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -491,7 +491,7 @@ a time with very little rest.  Though they are not among the smartest of races,
 they are regarded for their warrior skills and even the novice adventurer knows
 better then to get on the wrong side of a Minotaur.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -515,7 +515,7 @@ Training Grounds~
 They mostly keep to themselves because of their superior beliefs except during
 war.  If you ever had to go to war, this would be who you want as any ally.  
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -536,7 +536,7 @@ direct solutions to problems.  The majority of Minotaurs despise laziness and
 injustice.  You wonder exactly at what their definition of laziness and
 injustice would be.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -553,7 +553,7 @@ the stories of the minotaur way of life.  The family is the blood of the
 culture.  Without a family a Minotaur has no source for nobility, honor, or
 pride.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -569,7 +569,7 @@ Specialty Shop~
 You have heard stories of some people being able to get these items through
 other hands, but no minotaur ever gives up these special items willingly.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -582,7 +582,7 @@ but something disturbs you.  A staircase leads up.  The street is to the north.
 A large rug covers most of the floor here.  It is the first luxury you have
 seen in any minotuar home.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -612,7 +612,7 @@ lean against the walls, are stacked on the floor, and are even hanging from the
 ceiling.  You wonder what kinds of things might be for sale to you.  Most
 minotaurs only trade with their own kind.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -625,7 +625,7 @@ Maura.  Their minds and bodies are powerful, and they radiate auras of command
 and authority.  No one in their right mind comes to this city with evil
 intentions.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -643,7 +643,7 @@ minotaurs ivory-coloured horns reach up to two feet in length.  They adorn
 thier horns with gold rings which represent the number of combats won in the
 Arena.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -660,7 +660,7 @@ strong beating in battle.  Due to their nature, they are disliked by many other
 races but are tolerated because of their fierce warlike attitudes.  Minotaurs
 make superb warriors.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -681,7 +681,7 @@ They are stronger than any other race, and almost as durable as the dwarves.
 Minotaurs are very versatile.  They prefer to be what they were born to be: a
 Warrior!    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -698,7 +698,7 @@ likes of the "higher", "civilized" species.  They are a very brusque and direct
 people and don't particularly enjoy the likes of those races that rely on
 diplomacy and subterfuge to exist.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -714,7 +714,7 @@ The Western Gate of Dun Maura~
 to allow travel between the city of the centaurs and the Capital.  The
 wilderness beyond these gate is wild and untamed.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -727,7 +727,7 @@ you have heads that are shaped like that of a bull and their bodies are covered
 with fur and their feet are cleft hooves.  They have horns that grow 3-24
 inches.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -752,7 +752,7 @@ Maura.  Their minds and bodies are powerful, and they radiate auras of command
 and authority.  No one in their right mind comes to this city with evil
 intentions.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -768,7 +768,7 @@ VaQuero Road~
 important minotaurs must reside there.  It must be where the city is run from.
 To the south a small stone building is heavily guarded.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -792,7 +792,7 @@ VaQuero Road~
 tall humanoids with the horned head of a bull, minotaurs have fur all over
 their bodies, ranging in colour from red to brown and even black.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -809,7 +809,7 @@ seem like this city is overflowing, you wonder how so many can live in such a
 small city.  They seem oblivious to your presence, you are not sure if that is
 good or bad.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -835,7 +835,7 @@ minotaurs ivory-coloured horns reach up to two feet in length.  They adorn
 thier horns with gold rings which represent the number of combats won in the
 Arena.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -852,7 +852,7 @@ strong beating in battle.  Due to their nature, they are disliked by many other
 races but are tolerated because of their fierce warlike attitudes.  Minotaurs
 make superb warriors.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -869,7 +869,7 @@ They are stronger than any other race, and almost as durable as the dwarves.
 Minotaurs are very versatile.  They prefer to be what they were born to be: a
 Warrior!    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -886,7 +886,7 @@ you have heads that are shaped like that of a bull and their bodies are covered
 with fur and their feet are cleft hooves.  They have horns that grow 3-24
 inches.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -911,7 +911,7 @@ battles between the minotaurs and centaurs.  Some of the greatest fighters ever
 to clash in the great wars.  Now a temporary truce has stopped the war, but how
 long will it last?    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D3
 ~
 ~
@@ -924,7 +924,7 @@ race because of how they value strength.  This makes them very seclusive.
 Very rarely will a minotaur ever bee seen outside of the city.  Unless they are
 on a mission.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -940,7 +940,7 @@ Hall of Vardis~
 and strive to uphold justice in the name of the Glorious Vardis, their only
 god.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -956,7 +956,7 @@ Hall of Vardis~
 seems to be some kind of place of worship.  A large statue dominates the center
 of the room.  It must be the minotuars sole god.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -980,7 +980,7 @@ Hall of Vardis~
 Vardis.  Minotaurs possess good-natured dispositions and strive to uphold
 justice in the name of Glorious Vardis.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -996,7 +996,7 @@ Vassar Road~
 tall humanoids with the horned head of a bull, minotaurs have fur all over
 their bodies, ranging in colour from red to brown and even black.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1012,7 +1012,7 @@ Vorn Estate~
 cities economic stature and has supposedly been doing a great job for over 30
 years.  But, few minotaurs seem to respect him.  You wonder why.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1032,7 +1032,7 @@ Main Chamber~
 Skylights and windows are carved intricately into the walls.  This estate is a
 relief compared to the crude buildings in the rest of the city.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1052,7 +1052,7 @@ Waiting Room~
 upon.  The room is surprisingly empty.  Either Vorn runs a tight ship or the
 population must be scared of him.  The main chamber is to the west.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D3
 ~
 ~
@@ -1065,7 +1065,7 @@ cause dishonor to himself.  Minotaurs believe that "Might makes right.  " All
 legal cases are settled in the Arena.  The Arena is the heart of their culture.
   
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1081,7 +1081,7 @@ Whits Lane~
 cause dishonor to himself.  Minotaurs believe that "Might makes right.  " All
 legal cases are settled in the Arena.  The Arena is the heart of their culture.
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1097,7 +1097,7 @@ Hall of Vardis~
 Vardis.  Minotaurs possess good-natured dispositions and strive to uphold
 justice in the name of Glorious Vardis.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1114,7 +1114,7 @@ minotaurs has been known by many names.  The god of war, death, or justice.
 All minotaurs revere him and wait for his return to finally overthrow the
 centaurs to the east.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1144,7 +1144,7 @@ Hall of Vardis~
 and strive to uphold justice in the name of the Glorious Vardis, their only
 god.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -1161,7 +1161,7 @@ remember more of the minotuar history.  They are intensely proud creatures,
 half-human and half-cow, "bovine" is just about the worst insult anyone can
 hurl at a minotaur.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1182,7 +1182,7 @@ been persuaded by the ways of other races to live a more fertile and luxurious
 life.  This is frowned on by the society, but allowed by the Grand Master to
 allow for trade.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1206,7 +1206,7 @@ The Main Chamber~
 be to the west while Vorn himself should be in the audience chamber to the
 east.  This massive chamber continues north and south.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1231,7 +1231,7 @@ himself usually sits on top of a small platform at the back of the room to
 listen to anyone who has a reason to petition.  The room is lavishly decorated
 with curtains and a fine rug.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D3
 ~
 ~
@@ -1248,7 +1248,7 @@ the stories of the minotaur way of life.  The family is the blood of the
 culture.  Without a family a Minotaur has no source for nobility, honor, or
 pride.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1265,7 +1265,7 @@ likes of the "higher", "civilized" species.  They are a very brusque and direct
 towards people and don't particularly enjoy the likes of those races that rely
 on diplomacy and subterfuge to exist.  
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1281,7 +1281,7 @@ Zarn's Estate~
 city.  Everyone except the War Master answer to him and him alone.  Only in the
 time of war can his word be overran by the War Master.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1298,7 +1298,7 @@ is where the government, if you could call it that, of the minotaurs resides.
 Their is only one position.  The Grand Master.  He is the final say in all
 matters of the city.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1318,7 +1318,7 @@ Zarn's Estate~
 almost always accompanied by the War Master and a few advisors that help him
 make all the decisions for the city.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D3
 ~
 ~
@@ -1335,7 +1335,7 @@ intelligence.  They believe that the weak should perish and that might proves
 right.  It is to them, the natural process of life.  The street continues north
 and south.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1351,7 +1351,7 @@ Vorn Estate~
 They seem to have given up the normal minotaur life in order to pursue a more
 monetary lifestyle.  A spiral stairway leads up.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1371,7 +1371,7 @@ Vorn Estate~
 monetary system to keep the city healthy.  The occupants of this small estate
 must be in charge of all trade with the outsiders.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1391,7 +1391,7 @@ Vorn Estate~
 controls all trade with the other cities.  He is well known as a conniving
 salesman who always gets the best of any deal.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D3
 ~
 ~
@@ -1403,7 +1403,7 @@ Wasatch Lane~
 one specifically.  Minotaurs believe themselves to be the "Master Race.  " They
 believe the gods chose them to control the weak and dishonorable.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1428,7 +1428,7 @@ Zoa Way~
 enraged and wreak havoc if provoked.  You remind yourself to be very careful
 around these juggernauts.  The road continues west or south.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1444,7 +1444,7 @@ Zoa Way~
 Human in body, these creatures have the heads of bulls, making them not very
 well suited towards beautypageants.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1461,7 +1461,7 @@ which can accommodate their extended families.  They tend to get on well with
 anyone displaying similar qualities to their own.  You hope they will get along
 with you.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1478,7 +1478,7 @@ of the way of the minotaurs.  Their bodies are covered in a short dark fur.
 Minotaurs are not considered one of the smarter races, and tend be viewed as a
 race of bullies.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1495,7 +1495,7 @@ the stories well.  Generally sturdy, large and strong folk, they are mostly
 hard-working, assertive and uncompromising to the point of stubbornness, which
 can manifest as belligerence, boastful pride and a hot temper.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1520,7 +1520,7 @@ of the way of the minotaurs.  Their bodies are covered in a short dark fur.
 Minotaurs are not considered one of the smarter races, and tend be viewed as a
 race of bullies.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1536,7 +1536,7 @@ Zoa Way~
 provides quite a bit of warmth.  They trample past you with a certain
 determination that makes you feel uneasy.  They all look so...  Confident.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1552,7 +1552,7 @@ Zoa Way~
 seems to be very chaotic and barbaric.  But, this is not the case.  They just
 have a very different way of approaching law enforcement and society.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1572,7 +1572,7 @@ to prefer simple, direct solutions to problems.  The majority of Minotaurs
 despise laziness and injustice.  You wonder exactly what their definition of
 laziness and injustice would be.  
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -1588,7 +1588,7 @@ The Northern Gate of Dun Maura~
 breeze blows through the gate carrying with it the noise and smell of the
 forest.  A small path leads into the woods to the north.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D2
 ~
 ~
@@ -1600,7 +1600,7 @@ Bunk Room~
 other you wonder how anyone could live in such cramped quarters.  About a
 quarter of the population could probably live in this one house.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D5
 ~
 ~
@@ -1612,7 +1612,7 @@ Bunk Room~
 into the walls.  Three high, on right on top of the other.  At least 20
 minotaurs could probably sleep in here.  You see no personal items at all.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D5
 ~
 ~
@@ -1624,7 +1624,7 @@ Bunk Room~
 though.  Just bunks lining the walls giving the minotaurs somewhere to sleep.
 The night shift is snoring, asleep until thier next watch.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D5
 ~
 ~
@@ -1650,7 +1650,7 @@ Zarn's Hall~
 Where Zarn runs the city.  The hierarchy of minatours is simple.  Their God,
 the Grand Master, and finally the War Master.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1666,7 +1666,7 @@ Zarn's Hall~
 Where Zarn runs the city.  The hierarchy of minatours is simple.  Their God,
 the Grand Master, and finally the War Master.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D3
 ~
 ~
@@ -1683,7 +1683,7 @@ resides.  To the east and west are stairways leading down to the Hall of
 Vardis.  Several minotaurs are lounging around, awaiting an audience with Zarn.
   
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1703,7 +1703,7 @@ Advisors Room~
 Always withing shouting distance they help Zarn run the city.  To many Zarn is
 just a figurehead while the advisors are the real brains.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D1
 ~
 ~
@@ -1716,7 +1716,7 @@ light, and pillars to keep the ceiling from crashing down on your head.  In the
 center of the room is a pedestal where the grand master gives audience with his
 advisors.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1741,7 +1741,7 @@ almost as much as the war god himself.  The title War Master is the ultimate
 honor to be given to any minotaur.  It can only be given to a minotaur who has
 been a war hero and undefeated in the arena.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D3
 ~
 ~
@@ -1753,7 +1753,7 @@ Grand Masters Chamber~
 minotaurs even despise him because of this, but it was agreed that a figurehead
 is necessary in order to run the city and trade with the other races.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D0
 ~
 ~
@@ -1765,7 +1765,7 @@ A Bedroom~
 stone.  A large bed fills the room and even some small furniture is scattered
 haphazardly in the corners.    
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D5
 ~
 ~
@@ -1777,7 +1777,7 @@ Vorn's Chamber~
 known for thier honesty and word.  You wonder if it is possible for a minotaur
 to actually be evil.  If it is possible, Vorn would be a good place to start.
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D5
 ~
 ~
@@ -1789,7 +1789,7 @@ Guest Room~
 fit.  Many people of different races and from across the realm travel to this
 fabled city.  If they have the money Vorn is sure to swindle them out of it.  
 ~
-240 0 0 0 0 0
+240 0 0 0 0 1
 D5
 ~
 ~

--- a/lib/world/wld/242.wld
+++ b/lib/world/wld/242.wld
@@ -5,7 +5,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 It is far too high to climb. People are walking past you, hurrying to
 their destinations. To the north, you see the western bridge.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D1
 ~
 ~
@@ -139,7 +139,7 @@ Midgaard. People are bustling about, while street vendors are trying hard
 to sell hotdogs and other less legal merchandise. Streetlights can be
 seen along the road, and you also notice the odd tree.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -165,7 +165,7 @@ stone statue of a man stands here, surrounded by a ring of bushes and
 flowers. From all around you, you can hear the bustle of daily city life in 
 Midgaard. The central bridge is north, leading to the old part of Midgaard. 
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -206,7 +206,7 @@ Midgaard. People are bustling about, while street vendors are trying hard
 to sell hotdogs and other less legal merchandise. Streetlights can be
 seen along the road, and you also notice the odd tree.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -229,7 +229,7 @@ to sell hotdogs and other less legal merchandise. Streetlights can be
 seen along the road, and you also notice the odd tree. You can see the
 southern docks to the north.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -254,7 +254,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 It is far too high to climb. People are walking past you, hurrying to
 their destinations. To the north, you can see the southern docks.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -275,7 +275,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 It is far too high to climb. People are walking past you, hurrying to
 their destinations. 
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -297,7 +297,7 @@ Midgaard. People are bustling about, while street vendors are trying hard
 to sell hotdogs and other less legal merchandise. Streetlights can be
 seen along the road, and you also notice the odd tree.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -322,7 +322,7 @@ is wall road, while to the north you can see most of the city of Midgaard.
 You can see some street vendors here, standing inside small kiosks. You
 can see everything from cheap jewelry to leather jackets for sale.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -352,7 +352,7 @@ All along the bottom edge of it are lightbulbs. A double glass door leads
 north, while a few signs have been set up here on the sidewalk. You 
 recognize this as the entrance to the Midgaard Theatre.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -408,7 +408,7 @@ Midgaard. People are bustling about, while street vendors are trying hard
 to sell hotdogs and other less legal merchandise. Streetlights can be
 seen along the road, and you also notice the odd tree.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -433,7 +433,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 You can see a large stone entrance leading into the wall here, leading
 east. People are walking past you, hurrying to their destinations. 
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -455,7 +455,7 @@ leads south to the forest of Miden'Nir (Goblinic for 'Green Blood').
 You can still see the city to the east, but if you go south, there is
 fresh air and greenery.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -472,7 +472,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 It is far too high to climb. People are walking past you, hurrying to
 their destinations. 
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -493,7 +493,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 It is far too high to climb. People are walking past you, hurrying to
 their destinations. 
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -514,7 +514,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 It is far too high to climb. People are walking past you, hurrying to
 their destinations. 
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -535,7 +535,7 @@ grey rocks that have been fastened to each other with some kind of mortar.
 It is far too high to climb. People are walking past you, hurrying to
 their destinations. 
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -557,7 +557,7 @@ walking next to the western city wall, at the southeast gate.  The gate is
 closed, blocking all passage and seems to have been that way for a long time.
   
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D0
 ~
 ~
@@ -576,7 +576,7 @@ leading east and west. The tall buildings of southern Midgaard dominate the
 southern skyline, while you can see the huge temple of Midgaard off in the 
 north.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D2
 ~
 ~
@@ -621,7 +621,7 @@ have been built fairly high off the river, making it impossible to access
 the river from here. Several large crates and barrels are scattered around
 here. Across the river, you can see the levee.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D1
 ~
 ~
@@ -638,7 +638,7 @@ have been built fairly high off the river, making it impossible to access
 the river from here. Across the river, you can see a building that looks
 like an old warehouse.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D2
 ~
 ~
@@ -684,7 +684,7 @@ you're in the middle of the city, you feel as though you're in a deep
 forest. As your eyes adjust to the lower light, you notice a rope softly
 swaying in the wind, behind a thick tree.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D2
 ~
 ~
@@ -817,7 +817,7 @@ of the tree. From here, you have an excellent view of Midgaard. From out
 of nowhere, a thick chain falls out of the sky, right in front of your 
 face. It leads up into the clouds above.
 ~
-242 0 0 0 0 0
+242 0 0 0 0 1
 D5
 ~
 ~

--- a/lib/world/wld/243.wld
+++ b/lib/world/wld/243.wld
@@ -9,7 +9,7 @@ chirp quietly to themselves and you can smell the faint scent of flowers
 and freshly cut grass.  You feel like you could lie down in the grass and
 stay here forever, surrounded by powerful beauty in all directions.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -59,7 +59,7 @@ feel like you could lie down in the grass and stay here forever, surrounded
 by powerful beauty in all directions. You can see a large sign on the left
 side of the road.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -88,7 +88,7 @@ you can see some hills to the north.  The grass is no longer cut here, and
 you can feel a cold wind coming from the north. The hills up ahead have a
 bit of snow on them.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -106,7 +106,7 @@ Snowy Pass Entrance~
 still grows green,  but the hills straight ahead of you are covered with
 snow. A dirt trail leads north into the hills.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A dirt path leads North.
 ~
@@ -126,7 +126,7 @@ You find yourself at the base of a long hill that spans east and west.
 The grass is no longer cut here, and you can feel a cold wind coming from
 the north.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The field continues East.
 ~
@@ -146,7 +146,7 @@ You find yourself at the base of a long hill that spans east and west.
 The grass is no longer cut here, and you can feel a cold wind coming from
 the north.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D2
 The field continues South.
 ~
@@ -166,7 +166,7 @@ you can see a wide expanse of deep snow. You can see a very small
 hole leading into the eastern hill. A short wooden sign has been shoved
 into the ground beside the hill.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 4
 D0
 The trail continues North.
 ~
@@ -268,7 +268,7 @@ It's snowing heavily, and a strong wind is blowing it all around. Huge
 drifts of snow block your way east and west. The path has several
 inches of snow covering it.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -287,7 +287,7 @@ and a strong wind is blowing it all around. A huge drift of snow blocks your
 way west, but a very narrow path has been shoveled east. The path has 
 several inches of snow covering it.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -311,7 +311,7 @@ and a strong wind is blowing it all around. Huge drifts of snow block your
 way north and south. You can see some old frozen steps leading up to a
 wooden shack to the east.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 An old shack is East.
 ~
@@ -420,7 +420,7 @@ Ski Hill Road~
 hill, which must be the Cooland Ski Hill. To the east you can see a log
 cabin. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The cabin is East.
 ~
@@ -458,7 +458,7 @@ A Snowy Path~
 and a strong wind is blowing it all around. A huge drift of snow blocks your 
 way east, but a huge log cabin lies directly west. The path continues north.
 ~
-243 4 0 0 0 0
+243 4 0 0 0 2
 D0
 The path continues North.
 ~
@@ -481,7 +481,7 @@ A Snowy Path~
 a strong wind is blowing all around.  Huge snow drifts block your way to the
 east, west and north.  
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D2
 The path continues South.
 ~
@@ -809,7 +809,7 @@ A Snowy Path~
 and a strong wind is blowing all around. Huge snow drifts block your way to
 the east and west. The path continues north and south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -827,7 +827,7 @@ A Snowy Path~
 and a strong wind is blowing all around. Huge snow drifts block your way to
 the east and west. The path continues north and south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -845,7 +845,7 @@ Newbie ski trail~
 so this must be a newbie trail. You see the odd skier go by, but this trail
 is fairly empty. A thick forest blocks your way north and west.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The trail continues East.
 ~
@@ -863,7 +863,7 @@ Newbie ski trail~
 so this must be a newbie trail. You see the odd skier go by, but this trail
 is fairly empty. A thick forest blocks your way north.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The trail continues East.
 ~
@@ -886,7 +886,7 @@ Newbie ski trail~
 so this must be a newbie trail. You see the odd skier go by, but this trail
 is fairly empty. A thick forest blocks your way north.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The trail continues East.
 ~
@@ -910,7 +910,7 @@ so this must be a newbie trail. You see the odd skier go by, but this trail
 is fairly empty. A thick forest blocks your way north. You can see the back
 of the chalet to the south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The trail continues East.
 ~
@@ -929,7 +929,7 @@ so this must be a newbie trail. You see the odd skier go by, but this trail
 is fairly empty. A thick forest blocks your way north. You can see the back
 of the chalet to the south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The trail continues East.
 ~
@@ -949,7 +949,7 @@ by, but this trail is fairly empty. A thick forest blocks your way north
 and east. The chalet is to the southwest. A wide path (almost a road) 
 leads south to the ski hill's main entrance.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D2
 The path continues South.
 ~
@@ -967,7 +967,7 @@ Newbie ski trail~
 so this must be a newbie trail. You see the odd skier go by, but this trail
 is fairly empty. A thick forest blocks your way west.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The trail continues North.
 ~
@@ -990,7 +990,7 @@ Forest~
 see the ski trail to the north and west. Since this place is more hidden
 than the open trails, snowboarders like to come here to smoke up.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The newbie run is North.
 ~
@@ -1019,7 +1019,7 @@ see the ski trail to the north. Since this place is more hidden than the open
 trails, snowboarders like to come here to smoke up. The back of the chalet is
 directly east, blocking your way.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The newbie run is North.
 ~
@@ -1057,7 +1057,7 @@ Main Path~
    You find yourself at the top of the ski hill on a wide path. The chalet 
 blocks your way west, while a thick forest blocks your way east.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -1076,7 +1076,7 @@ too steep, so this must be a newbie trail. You see the odd skier go by, but
 thistrail is fairly empty. A thick forest blocks your way west and south. 
 Since there aren't any ski lifts at this hill, you'll have to walk back up.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The trail continues North.
 ~
@@ -1094,7 +1094,7 @@ Forest~
 see the newbie trail to the west. Since this place is more hidden than the 
 open trails, snowboarders like to come here to smoke up.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The forest continues North.
 ~
@@ -1123,7 +1123,7 @@ see the newbie trail to the west. The chalet blocks your way east. Since this
 place is more hidden than the open trails, snowboarders like to come here to 
 smoke up.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The forest continues North.
 ~
@@ -1194,7 +1194,7 @@ blocks your way east. A large wooden building is built right into the hill to
 the west. Several ski racks sit outside the door, and a huge chimney is 
 billowing out smoke from the side of the chalet.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -1218,7 +1218,7 @@ the intermediate trail to the south. Since this place is more hidden than the
 open trails, snowboarders like to come here to smoke up. The forest thickens
 and blocks your way west.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The forest continues North.
 ~
@@ -1241,7 +1241,7 @@ Forest~
 the intermediate trail to the south. Since this place is more hidden than the 
 open trails, snowboarders like to come here to smoke up. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The forest continues North.
 ~
@@ -1270,7 +1270,7 @@ see the newbie trail to the west. Since this place is more hidden than the
 open trails, snowboarders like to come here to smoke up. The chalet blocks 
 your way north.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The forest continues East.
 ~
@@ -1294,7 +1294,7 @@ see the newbie trail to the west. Since this place is more hidden than the
 open trails, snowboarders like to come here to smoke up. The chalet blocks 
 your way north, while you can see the main path east.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The main path is East.
 ~
@@ -1317,7 +1317,7 @@ Main Path~
 north, while the more advanced runs are south. A forest lies west, and the
 steel entrance gate is east.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The main path continues North.
 ~
@@ -1342,7 +1342,7 @@ west and down. except east where the trail leads up. The snow is rather deep
 here, and it isn't groomed. You can see large ape-like footprints in the snow. 
 You get the feeling no one comes down here very often.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The intermediate trail continues East.
 ~
@@ -1361,7 +1361,7 @@ up through the snow, and many moguls and bumps are all around. This trail is
 obviously made for better skiers and snowboarders. A thick forest blocks your
 way north.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The intermediate trail continues East.
 ~
@@ -1384,7 +1384,7 @@ Intermediate ski trail~
 up through the snow, and many moguls and bumps are all around. This trail is
 obviously made for better skiers and snowboarders. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1412,7 +1412,7 @@ Intermediate ski trail~
 up through the snow, and many moguls and bumps are all around. This trail is
 obviously made for better skiers and snowboarders. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1440,7 +1440,7 @@ Intermediate ski trail~
 up through the snow, and many moguls and bumps are all around. This trail is
 obviously made for better skiers and snowboarders. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1468,7 +1468,7 @@ Intermediate ski trail~
 up through the snow, and many moguls and bumps are all around. This trail is
 obviously made for better skiers and snowboarders. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1495,7 +1495,7 @@ Start of the intermediate trailt~
    You're on the main path of the ski hill, at the entrance to the
 intermediate run. A thick forest blocks your way east.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The main path continues North.
 ~
@@ -1552,7 +1552,7 @@ the intermediate trail to the north. Since this place is more hidden than the
 open trails, snowboarders like to come here to smoke up. The forest thickens
 and completely blocks your way west and south. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The intermediate trail is North.
 ~
@@ -1570,7 +1570,7 @@ Forest~
 the intermediate trail to the north. Since this place is more hidden than the 
 open trails, snowboarders like to come here to smoke up. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The intermediate trail is North.
 ~
@@ -1598,7 +1598,7 @@ Forest~
 the intermediate trail to the north. Since this place is more hidden than the 
 open trails, snowboarders like to come here to smoke up. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The intermediate trail is North.
 ~
@@ -1626,7 +1626,7 @@ Forest~
 the intermediate trail to the north. Since this place is more hidden than the 
 open trails, snowboarders like to come here to smoke up. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The intermediate trail is North.
 ~
@@ -1654,7 +1654,7 @@ Forest~
 the intermediate trail to the north. Since this place is more hidden than the 
 open trails, snowboarders like to come here to smoke up. 
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The intermediate trail is North.
 ~
@@ -1681,7 +1681,7 @@ Main Path~
    You're on the main path of the ski hill, at the entrance to the
 intermediate run. A thick forest blocks your way east.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The main path continues North.
 ~
@@ -1706,7 +1706,7 @@ is very steep. This place is definitely not for beginners. A high cliff is
 directly south. A large sign sits on the left side of the trail. (You should 
 read it!)
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1744,7 +1744,7 @@ snow, and huge jumps and bumps sit right in the middle of the trail. The slope
 is very steep. This place is definitely not for beginners. A thick forest blocks
 your way south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1768,7 +1768,7 @@ snow, and huge jumps and bumps sit right in the middle of the trail. The slope
 is very steep. This place is definitely not for beginners. A thick forest blocks
 your way south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1792,7 +1792,7 @@ snow, and huge jumps and bumps sit right in the middle of the trail. The slope
 is very steep. This place is definitely not for beginners. A thick forest blocks
 your way south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 A forest is North.
 ~
@@ -1816,7 +1816,7 @@ snow, and huge jumps and bumps sit right in the middle of the trail. The slope
 is very steep. This place is definitely not for beginners. A thick forest 
 blocks your way west and south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D0
 The main path is North.
 ~
@@ -1836,7 +1836,7 @@ forest below. Hey, now it doesn't look so far anymore. Oh, now you're impaled
 on a tall icy pine tree. Right before you black out, you feel the coldness of
 the wood in your chest.
 ~
-243 4 0 0 0 0
+243 4 0 0 0 3
 S
 T 24300
 #24392
@@ -1849,7 +1849,7 @@ A small booth stands here, where people must buy their lift tickets to get
 in. A small wooden sign has been nailed to the booth. A steel gate lies 
 west.
 ~
-243 68 0 0 0 0
+243 68 0 0 0 2
 D1
 The road continues East.
 ~
@@ -1880,7 +1880,7 @@ Main Path~
 you can see the entry gates, while to the west you can see the ski hill.
 A thick forest blocks your way north and south.
 ~
-243 0 0 0 0 0
+243 0 0 0 0 2
 D1
 The main entrance is East.
 ~

--- a/lib/world/wld/247.wld
+++ b/lib/world/wld/247.wld
@@ -4,7 +4,7 @@ A Gravel Road on the Graveyard~
 graveyard.  On both sides of the road, grave markers poke up out of the ground.
 An iron grate is to the north.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 1
 D1
 Headstones are arranged in neat rows to the east.
 ~
@@ -51,7 +51,7 @@ A Gravel Road on the Graveyard~
 graveyard.  Both sides of the road are lined with grave markers poking up out
 of the ground.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 1
 D0
 The gravel road continues northward.
 ~
@@ -79,7 +79,7 @@ A Gravel Road on the Graveyard~
 graveyard.  Both sides of the road are lined with grave markers poking up out
 of the ground.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 1
 D0
 The gravel road continues northward.
 ~
@@ -107,7 +107,7 @@ A Gravel Road on the Graveyard~
 graveyard.  Both sides of the road are lined with grave markers poking up out
 of the ground.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 1
 D0
 The gravel road continues northward.
 ~
@@ -136,7 +136,7 @@ In front of the Chapel~
 through the graveyard and the chapel entrance is to the south.  A few flowers
 have been trampled into the dirt.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 1
 D0
 The gravel road continues northward.
 ~
@@ -153,7 +153,7 @@ Inside the Chapel~
    You are in a small, dark chapel.  The dark brown glass in the tiny windows
 does not let much light through.  A few rows of worn wooden benches stand here.
 ~
-247 0 0 0 0 0
+247 0 0 0 0 1
 D0
 The chapel door is made of dark wood.
 ~
@@ -174,7 +174,7 @@ A Grave~
 beneath your feet and the smell of freshly dug dirt hits your nostrils.  The
 gravel path is to the west and there are more graves to the east and south.  
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies another cemetery plot.
 ~
@@ -201,7 +201,7 @@ A Grave~
 beneath your feet and the smell of freshly dug dirt hits your nostrils.  The
 gravel path is to the west and there are more graves to the east and south.  
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 A small shack is east of here.
 ~
@@ -241,7 +241,7 @@ A Grave~
 in his work.  The gravel path is to the west and more plots lie to the north,
 east and south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -273,7 +273,7 @@ A Grave~
 in his work.  Dark evergreen trees grow to the east.  More plots lie to the
 north, west and south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -300,7 +300,7 @@ A Grave~
 in his work.  More plots lie to the north, east and south and the gravel path
 lies west.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -331,7 +331,7 @@ A Grave~
 in his work.  Dark evergreen trees grow east of here.  More plots lie to the
 north, west and south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -358,7 +358,7 @@ A Grave~
 in his work.  Dark evergreen trees grow to the south.  To the west is the
 gravel path and more plots lie to the north and east.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -388,7 +388,7 @@ evergreen trees grow to the south and east, although there is an opening to
 east where something has smashed through the tree limbs.  More plots lie to the
 north and west.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -412,7 +412,7 @@ trees and broken branches litter the ground.  Although the trail is dark, these
 markers clearly show you the path.  The trail continues to the east, the
 cemetery lies west.    
 ~
-247 4 0 0 0 0
+247 4 0 0 0 3
 D1
 Without the broken branches to show you the way, the trail would be impossible
 to follow.
@@ -433,7 +433,7 @@ over creating impassable deadfalls to the north and east.  Similar dead trees
 have form what resembles a cave to the south.  The nauseating stench of decay
 drifts from somewhere and you sense a powerful evil nearby.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D2
 It looks very dark and foreboding in there.
 ~
@@ -465,7 +465,7 @@ path.  A light fog seems to hang over this part of the cemetery and the mist
 sometimes seems to take humanoid forms as ghostly apparitions.  The cemetery
 continues to the west and south.  The gravel path is back to the east.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies the gravel path.
 ~
@@ -492,7 +492,7 @@ A Grave~
 sometimes seems to take humanoid forms as ghostly apparitions.  The cemetery
 continues to the west, south and east.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies another cemetery plot.
 ~
@@ -519,7 +519,7 @@ A Grave~
 sometimes seems to take humanoid forms as ghostly apparitions.  The cemetery
 continues to the east, south and west.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies the another cemetery plot.
 ~
@@ -548,7 +548,7 @@ sometimes seems to take humanoid forms as ghostly apparitions.  The cemetery
 continues to the north, west and south.  The gravel path is back to the east.
   
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -581,7 +581,7 @@ to take humanoid forms as ghostly apparitions.  You feel a rising power of some
 sort emanating from the southwest.  The cemetery continues in all directions.
   
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -613,7 +613,7 @@ A Grave~
 to take humanoid forms as ghostly apparitions.  You feel a rising power
 emanating from the south.  The cemetery continues in all directions.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -647,7 +647,7 @@ sometimes seems to take humanoid forms as ghostly apparitions.  The cemetery
 continues to the north, west and south.  The gravel path is back to the east.
   
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -679,7 +679,7 @@ A Grave~
 to take humanoid forms as ghostly apparitions.  You feel a rising power
 emanating from the west.  The cemetery continues in all directions.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -712,7 +712,7 @@ take humanoid forms as ghostly apparitions.  There is a very strong power field
 of some sort emanating from a mausoleum to the west.  The cemetery continues to
 the north, east and south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -751,7 +751,7 @@ sometimes seems to take humanoid forms as ghostly apparitions.  Dark evergreen
 trees grow to the south.  The cemetery continues north and west.  The gravel
 path is back to the east.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -779,7 +779,7 @@ take humanoid forms as ghostly apparitions.  A rising power emanates from the
 northwest.  Dark evergreen trees grow to the south.  The cemetery continues to
 the north, east and west.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -806,7 +806,7 @@ A Grave~
 take humanoid forms as ghostly apparitions.  A rising power emanates from the
 north.  The cemetery continues to the north, east and west.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1430,7 +1430,7 @@ A Grave~
 peace.  Figures move through the swirling fog.  The cemetery continues to the
 west east and south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies another cemetery plot.
 ~
@@ -1458,7 +1458,7 @@ peace.  Figures move through the swirling fog.  The smooth stone wall of a
 mausoleum is to the south.  The cemetery continues to the north, east and west.
   
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1487,7 +1487,7 @@ swirling fog.  Dark evergreen trees grow to the south.  The smooth stone wall
 of a mausoleum is to the north, and the cemetery continues to the east and
 west.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies another cemetery plot.
 ~
@@ -1509,7 +1509,7 @@ A Grave~
 exhale.  The still clam put your thoughts at ease as you stare into the
 swirling fog.  The cemetery continues to the west, north and east.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1537,7 +1537,7 @@ exhale.  The still calm put your thoughts at ease as you stare into the
 swirling fog.  The smooth stone wall of a mausoleum is to the east, and the
 cemetery continues to the north, south and west.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1564,7 +1564,7 @@ A Grave~
 exhale.  The still calm put your thoughts at ease as you stare into the
 swirling fog.  The cemetery continues in all directions.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1597,7 +1597,7 @@ cold clammy feel.  A faint sweet smell of decay hangs in the air, yet you feel
 calm and at peace in this place.  The cemetery continues to the west, east and
 south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies another cemetery plot.
 ~
@@ -1625,7 +1625,7 @@ exhale.  The still calm puts your thoughts at ease as you stare into the
 swirling fog.  Dark evergreen trees grow to the south and west.  The cemetery
 continues to the north and east.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1649,7 +1649,7 @@ swirling fog.  Dark evergreen trees grow to the west.  The smooth stone wall of
 a mausoleum is to the east, and the cemetery continues to the north and south.
   
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1677,7 +1677,7 @@ exhale.  The still calm put your thoughts at ease as you stare into the
 swirling fog.  Dark evergreen trees grow to the west.  The cemetery continues
 to the north, east and south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D0
 To the north lies another cemetery plot.
 ~
@@ -1705,7 +1705,7 @@ cold clammy feel.  A faint sweet smell of decay hangs in the air, yet you feel
 calm and at peace in this place.  Dark evergreen trees grow to the west and the
 cemetery continues to the east and south.    
 ~
-247 0 0 0 0 0
+247 0 0 0 0 2
 D1
 To the east lies another cemetery plot.
 ~

--- a/lib/world/wld/248.wld
+++ b/lib/world/wld/248.wld
@@ -23,7 +23,7 @@ Entrance to the Elven Forest~
 canopies.  A large steel reinforced wooden gate is set into a wall of wood logs
 just to the north.    
 ~
-248 0 0 0 0 0
+248 0 0 0 0 3
 D0
 ~
 ~
@@ -35,7 +35,7 @@ Guarded Path Through the Forest~
 yourself observed by someone.  To the east you see a wooden door in a large
 tree, and to the west you see a rope hanging down from a tree.    
 ~
-248 0 0 0 0 0
+248 0 0 0 0 3
 D0
 ~
 ~
@@ -59,7 +59,7 @@ A Guard Room~
 table.  To the east and west you can see doors.  The sound of footseps can be
 heard in the distance.    
 ~
-248 8 0 0 0 0
+248 8 0 0 0 3
 D1
 ~
 ~
@@ -75,7 +75,7 @@ A Guard Chief's Bedroom~
 and awards line the walls.  In a corner stands a large bed and there is a door
 to the west.    
 ~
-248 8 0 0 0 0
+248 8 0 0 0 3
 D3
 ~
 ~
@@ -87,7 +87,7 @@ A Cellar~
 Filled, almost to the point of collapse, with various dried foods and storage
 containers.    
 ~
-248 9 0 0 0 0
+248 9 0 0 0 3
 D4
 ~
 ~
@@ -99,7 +99,7 @@ On the Platform~
 forest.  From here, above the tree tops, the town of Thewston is visible in the
 distance.    
 ~
-248 4 0 0 0 0
+248 4 0 0 0 5
 D5
 ~
 ~
@@ -111,7 +111,7 @@ A Guarded Path Through the Forest~
 is in good condition and looks well kept.  No dead branches or brush is visible
 between the trees.    
 ~
-248 0 0 0 0 0
+248 0 0 0 0 3
 D0
 ~
 ~
@@ -127,7 +127,7 @@ A Path Crossing~
 the crossing stands a gigantic stone obelisk with some runes engraved into it.
   
 ~
-248 0 0 0 0 0
+248 0 0 0 0 3
 D0
 ~
 ~
@@ -148,7 +148,7 @@ A Fine Path Through the Elven Forest~
 telling you this must be the weapon shop, and over the western door is a
 similar sign telling you it's the armoury.    
 ~
-248 0 0 0 0 0
+248 0 0 0 0 3
 D0
 ~
 ~
@@ -197,7 +197,7 @@ telling you this must be the magic shop of the elven village, and over the
 western door is a similar sign telling you it's Quintors fine shop.  To the
 north the path continues.    
 ~
-248 0 0 0 0 0
+248 0 0 0 0 3
 D0
 ~
 ~
@@ -245,7 +245,7 @@ The End of the Path~
 telling you this must be the tavern of the village, and to the north you see a
 large house, about two stores high.    
 ~
-248 0 0 0 0 0
+248 0 0 0 0 3
 D0
 ~
 ~

--- a/lib/world/wld/25.wld
+++ b/lib/world/wld/25.wld
@@ -6,7 +6,7 @@ menace permeates the surrounding area.  You have a strange urge to turn
 back and go back the way you've come.
    A small path leads north into the shadows and back south to the plains.
 ~
-25 68 0 0 0 0
+25 68 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -29,7 +29,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -58,7 +58,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 You see a small clearing in the shadows.
 ~
@@ -87,7 +87,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -116,7 +116,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -145,7 +145,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -174,7 +174,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -203,7 +203,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -232,7 +232,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All exits lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -261,7 +261,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All directions lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -290,7 +290,7 @@ from all sides.  The shadowy mist obscures most of your vision.  Strange
 sounds of moaning and growling come from all directions.
    All directions lead into shadows, you are very confused.
 ~
-25 101 0 0 0 0
+25 101 0 0 0 3
 D0
 The shadows obscure your vision.
 ~
@@ -321,7 +321,7 @@ your view into the grove.
    A small path leads north to some shadowy structure.  All other exits are
 shrouded in shadowy mist.
 ~
-25 65 0 0 0 0
+25 65 0 0 0 3
 D0
 You can barely make out some sort of building to the north.
 ~

--- a/lib/world/wld/250.wld
+++ b/lib/world/wld/250.wld
@@ -6,7 +6,7 @@ realize that the clay road is completely invisible to you from here.  To the
 east, the path continues.  It appears that the western opening you entered
 through is now impassible.  You are here whether you like it or not....    
 ~
-250 0 0 0 0 0
+250 0 0 0 0 3
 D1
 An Ancient Path through the dense forest
 ~
@@ -31,7 +31,7 @@ if not for the mountain you can now see in the distance, would probably just
 recall to Midgaard.  But then again, who ever said that adventuring was easy?
   
 ~
-250 0 0 0 0 0
+250 0 0 0 0 3
 D1
 End of the Ancient Path
 ~
@@ -50,7 +50,7 @@ the foot of a path.  The path leads north, to the mountain which has, until now
 been your only beacon.  Now that you can better see the ominous mountain
 looming before you, you begin to rethink the idea of recalling to Midgaard.  
 ~
-250 0 0 0 0 0
+250 0 0 0 0 3
 D0
 Path to the Mountain
 ~
@@ -69,7 +69,7 @@ closer you get to the mountain, the worse you feel about the whole thing.  You
 begin to remember hearing old stories about a hidden mountain, which was, for
 some unknown reason, named DragonSpyre.    
 ~
-250 0 0 0 0 0
+250 0 0 0 0 3
 D0
 Path to the Mountain
 ~
@@ -89,7 +89,7 @@ deep stench of dragon is wafting through the air now, and you are starting to
 feel the first tinges of dragon fear stir within you.  Maybe you should go back
 while you still have that option.    
 ~
-250 0 0 0 0 0
+250 0 0 0 0 3
 D0
 At the foot of the Mountain
 ~
@@ -108,7 +108,7 @@ almost strong enough to disable you.  The only way you are able to stand it is
 by ripping of a piece of cloth, and covering your mouth and nose with it as you
 walk.  Far above you, you see what must be the entrance to the cave.    
 ~
-250 0 0 0 0 0
+250 0 0 0 0 3
 D2
 Path to the Mountain
 ~

--- a/lib/world/wld/251.wld
+++ b/lib/world/wld/251.wld
@@ -5,7 +5,7 @@ grasses completely surround you. You can see the odd willow tree growing
 amongst the grass. A dense forest is to the south and west. A dirt path
 is to the east.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -45,7 +45,7 @@ Dirt Path~
 trees scattered about lie to the east and west. The sun is very bright,
 making it almost difficult to see.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -69,7 +69,7 @@ grasses completely surround you. You can see the odd willow tree growing
 amongst the grass. A dense forest is to the south. A dirt path is to the 
 west.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -92,7 +92,7 @@ Grassy Field~
 grasses completely surround you. You can see the odd willow tree growing
 amongst the grass. A dense forest is to the south.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -115,7 +115,7 @@ Grassy Field~
 grasses completely surround you. You can see the odd willow tree growing
 amongst the grass. A dense forest is to the south and east.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -134,7 +134,7 @@ grasses completely surround you. You can see the odd willow tree growing
 amongst the grass. A dense forest is to the west, and a dirt path is to
 the east.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -157,7 +157,7 @@ Dirt Path~
 trees scattered about lie to the east and west. The sun is very bright,
 making it almost difficult to see.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -185,7 +185,7 @@ Grassy Field~
 You can see the odd willow tree growing amongst the grass. A dirt path is to
 the west.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -213,7 +213,7 @@ Grassy Field~
 You can see the odd willow tree growing amongst the grass.  The wind
 occasionally sweeps across the field swaying the grass and willow gently.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -241,7 +241,7 @@ Grassy Field~
 grasses completely surround you. You can see the odd willow tree growing
 amongst the grass. A dense forest blocks your way to the east.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -265,7 +265,7 @@ grasses completely surround you. You can see the odd willow tree growing
 amongst the grass. A dense forest is to the west, and a dirt path is to
 the east.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -289,7 +289,7 @@ trees scattered about lie to the east and west. The sun is very bright,
 making it almost difficult to see. Strange, sandy coloured dome shaped
 houses can be made out ahead.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The path continues North.
 ~
@@ -317,7 +317,7 @@ Grassy Field~
 You can see the odd willow tree growing amongst the grass. A dirt path is to
 the west.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -345,7 +345,7 @@ Grassy Field~
 You can see the odd willow tree growing amongst the grass.  The wind
 occasionally sweeps across the field swaying the grass and willow gently.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The field continues North.
 ~
@@ -374,7 +374,7 @@ grasses completely surround you. A large sandy coloured building is
 to the north. The grass has been cut around the building, and a small
 stack of firewood is resting beside the door.
 ~
-251 4 0 0 0 0
+251 4 0 0 0 2
 D0
 A sandy coloured building is North.
 ~
@@ -397,7 +397,7 @@ Grassy Field~
 grasses completely surround you. The back of a large sandy coloured 
 building is directly north of you.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The Ape Village Entrance is East.
 ~
@@ -417,7 +417,7 @@ road. A tall steel rod is attached to the side of the booth, and a large
 cloth flag attached to the top flaps in the wind. The flag has a picture
 of a monkey face on it, meaning that this place must be the APE VILLAGE!
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 Ape Road continues North.
 ~
@@ -445,7 +445,7 @@ Grassy Field~
 grasses completely surround you. The back of a large sandy coloured 
 building is directly north of you.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The field continues East.
 ~
@@ -469,7 +469,7 @@ grasses completely surround you. The back of a large sandy coloured
 building is directly north of you, and another sandy coloured building
 is east of you.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D2
 The field continues South.
 ~
@@ -542,7 +542,7 @@ Ape Road South~
 buildings. The Wax Museum lies to the west, and the Weapons Shop is
 to the east. The Town Square is to the north. 
 ~
-251 4 0 0 0 0
+251 4 0 0 0 1
 D0
 Ape Road continues North.
 ~
@@ -592,7 +592,7 @@ field is a huge bamboo cage. Inside this cage are several cavemen, who are
 all climbing, screaming, and fighting each other. The apes find this to be 
 pretty exciting.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 Ape Lane is to the North.
 ~
@@ -674,7 +674,7 @@ Western End of Ape Lane~
 large pond, which must be where the apes get their water. A small park 
 lies North, and the Wax Museum is to the South.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D0
 Ape Park is to the North.
 ~
@@ -703,7 +703,7 @@ greatest Ape to ever live, the Law Giver, stands in the centre of the
 square on a stone pedistal. The words "Ape will never kill ape!" are 
 inscribed on the pedistal.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D0
 Ape Road continues North.
 ~
@@ -731,7 +731,7 @@ Ape Lane East~
 Weapons Shop is to the South.  The place looks like a typical human town,
 except for the inhabitants.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D0
 Simian Public School is to the North.
 ~
@@ -759,7 +759,7 @@ Eastern End of Ape Lane~
 is to the east, Cornelius and Zira's house is to the north, and the Ape Zoo
 is to the south.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D0
 Cornelius and Zira's House is to the North.
 ~
@@ -823,7 +823,7 @@ Ape Pond~
 are growing all around.  To the north you can see a dangerous raging whirlpool.
   
 ~
-251 4 0 0 0 0
+251 4 0 0 0 6
 D0
 A raging whirlpool is North.
 ~
@@ -841,7 +841,7 @@ Ape Pond~
 but you probably would not want to drink from it.  To the east is a clearing
 leading to Ape Park.    
 ~
-251 4 0 0 0 0
+251 4 0 0 0 6
 D0
 The pond continues North.
 ~
@@ -864,7 +864,7 @@ Ape Park~
 games.  A large pond is to the west in the middle of the large clearing for
 swimming.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 Ape Road is to the East.
 ~
@@ -887,7 +887,7 @@ Ape Road North~
 the Ape Park and what looks like a lake.  To the east is Simian Public School.
   
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D0
 Ape Road continues North.
 ~
@@ -946,7 +946,7 @@ Whirlpool~
 peer down into the water but all you can see is darkness. Maybe going
 down isn't such a good idea.
 ~
-251 5 0 0 0 0
+251 5 0 0 0 6
 D0
 The pond continues North.
 ~
@@ -969,7 +969,7 @@ Ape Pond~
 are growing all around.  To the west you can see a dangerous raging whirlpool.
   
 ~
-251 4 0 0 0 0
+251 4 0 0 0 6
 D0
 The pond contines North.
 ~
@@ -997,7 +997,7 @@ Ape Pond West Shore~
 but you probably wouldn't want to drink from it. To the south is Ape Park,
 while to the east is Ape Road North.
 ~
-251 4 0 0 0 0
+251 4 0 0 0 6
 D1
 Ape Road North is East.
 ~
@@ -1020,7 +1020,7 @@ Ape Road North~
 a large pond and a park.  To the east is the amphitheatre with a few apes
 walking in and out.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D0
 Ape Road continues North.
 ~
@@ -1048,7 +1048,7 @@ Ape Amphitheatre~
 with about 6 or 7 levels of seats. The bottom part is where Dr. Zaius and Ursus
 rally all the other apes.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D3
 Ape Road is to the West.
 ~
@@ -1066,7 +1066,7 @@ Ape Pond~
 are growing all around.  To the south you can see a dangerous raging whirlpool.
   
 ~
-251 4 0 0 0 0
+251 4 0 0 0 6
 D1
 The pond continues East.
 ~
@@ -1084,7 +1084,7 @@ Ape Pond~
 are growing all around.  The water is clean and clear all the way to the
 bottom.    
 ~
-251 4 0 0 0 0
+251 4 0 0 0 6
 D2
 The pond continues South.
 ~
@@ -1115,7 +1115,7 @@ Ape Road North~
 Dr.  Zaius's house, and to the east is Dr.  Zaius's lab.  The buildings look
 rather mundane.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 1
 D0
 Ape Road continues North.
 ~
@@ -1255,7 +1255,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way west. The gusting winds blow sand all over you. You don't think 
 anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1274,7 +1274,7 @@ scattered about, and you can see the odd dead shrub.  The gusting winds blow
 sand all over you.  You don't think anything could live out here.  You can see
 the Ape Village to the south.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1300,7 +1300,7 @@ high cliff blocks your way to the east. The gusting winds blow sand all over
 you. You don't think anything could live out here. You can see the Ape Village 
 to the south.
 ~
-251 4 0 0 0 0
+251 4 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1324,7 +1324,7 @@ scattered about, and you can see the odd dead shrub.  A high cliff blocks your
 way west.  The gusting winds blow sand all over you.  You don't think anything
 could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1347,7 +1347,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub.  The gusting winds blow
 sand all over you.  You don't think anything could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1376,7 +1376,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the east. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1400,7 +1400,7 @@ scattered about, and you can see the odd dead shrub.  A high cliff blocks your
 way west.  The gusting winds blow sand all over you.  You don't think anything
 could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1423,7 +1423,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub.  The gusting winds blow
 sand all over you.  You don't think anything could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1452,7 +1452,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the east. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1476,7 +1476,7 @@ scattered about, and you can see the odd dead shrub.  A high cliff blocks your
 way west.  The gusting winds blow sand all over you.  You don't think anything
 could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1499,7 +1499,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub.  The gusting winds blow
 sand all over you.  You don't think anything could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1528,7 +1528,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the east. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1553,7 +1553,7 @@ your way east, west, and south, and they also stop some of the winds. You
 barely notice an old weather beaten stone table, which is mostly buried in
 sand.  You don't think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1567,7 +1567,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the east and west, and they also block some of the winds. You
 don't think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1586,7 +1586,7 @@ scattered about, and you can see the odd dead shrub.  A high cliff blocks your
 way west.  The gusting winds blow sand all over you.  You don't think anything
 could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1609,7 +1609,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub.  The gusting winds blow
 sand all over you.  You don't think anything could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1637,7 +1637,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub. The gusting winds 
 blow sand all over you. You don't think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1666,7 +1666,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the south. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1690,7 +1690,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the east. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1714,7 +1714,7 @@ scattered about, and you can see the odd dead shrub.  A high cliff blocks your
 way west.  The gusting winds blow sand all over you.  You don't think anything
 could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1737,7 +1737,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub.  The gusting winds blow
 sand all over you.  You don't think anything could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1765,7 +1765,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub. The gusting winds 
 blow sand all over you. You don't think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1793,7 +1793,7 @@ Forbidden Zone~
 scattered about, and you can see the odd dead shrub. The gusting winds 
 blow sand all over you. You don't think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1822,7 +1822,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the east. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The Forbidden Zone continues North.
 ~
@@ -1846,7 +1846,7 @@ scattered about, and you can see the odd dead shrub.  A high cliff blocks your
 way west.  The gusting winds blow sand all over you.  You don't think anything
 could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The Forbidden Zone continues East.
 ~
@@ -1865,7 +1865,7 @@ scattered about, and you can see the odd dead shrub.  A high cliff blocks your
 way north.  The gusting winds blow sand all over you.  You don't think anything
 could live out here.    
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The Forbidden Zone continues East.
 ~
@@ -1889,7 +1889,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the north. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The Forbidden Zone continues East.
 ~
@@ -1913,7 +1913,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the north. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The Forbidden Zone continues East.
 ~
@@ -1937,7 +1937,7 @@ scattered about, and you can see the odd dead shrub. A high cliff blocks
 your way to the north. The gusting winds blow sand all over you. You don't 
 think anything could live out here. 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The Forbidden Zone continues East.
 ~
@@ -1962,7 +1962,7 @@ your way to the north and south. The gusting winds blow sand all over you.
 You don't think anything could live out here. You can see an ocean and a
 sandy beach to the east.
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D1
 The sandy beach is East.
 ~
@@ -1982,7 +1982,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. Too bad the apes don't like swimming, because this place is
 perfect for it!
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2008,7 +2008,7 @@ shore. A high cliff blocks your way west. You notice a large statue
 located further north. Too bad the apes don't like swimming, because 
 this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2030,7 +2030,7 @@ resting right on the side of the beach. It's a woman wearing a large
 spikey crown holding a book, so it must be the ruins of the Statue of
 Liberty! Damn them all to hell! 
 ~
-251 4 0 0 0 0
+251 4 0 0 0 2
 D2
 The sandy beach continues South.
 ~
@@ -2050,7 +2050,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. A high cliff blocks your way west and south. Too bad the apes 
 don't like swimming, because this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2065,7 +2065,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. A high cliff blocks your way west. Too bad the apes don't like 
 swimming, because this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2085,7 +2085,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. A low cave lead into the cliff to the west. Too bad the apes don't 
 like swimming, because this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2110,7 +2110,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. A high cliff blocks your way west. Too bad the apes don't like 
 swimming, because this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2130,7 +2130,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. A high cliff blocks your way west. Too bad the apes don't like 
 swimming, because this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2150,7 +2150,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. A high cliff blocks your way west. Too bad the apes don't like 
 swimming, because this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~
@@ -2170,7 +2170,7 @@ stretches as far as the eye can see, and small waves gently lap on the
 shore. A high cliff blocks your way west. Too bad the apes don't like 
 swimming, because this place is perfect for it! 
 ~
-251 0 0 0 0 0
+251 0 0 0 0 2
 D0
 The sandy beach continues North.
 ~

--- a/lib/world/wld/252.wld
+++ b/lib/world/wld/252.wld
@@ -9,7 +9,7 @@ from here you cannot be sure.  Your choices seem to be quite limited.  You can
 either head up the winding trail to the castle or head back into this terrible
 forest, taking your chances with the many monsters which roam the trees.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D0
 ~
 ~
@@ -38,7 +38,7 @@ A Winding Mountain Trail~
 castle.  You see no sign of light or life within.  Possibly it is just an old
 empty abandoned castle that doesn't warrant a look around.  Possibly.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D3
 ~
 ~
@@ -56,7 +56,7 @@ the rest of the castle.  You see that the gates are closed, probably locked.
 As you look up at the menacing castle above you, a shiver runs through your very
 soul.  This whole place gives you a very bad feeling.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D3
 ~
 ~
@@ -72,7 +72,7 @@ A Winding Mountain Trail~
 You can now see the top of the turret, where bats circle constantly, as if
 watching, guarding for some unseen master.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D1
 ~
 ~
@@ -89,7 +89,7 @@ a good ways above the forest, high up on the trail.  You see that the entire
 forest is enclosed by the mountains, forming a sort of prison in the form of a
 forest full of horrors.  What an awful place you have come to!  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D1
 ~
 ~
@@ -104,7 +104,7 @@ A Winding Mountain Trail~
    The trail heads and west - east toward the hellish castle and west toward the
 nightmarish forest.  You are not really left with much a choice.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D1
 ~
 ~
@@ -120,7 +120,7 @@ A Winding Mountain Trail~
 of the castle.  You are now extremely high above the forest, looking over the
 tree tops.  Not that you can all that far - it's pretty damn dark out there.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D3
 ~
 ~
@@ -137,7 +137,7 @@ a man's height or so.  To the west is the base of a set of wide stone steps
 which lead directly up to the front gates of the castle.  The trail also leads
 down from here toward the forest below.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D3
 ~
 ~
@@ -154,7 +154,7 @@ built into the mountain itself, leads up to the main entrance to this evil
 looking place.  The trail heads back east, winding it's way down to the forest
 below.  
 ~
-252 1 0 0 0 0
+252 1 0 0 0 3
 D1
 ~
 ~

--- a/lib/world/wld/254.wld
+++ b/lib/world/wld/254.wld
@@ -13,7 +13,7 @@ hole in the ground used for a toilet stinks so bad that you have to keep trying
 to hold your breath, and every time you take in air you have to cover your mouth
 with your arm and breath that way or else you'll gag.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 door cell~
@@ -43,7 +43,7 @@ A Dirt Path~
 south, you can see more holding cells, to the east you see a number of huts,
 tents, and outbuildings.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -68,7 +68,7 @@ one of which is directly west of you, currently closed.  To the southwest, right
 next to the cell, is what appears to be an outhouse.  To the northwest is
 another holding cell.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -88,7 +88,7 @@ A Dirt Path~
 'roads' in the village.  A crude bamboo holding cell is directly west of you,
 with an outhouse just north of it.  To the south are more cells.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -112,7 +112,7 @@ cheap 'B' horror movie.  Just the same, you assume it's an outhouse.  Another
 clue to the small building's capacity is the tepid trail, a mini stream, of
 urine which runs downhill right through the middle of this cell - EWWWWWW!  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 door cell~
@@ -124,7 +124,7 @@ A Holding Cell~
 which looks as if it might be an outhouse, lies to the south, wedged right up
 against the side of the cell.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 door cell~
@@ -153,7 +153,7 @@ Although it IS the public poop hole, it is relatively kept up and, against your
 better judgement, you find yourself wanting to try it out - just for the heck of
 it.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 ~
@@ -164,7 +164,7 @@ A Dirt Path~
    This path leads north to a row of holding cells or west into a building which
 looks to be an outhouse.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -179,7 +179,7 @@ A Dirt Path~
    This path leads south to a row of holding cells or west into a building which
 smells SO bad, it MUST be an outhouse.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D2
 ~
 ~
@@ -195,7 +195,7 @@ A Dirt Path~
 the east you may enter the main section of the village, and directly north and
 south of you are long, low buildings which look a great deal like barracks.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -218,7 +218,7 @@ A Dirt Path~
    This path leads east towards the main part of the village or west to a row of
 holding cells.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 ~
@@ -234,7 +234,7 @@ Barracks~
 chosen to fight for Mordecai's cause.  Two rows of beds run the length of the
 walls, both east and west, all with a matching trunk next to it.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D2
 ~
 ~
@@ -257,7 +257,7 @@ A Dirt Path~
    This path leads east to a crossing of paths (possibly the center of the
 village) and west toward some low buildings and a row od holding cells.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 ~
@@ -275,7 +275,7 @@ and disgusting.  You catch a faint odor breezing it's way from the north, and in
 looking in that direction, you see why.  To the north is a barn, while to the
 south is a huge tent set up on a hill.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -299,7 +299,7 @@ A Muddy Trail~
 make matters worse, it even is beginning to smell a bit.  A ways north of you is
 a hay barn, to the northeast and northwest are chicken coops.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -315,7 +315,7 @@ A Muddier Trail~
 holding a few chickens.  To the north is a hay barn, which seems to be stocked
 well.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -339,7 +339,7 @@ Chicken Coop~
 shit.  Little cluckers run around you pecking here and pecking there, generally
 being a nuisance.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 ~
@@ -351,7 +351,7 @@ Chicken Coop~
 chickens who seem to think you are the guy that's bringing the food.  By the
 way, what's that on the bottom of your shoe?  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D3
 ~
 ~
@@ -363,7 +363,7 @@ Hay Barn~
 the village.  Bales upon bales fill this tin roofed building, alomost to the
 rafters.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -380,7 +380,7 @@ Jareth can compare to this.  Stalls line the east wall, with a cow milling about
 in each one.  The floor os covered in fecal matter, obviously from the cows in
 the stalls.  Watch your step!  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -396,7 +396,7 @@ Pasture~
 graze here at this time.  Fenced in, this pasture's only exit is south into the
 Stinky Barn.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D2
 ~
 ~
@@ -408,7 +408,7 @@ A Dirt Trail~
 see another structure, a more permanent looking place.  To the north the trail
 gets very muddy.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -425,7 +425,7 @@ both to the east and west here.  To the east you see a wooden building, not a
 lodging, but maybe some sort of storage structure.  West the trail twists and
 turns, if it leads to anything, you cannot see what that might be.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -449,7 +449,7 @@ Food Tent~
 raised chair at the head of the long table looks down on all, this must
 obviously be Mordecai's seat of honor.  Currently, there is no one here eating.
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -463,7 +463,7 @@ animals hang above them, collecting flies and who knows what else.  An area near
 the rear of the building looks to be seignated as the prep area with a hand pump
 for water and many different kinds of spices and seasonings on shelves.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D3
 ~
 ~
@@ -474,7 +474,7 @@ A Twisty Turning Trail~
    This trail heads through some trees to an unknown destination, but generally
 in an easterly direction.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 ~
@@ -491,7 +491,7 @@ is directly south of you, but it doesn't appear as if you will be getting in any
 time soon, since the door is oak bound in iron, and no apparent windows from
 where you stand.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 ~
@@ -518,7 +518,7 @@ A Dirt Path~
 tents and huts the farther east you go, these must be the permanent residences
 of the village.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D1
 ~
 ~
@@ -533,7 +533,7 @@ A Dirt Trail~
    The trail heads east into the center of the village, to the north and south
 of you are tents, large enough to hold a family or at a few people.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D1
 ~
 ~
@@ -548,7 +548,7 @@ A Meeting of Two Trails~
    Here the two main trails in the village meet.  One of them heads west and the
 other runs north to south.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -656,7 +656,7 @@ Hut~
 family of four.  In this cramped 8x8 area, four cots and a large chest all
 occupy what little living area there was.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D1
 ~
 ~
@@ -667,7 +667,7 @@ The Trail Out of Town~
    This trail leads south into the wilderness, leaving the village behind.  To
 the north the trail leads into the main part of the village.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -690,7 +690,7 @@ The Trail Out of Town~
    This trail leads south into the wilderness, even now the way becomes a bit
 more choked with trees.  To the north you see the main part of the village.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -709,7 +709,7 @@ The Trail Out of Town~
    You are now at the outskirts of the village.  You may leave it to the south
 or go back into the main section to the north.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 3
 D0
 ~
 ~
@@ -721,7 +721,7 @@ A Dusty Trail~
 trail and another running west.  To the north there are some tents and huts and
 farther north, upon a hill, you see a few more permanent looking structures.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D0
 ~
 ~
@@ -743,7 +743,7 @@ S
 A Dusty Trail~
    The trail leads north to south, huts and tents spaced out at intervals.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -764,7 +764,7 @@ main buildings for this village, possibly even Mordecai's place of dwelling.
 South of you are the many huts and tents which serve as homes for Mordecai's
 people.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -789,7 +789,7 @@ the east.  It appears as if a temple or place of worship has been erected there,
 you may enter it to the east.  North of you are the main buildings for Mordecai,
 south are the many huts and tents of the village people.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -810,7 +810,7 @@ sloping peaked roof.  It appears that he fears none of his people, for the door
 to his home is wide open.  To the east you see another stone house, this one a
 bit smaller than Mordecai's, and west of you is yet another stone house.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 2
 D0
 ~
 ~
@@ -835,7 +835,7 @@ a place of worship by the people of the village.  Wooden benches serving as
 pughs have been set into side of the hill.  At the bottom of the basin, a stage
 with a podium has been erected, obviously for Mordecai and his sermons.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 3
 D3
 ~
 ~
@@ -847,7 +847,7 @@ Lieutenant Caspan's Home~
 granted this home in recognition of his extreme loyalty, and he doesn't appear
 at all pleased to see that you have invaded his sanctuary.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D3
 ~
 door~
@@ -913,7 +913,7 @@ Dark and Gloomy Tunnel~
    This is the end of the tunnel.  Above you, a faint light filters through
 cracks in a trap door.  
 ~
-254 0 0 0 0 0
+254 0 0 0 0 1
 D2
 ~
 ~

--- a/lib/world/wld/256.wld
+++ b/lib/world/wld/256.wld
@@ -18,7 +18,7 @@ Cobbled Street~
    The street continues with parks and lush, well-kept grass on either side.  
 To the north you see the Lord's Keep, to the south the city awaits.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 The street continues.~
 ~
@@ -177,7 +177,7 @@ bed, dark oak dresser, and a water basin for light washing.  A window set into
 the eastern wall offers a view of the Alquandon River and the northern reaches
 of Jareth.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D1
 ~
 ~
@@ -458,7 +458,7 @@ folk, be they Lord's guest or servant.  Trees dot the yard, all in full bloom,
 with a walk way made from red wood chips showing the way through the trees.  
 The path leads north, south and east, or you may enter the Keep to the west.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D0
 ~
 ~
@@ -483,7 +483,7 @@ folk, be they Lord's guest or servant.  Beautiful trees dot the yard, all im
 full bloom, with a walk way made from red wood chips showing you the way through
 the trees.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D0
 ~
 ~
@@ -524,7 +524,7 @@ the southwest is beautiful rolling hills.  Looking down on the courtyard, you
 see guards on break, sweethearts strolling hand in hand, and common folk out
 enjoying the sunshine.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -638,7 +638,7 @@ wish that you could stay in its embrace forever.  Such care is given to these
 rows of life, the keeper of this garden must be almost fanactical in their
 attention.  The winding path conitinues north and east from here.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 2
 D0
 ~
 ~
@@ -676,7 +676,7 @@ attention to detail the craftsmen put into it.  The statue sits in the center of
 a fountain upon a dias.  An inscription at the base reads; In loving memory The
 stone path continues to wend it's way north, south, and west.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 2
 D0
 ~
 ~
@@ -696,7 +696,7 @@ Lord's Garden~
 tended paths.  Flowers of all shapes, size and color abound.  The stone path
 meanders east, south, and north from here.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 2
 D0
 ~
 ~
@@ -720,7 +720,7 @@ perfection that gives those flaws their very reason for existance.  A winding
 stone path wends it's way through the garden, heading north and west, and a door
 to your south allows entrance back into the keep.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 2
 D0
 ~
 ~
@@ -820,7 +820,7 @@ folk, be they Lord's guest or servant.  Trees dot the yard, all in full bloom,
 with a walk way made from red wood chips showing you the way through the trees
 to the west and south.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D2
 ~
 ~
@@ -837,7 +837,7 @@ folk, be they Lord's guest or servant.  A small man made pool of clear blue
 water is here, stocked with imported golden fish.  A walk way made from red wood
 chips allows passage through the trees to the north, west and south.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D0
 ~
 ~
@@ -858,7 +858,7 @@ folk, be they Lord's guest or servant.  Trees dot the yard, all in full bloom,
 with a walk way made from red wood chips showing you the way through the trees
 west, north, and south.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D0
 ~
 ~
@@ -911,7 +911,7 @@ folk, be they Lord's guest or servant.  Beautiful trees dot the yard, all in
 full bloom.  A trail made from wood chips wends its way through the trees and
 around benches.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -934,7 +934,7 @@ of an octagon with long planks of flooring running outward from it like long
 spokes.  This looks as if it would be a good place to rest, if that is your
 inclination.  You may leave back into the courtyard to the west or north.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D0
 ~
 ~
@@ -950,7 +950,7 @@ Along the Parapet~
 guard towers.  This narrow stone walkway also provides a means for defense in
 times of war.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 A normal, wooden front door to a normal looking home.  It is
 nothing to write home about.
@@ -986,7 +986,7 @@ Lord's Garden~
 beautiful flowers wreath the wall, lending a timeless look to these already
 beautiful gardens.  The stone path continues east and south from here.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 2
 D1
 ~
 ~
@@ -1002,7 +1002,7 @@ Lord's Garden~
 you can see the top of the wall where the Lord's Guard patrols the parapet.  
 The winding stone path winds west and south here.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 2
 D2
 ~
 ~
@@ -1019,7 +1019,7 @@ folk, be they Lord's guest or servant.  Trees dot the yard, all in full bloom,
 with a walk way made from red wood chips showing you the way through the trees
 to the south and east, or you may enter the Keep to the west.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 4
 D1
 ~
 ~
@@ -1109,7 +1109,7 @@ Along the Parapet~
 walkway connects all the guard towers to one another and allows the Lord's Guard
 to defend their Lord's home.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1125,7 +1125,7 @@ Northeast Guard Tower~
 be seen through arrow holes in the north and east walls.  The parapet continues
 here to the west and south.  
 ~
-256 8 0 0 0 0
+256 8 0 0 0 1
 D2
 ~
 ~
@@ -1141,7 +1141,7 @@ Along the Parapet~
 walkway connects all the guard towers to one another and provides a defendable
 position for the Lord's Guard in times of war.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1159,7 +1159,7 @@ well-kept here, but not as many people lounge on it here as there were closer to
 the city.  Although not threatening in any way, the mood of this street seems to
 get a bit gloomier with each step you take toward the keep.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 The street continues.~
 ~
@@ -1176,7 +1176,7 @@ north here toward the keep.  Just north of here, you see that the street opens
 into a large court and turns to the east, where it enters the majestic halls of
 Lord's Keep.  South of you the city awaits.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 The street opens into a wide court.~
 ~
@@ -1192,7 +1192,7 @@ Lord's Court~
 visiting royalty.  Flags from all royal and noble houses fly bravely here,
 welcoming all to the splendor and majesty that is Jareth and Lord's Keep.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 The Keep looms close by.~
 ~
@@ -1213,7 +1213,7 @@ merriment or laughter, as is usually the case in the entryway of the Lord's
 Keep.  The Lord's Court lies west of you, while the twin guard towers flank your
 entry to the east into Lord's Keep.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 You may enter the Keep to the east.~
 ~
@@ -1256,7 +1256,7 @@ Along the Parapet~
 walkway connects all the guard towers at Lord's Keep.  It also provides a
 defndable position for the Lord's Guard in times of war.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1272,7 +1272,7 @@ Northwest Guard Tower~
 to fire arrows from this height at any would be aggressors in times of war.  
 The parapet continues along to the east and south from here.  
 ~
-256 8 0 0 0 0
+256 8 0 0 0 1
 D1
 ~
 ~
@@ -1305,7 +1305,7 @@ stronger yet.  The claw tracks in the stone stop abruptly here, where there
 seems to be a lot of unearthed dirt and stone around, heaped upon the floor.  
 You feel uneasy about this place.  
 ~
-256 585 0 0 0 0
+256 585 0 0 0 4
 D2
 ~
 ~
@@ -1331,7 +1331,7 @@ the entire perimeter of Lord's Keep, connecting all the guard towers.  It also
 supplies a defendable position for the Lord's Guard so that in times of war,
 they can protect their Lord and his home.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 ~
 ~
@@ -1348,7 +1348,7 @@ and uncomfortably warm, despite the closeness of the cave's entrance above you.
 There's a deep, musky odor in the air, and the giant claw marks continue
 downwards.  
 ~
-256 585 0 0 0 0
+256 585 0 0 0 4
 D0
 ~
 ~
@@ -1367,7 +1367,7 @@ drowning out everything else in the air and making it hard to breathe.
 Something in your gut begins squirming uncomfortably as you wonder what's
 ahead...  
 ~
-256 585 0 0 0 0
+256 585 0 0 0 4
 D0
 ~
 ~
@@ -1382,7 +1382,7 @@ Along the Parapet~
    You stand atop the parapet which runs east to west here.  This narrow walkway
 connects all the guard towers and provides a means for defense in times of war.
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 ~
 ~
@@ -1397,7 +1397,7 @@ Along the Parapet~
    The parapet runs north to south here, connecting the northeast guard tower
 and the southeast guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1412,7 +1412,7 @@ Along the Parapet~
    The parapet runs north to south here, connecting the northeast guard tower to
 the southeast guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1427,7 +1427,7 @@ Along the Parapet~
    The parapet runs north to south here, connecting the northeast guard tower to
 the southeast guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1442,7 +1442,7 @@ Along the Parapet~
    The parapet runs north to south here, connecting the northeast guard tower to
 the south east guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1457,7 +1457,7 @@ Along the Parapet~
    The parapet runs north to south here, connecting the northeast guard tower to
 the southeast guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1472,7 +1472,7 @@ Along the Parapet~
    The parapet runs north to south here, connecting the northeast guard tower
 and the southeast guard tower.  The southeast tower is directly south of you.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1488,7 +1488,7 @@ Southeast Guard Tower~
 Small chunks of stone are missing around the arrow slits, and many nicks and
 chunks are missing from the walls themselves.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1503,7 +1503,7 @@ Along the Parapet~
    The parpet runs east to west here, connecting the southeast guard tower to
 the southwest guard tower.  The southeast tower is directly east of you.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 ~
 ~
@@ -1518,7 +1518,7 @@ Along the Parapet~
    The parapet runs east to west here, connecting the southeastern guard tower
 to the southwestern guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 ~
 ~
@@ -1533,7 +1533,7 @@ Along the Parapet~
    The parapet runs east to west here, connecting the southeastern guard tower
 to the southwestern guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D1
 ~
 ~
@@ -1549,7 +1549,7 @@ Southwestern Guard Tower~
 are piled in one corner, and the remains of someone's lunch sits in another.  
 The parapet continues to the east and to the north from here.  
 ~
-256 8 0 0 0 0
+256 8 0 0 0 1
 D0
 ~
 ~
@@ -1565,7 +1565,7 @@ Along the Parapet~
 tower to the southern bridge guard tower.  The southeastern tower is directly
 south of you.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1580,7 +1580,7 @@ Along the Parapet~
    The parapet continues north to south here, connecting the southeastern guard
 tower to the south bridge guard tower.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~
@@ -1596,7 +1596,7 @@ Along the Parapet~
 to the south bridge guard tower.  The south bridge guard tower is directly north
 of you.  
 ~
-256 0 0 0 0 0
+256 0 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/257.wld
+++ b/lib/world/wld/257.wld
@@ -58,7 +58,7 @@ convenient, wouldn't you say?  Obviously, Maris the arms dealer thinks so, too,
 since his name is on both store fronts, proclaiming him the procurer of the
 finest armor and weapons in all of Jareth.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 Looking north you see Bourbon Street stretch off into the distance.
 ~
@@ -89,7 +89,7 @@ To the north you see The Bootery.  It appears that to the east, the avenue opens
 into a large square of some kind, while to the west Floris Avenue runs
 uninterrupted.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see the entrance to the Bootery.
 ~
@@ -118,7 +118,7 @@ To the north you may enter the Constabulary, the main office and station of
 Jareth's law enforcemnt professionals.  To the south begins Worship Way, the
 road leading to Jareth's famed Temple of All and None.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see the main office of the Constabulary.
 ~
@@ -165,7 +165,7 @@ you whatsoever.  To the north, Bourbon street continues to a dead end at the
 river bank, to the south Bourbon St.  Offers a slew of inns and taverns, and
 east and west Floris St lines itself with shops of every description.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 Bourbon St heads north from here.
 ~
@@ -194,7 +194,7 @@ north you see an entrance to Maris' Weapon Shop, and to your south lies an
 entrance to the Kitty-Kat Club, a local fine dining and entertainment
 establishment.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see the entrance to Maris' Weaponry.
 ~
@@ -225,7 +225,7 @@ building with worked stone, polished glass, and a great deal of copper trimming.
 To the south lies the entrance to the City Provisioner.  Any and all foodstuffs
 needed can be purchased in his shop.  East and west Floris Ave continues.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You may enter Jareth City Bank to the north.
 ~
@@ -337,7 +337,7 @@ River St~
 part of Jareth, south is a Constable's Outpost.  To the east is the Jeweler and
 to the west is the Mage's Guild.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 River St continues north.
 ~
@@ -368,7 +368,7 @@ in battle and damsels in distress waving white handkerchieves.  To the south is
 the northernmost wall of Grainy's Tavern, famous for their malt liquor and great
 entertainment.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 You see the City Proper.
 ~
@@ -394,7 +394,7 @@ from the look of the servers you can see through the windows, they serve more
 than bar burgers.  To the south are more shops of ill repute, and the town
 square opens up to the north.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see the City Proper.
 ~
@@ -453,7 +453,7 @@ hoping to make a sale.  Many shelves and racks stand all over this small shop
 waiting for your purchase.  The only available exit is to the north, leading to
 Floris Ave.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see Floris Ave.
 ~
@@ -496,7 +496,7 @@ large complex of flats.  To your east you see the western wall of of the
 bootery, where you may windowif so desired.  North is more of River St, which
 crosses the river further up, and south, River St crosses Floris St in a square.
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 River St runs north over the River Alquandon.
 ~
@@ -623,7 +623,7 @@ To your east you can peer through windows into the dining area of The Kitty-Kat
 club, and what you see is very enticing.  To your west is The Bloated Goat, a
 tavern for wayward adventurers.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see more of Bourbon St.
 ~
@@ -651,7 +651,7 @@ realize that there is a man standing directly before you.  How could you have
 missed him when you first walked in?  There is a large tree to your east which
 looks to be hollow, and the exit into the reception room is north.  
 ~
-257 540 0 0 0 0
+257 540 0 0 0 1
 D0
 ~
 ~
@@ -689,7 +689,7 @@ Floris Ave~
 east of here.  To the west, the City of Jareth awaits your pleasure.  North of
 you are the stables and south is the horse trader.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see the stables.
 ~
@@ -722,7 +722,7 @@ leave the city, you need only to move east, but to enter it may prove to be a
 bit more difficult.  Although Jareth does boast the title 'The Free City', it
 does have laws and they are enforced.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 ~
 ~
@@ -746,7 +746,7 @@ although in a rough part of town, has nevertheless perservered and even been
 able to thrive on a healthy chunk of business, or so it seems from the way the
 building is maintained.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 Bars bars bars and Bourbon St.
 ~
@@ -928,7 +928,7 @@ entertaining side of town.  To the south lies more of River St and what looks to
 be a number of shops, while to the east, Floris Ave offers a variety of shops
 which gradually give way to Jareth's city proper.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 River St runs north.
 ~
@@ -959,7 +959,7 @@ Twon Provisioner's small shop, while to the east, you see the westren wall of
 the Cartwright's shop.  North you can enter back into the hustle and bustle of
 regular city traffic on Floris Ave.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You may enter onto Floris Ave.
 ~
@@ -991,7 +991,7 @@ wandering adventurer.  North you see Floris Ave crossing River St and to the
 south, more shops and at a cul-de-sac where the road ends, a constable's
 outpost.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 River St continues north.
 ~
@@ -1022,7 +1022,7 @@ exchange weapons for better killing power, and stretch out in anticipation of a
 good fight.  You can't help but feel just a bit apprehensive as the group begins
 their approach.  
 ~
-257 1 0 0 0 0
+257 1 0 0 0 1
 D0
 ~
 ~
@@ -1040,7 +1040,7 @@ from a game of dice as you enter their territory, and they seem just a bit
 perturbed.  You can leave to the north or south, though neither choice seems all
 that inviting since both directions lead to more of what you're standing in now.
 ~
-257 1 0 0 0 0
+257 1 0 0 0 1
 D0
 The alley seems to get a bit brighter in that direction.
 ~
@@ -1059,7 +1059,7 @@ firepit in the center glows with hot coals.  It seems the tree itself serves as
 a chimney for the smoke from the hot coals, but you cannot be certain of that,
 because looking up into the tree, you see only darkness.  
 ~
-257 540 0 0 0 0
+257 540 0 0 0 1
 D3
 The alley leads west.
 ~
@@ -1072,7 +1072,7 @@ Floris Ave~
 of the city.  To the south is the Ranger Guild and to the north begins a
 cobblestone street which leads to Lord's Keep, home of the Lord of Jareth.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see the beginning of a Cobbled St.
 ~
@@ -1107,7 +1107,7 @@ numbers will prevent you from any advantages.  Your only chance to run like hell
 is now, and although a cowardly way to deal with the situation, it is
 recommended.  
 ~
-257 1 0 0 0 0
+257 1 0 0 0 1
 D1
 You see a nondescript brick wall.
 ~
@@ -1171,7 +1171,7 @@ mobile transportation enabling easier transport of larger and/or heavier loads
 over long distances.  North is the windowless wall of the city jail, which can
 be entered through the Constabulary to the northwest.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 Floris Ave runs east.
 ~
@@ -1195,7 +1195,7 @@ the river bank trying their luck while others relax on benches here enjoying the
 sights and sounds of the river.  You can enter the Bait & Tackle to the north or
 continue along the Boardwalk.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see the Bait and Tackle.
 ~
@@ -1218,7 +1218,7 @@ Floris Ave~
 dirtier and worn the closer you get to the west gate.  The paving is chipped,
 cracked, and in some places entirely gone, making the way somewhat bumpy.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 Floris Ave opens into a square.
 ~
@@ -1261,7 +1261,7 @@ Dalston the Wanderer began way back when he was still a strapping young man.
 It is said that now his children run the franchise, and the rumor is, they do a
 handsome business by being fair priced and always giving a quality product.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 You see the entrance to Dalston Outfitters.
 ~
@@ -1286,7 +1286,7 @@ get the hell out of here!  Three street toughs lounge against the alley wall,
 not moving, not talking, they just stare intently at you, as if waiting for some
 unseen signal.  
 ~
-257 1 0 0 0 0
+257 1 0 0 0 1
 D1
 ~
 ~
@@ -1308,7 +1308,7 @@ only head west.  Entering, however, may prove to be a bit more difficult.
 Although Jareth does boast the title Free City, it does have laws and they are
 enforced.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 Floris Ave runs east.
 ~
@@ -1343,7 +1343,7 @@ temple in all Dibrova where all races and classes are welcome and all forms of
 worship are embraced.  To the west you see the entrance to the blacksmith's and
 to the east is the pet shop.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 Worship Way runs north.
 ~
@@ -1375,7 +1375,7 @@ Boat House, where Vulcevic buys, sells, and repairs new and used boats.  West is
 the long tall building which houses flats for any who wish to lease, although
 the entrance is southwest.  Directly west only leads to a tall, windowless wall.
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 River St crosses a beautiful bridge to the north.
 ~
@@ -1401,7 +1401,7 @@ the east is Contracts, Ltd.  , where one may offer gold in return for the
 service of a professional assassin.  North is Worship Way and the many shops it
 offers.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 Worship Way runs north.
 ~
@@ -1449,7 +1449,7 @@ places making pass-through impossible.  You finally make it to the counter,
 behind which stands a clerk in a blue and green striped shirt with the Dalston
 logo emblazoned on the left breast.  The only exit is to the west.  
 ~
-257 8 0 0 0 0
+257 8 0 0 0 1
 D3
 You see the exit out to Bourbon St.
 ~
@@ -1482,7 +1482,7 @@ The Cryogenic Center~
 body-length canisters lined up against the walls.  The Reception is to the
 south.  
 ~
-257 8 0 0 0 0
+257 8 0 0 0 1
 D2
 The Reception is to the south.
 ~
@@ -1536,7 +1536,7 @@ here looking bored makes you think that either he is a complete moron to be here
 alone selling wares, or he could simply be the baddest sonofabitch (in disguise)
 that you've ever laid eyes on.  Take your pick.  The exit is west.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D3
 ~
 afghan secret door~
@@ -1646,7 +1646,7 @@ Cobbled St~
 east you may enter the stables, west is the windowless wall of the City Jail,
 and south is the hustle and bustle of Floris Ave.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 ~
 ~
@@ -1781,7 +1781,7 @@ work could only be the work of the fabled dwarven metalsmiths at Krat.  North of
 you the boardwalk begins, south is a square and most of Jareth, and you may
 enter the Alquandon River from a path leading down.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 River St runs north into the more 'upper class' section of Jareth.
 ~
@@ -1800,7 +1800,7 @@ district of Jareth.  South of you is the Bridge, north the road makes a turn to
 the west before a Constable's Ouptost, and east begins the Boardwalk along the
 river.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 River St runs north.
 ~
@@ -1823,7 +1823,7 @@ Ulath Way~
 Outpost is north of you, offering protection to any in need.  To the east Ulath
 Way continues with the city wall to the north and River St to the south.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see a Constable's Outpost.
 ~
@@ -1956,7 +1956,7 @@ Ulath Way~
    Ulath Way continues east and west along the north wall.  To the south, you
 may enter the Post Office.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 Ulath Way runs east.
 ~
@@ -1978,7 +1978,7 @@ Ulath Way~
    The road continues east and west along the north wall.  You may enter the
 Hospital to the south.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 Ulath Way runs east.
 ~
@@ -2000,7 +2000,7 @@ Ulath Way~
    The road continues east and west here along the north wall.  You may enter
 the Library to the south.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 Did I say you could look east, punk?
 ~
@@ -2023,7 +2023,7 @@ Ulath Way~
 see that Ulath Way makes a turn south, onto the boardwalk.  Directly south of
 you is the Training Hall.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D1
 Ulath Way runs east.
 ~
@@ -2045,7 +2045,7 @@ Boardwalk~
    You stand on a wooden road which runs south along the river bank.  To your
 west is Ulath Way, the northernmost road in Jareth.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D2
 The boardwalk runs south.
 ~
@@ -2063,7 +2063,7 @@ Boardwalk  ~
 the Karafa meet.  Fishermen line the bank, trying their luck, while others
 lounge on benches just enjoying the sights and sounds along the river.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 The boardwalk runs north
 ~
@@ -2082,7 +2082,7 @@ following the course of the river.  Fishermen line the river bank, trying their
 luck, while others just lounge on benches here, enjoying the sights and sounds
 of the river.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 The boardwalk runs north.
 ~
@@ -2100,7 +2100,7 @@ Boardwalk~
 or relaxation, as you will.  Les Franz, a well reknowned clothing shop in
 Jareth, is to your north.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see a clothing shop.
 ~
@@ -2125,7 +2125,7 @@ simply sit on benches here enjoying the sights and sounds of the river.  Loud
 music can be heard to the north, coming from a bar and to your west you may
 enter onto River St.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 You see a bar.
 ~
@@ -2147,7 +2147,7 @@ The Boardwalk~
    The boardwalk runs east and west along the riverbank.  There is a casino to
 the north and if one has the desire, on may try fishing here in the river.  
 ~
-257 0 0 0 0 0
+257 0 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/258.wld
+++ b/lib/world/wld/258.wld
@@ -8,7 +8,7 @@ probably made by some farmer or woodcutter who wanted easier access to his home.
 West you can see the walled city of Jareth, with majestic Lord's Keep sitting
 high atop the tallest hill, flying Jareth's standard proudly.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D0
 ~
 ~
@@ -55,7 +55,7 @@ A Shady Lane~
 way through the forest.  To the south, you may enter onto a well travelled road
 which runs east and west.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 1
 D0
 ~
 ~
@@ -71,7 +71,7 @@ A Well Travelled Road~
 carts abreast.  It is obvious from the amount of cart and wagon tracks you see
 that this is one of the main roads in XXXX.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D1
 You see a fairly large road leading towards a grand castle in the distance.
 ~
@@ -88,7 +88,7 @@ The City Entrance~
 uncharted and uncivilized lands, while to the west, the city awaits with all its
 splendor and majesty.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D1
 ~
 ~
@@ -104,7 +104,7 @@ A Shady Lane~
 South of you, the forest lightens and gives way to an open area, while to the
 north, the forest only gets deeper and darker.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 ~
 ~
@@ -126,7 +126,7 @@ Dirt Road~
 of the spires of the great city of Jareth.  A large house lies south of the
 path.  It looks very inviting.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 More light forest.
 ~
@@ -148,7 +148,7 @@ Dirt Road~
    The road runs east and west, with a branch going north as well.  The forest
 here seems more peaceful, more relaxing than the forest to the west.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 ~
 ~
@@ -169,7 +169,7 @@ Dirt Road~
    The road bends here, turning south.  This road seems to branch in many
 places, leading to many different realms of XXXX.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D2
 More and darker woods.
 ~
@@ -187,7 +187,7 @@ On a Wide Road~
 left, but it is easily passable just the same.  The forest around you seems
 alive with sound and motion.  It is really quite enjoyable.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 ~
 ~
@@ -203,7 +203,7 @@ Skirting the Clearing~
    The clearing still lies south of you, however the trail you follow leads away
 from clearing into deeper forest in an easterly direction.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 Huge grey mountains lie in this direction.
 ~
@@ -219,7 +219,7 @@ Edge of a Clearing~
    Just to the south of you, the forest opens up into a large grassy field, it's
 size undeterminable.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 Trees as far as the eye can see.
 ~
@@ -242,7 +242,7 @@ A Forest Trail~
 begin to hear the sound of animals making their way around you now that you are
 far away from any kind of civilization.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 The trail bends to the north.
 ~
@@ -278,7 +278,7 @@ A Dark and Gloomy Trail~
 hear the sound of running water to the south, possibly it leads to a place a bit
 more bright and cheery than this...?  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 There is a small clearing to the north.
 ~
@@ -315,7 +315,7 @@ You feel no menace to your surroundings whatsoever, as people walk by and wave
 cheerily at you.  Even all the little forest animals seem undisturbed and
 unafraid.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 A trail leading north-south.
 ~
@@ -333,7 +333,7 @@ On a Wide Road~
 has been neatly cleared away from the path, all manner of obstruction removed.
 You must be near a large city.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 More trees.
 ~
@@ -351,7 +351,7 @@ A Wide Bend~
 north for quite some distance.  The road seems to be very well-kept, which makes
 the travelling light and enjoyable.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 Many trees to the north.
 ~
@@ -369,7 +369,7 @@ A Wide Road~
 constantly, a flurry of activity now that you near XXXX.  In fact, you can begin
 to see the spires of the city to northeast.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 You can see a trail this way.
 ~
@@ -388,7 +388,7 @@ discernable, heads in a southerly direction.  To the north, a large forest
 begins.  Under your feet, the road is very hard-packed, as if many heavy feet
 pass this way regularly.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D0
 The forest gets lighter this way.
 ~
@@ -415,7 +415,7 @@ here, and the branches high above your head are so thick that they block out all
 direct sunlight.  While it is much too thick to go further east, you might be
 able to make your way though the forest to the south and west.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 ~
 ~
@@ -432,7 +432,7 @@ Old Stone Road~
 south.  Under the dirt and loose gravel you think you may be able to see some
 old stones which might have formed a well used road long ago.  
 ~
-258 1 0 0 0 0
+258 1 0 0 0 3
 D0
 Darkness...
 ~
@@ -455,7 +455,7 @@ Deep in the Forest~
 north, you catch glimpses of daylight.  To the east, you simply cannot see.  
 The trees are close and stifling.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D2
 ~
 ~
@@ -470,7 +470,7 @@ Grassy Field~
    This field seems to go on forever.  The trail continues north and south of
 here.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D0
 It appears to get much darker that direction.
 ~
@@ -516,7 +516,7 @@ the outdoor setting, hearing all the hustle and bustle of the city so near.
 You may head to the toll booths just east of here, or leave to the west into the
 wilderness.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 4
 D1
 ~
 ~
@@ -533,7 +533,7 @@ bridges leading into McGintey Cove.  The second, just east of you, looks just as
 busy as this one.  If you are not sure what to do next, possibly reading the
 sign on the outside of the booth may give you some idea.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 4
 D1
 ~
 ~
@@ -554,7 +554,7 @@ Take your pick, east or west.  There also seems to be some sort of park to the
 south, and to the north is an enormous stable, where alll steeds are kept, since
 none are allowed in the city.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 4
 D0
 ~
 ~
@@ -578,7 +578,7 @@ Eastern Toll Booth~
 seaport city, McGintey Cove.  If you are not quite sure how to gain access, just
 read the sign posted on the outer wall of the booth.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 4
 D1
 ~
 ~
@@ -626,7 +626,7 @@ same in terms of ease of travel.  There looks to be a bit more traffic to the
 north, however the trails leading east and west don't exactly look unused
 themselves.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 ~
 ~
@@ -646,7 +646,7 @@ Forest Road~
 almost alive from the way the playful breeze ruffles through their branches.  
 To the west the road splits to the north or continues its way west.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D3
 ~
 ~
@@ -657,7 +657,7 @@ A Wide Road~
    The road turns here heading east and south.  It seems to run quite some way
 to the east, however to the south it makes another turn.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 ~
 ~
@@ -674,7 +674,7 @@ seems to end!  It looks as if there may be a large cliff to your south, and from
 the smell of things, it must lead down to the sea.  To the north, the field runs
 for some distance until reaching a far-off forest.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D0
 ~
 ~
@@ -699,7 +699,7 @@ A Wide Road Near the City~
 a long, wide road which is filled with traffic at all ours of the day and night,
 it being the main route from XXXX to Jareth, the Free City.  
 ~
-258 1 0 0 0 0
+258 1 0 0 0 3
 D0
 ~
 ~
@@ -716,7 +716,7 @@ Just West of XXXX~
 way down a long, wide, and extremely well traveled road.  To the north you see a
 road made from aged cobblestones.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 1
 D0
 ~
 ~
@@ -733,7 +733,7 @@ A Tunnel In The Mountains~
 south the passage gets smaller and smaller.  A small alcove has been carved into
 the east wall.  
 ~
-258 1 0 0 0 0
+258 1 0 0 0 1
 D0
 The tunnel gets wider in this direction.
 ~
@@ -751,7 +751,7 @@ Diminishing Trail~
 vegetation is growing in on the trail, it is hard to tell.  It looks like the
 trail may head east and north from here.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 ~
 ~
@@ -772,7 +772,7 @@ Faint Trail~
 hope you are heading in the right direction, through openings in trees and such,
 so faint is the trail.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 ~
 ~
@@ -788,7 +788,7 @@ Nearing the Maze~
 It runs north and south of the path you stand on as far as your eyes can see in
 either direction.  Looks like a fellow could get lost in there pretty easily.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 ~
 ~
@@ -803,7 +803,7 @@ Old Stone Road~
    The road runs north and south still.  There is a large gate, closed, way off
 to the north, a large building just beyond the gates.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 ~
 ~
@@ -825,7 +825,7 @@ Cliff's Edge~
 looking south over the edge, you see the someone has made some crude steps that
 run along the wall of the cliff.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D1
 ~
 ~
@@ -845,7 +845,7 @@ Old Stone Road~
 what appears to be an old cathedral or church.  To the south the road heads back
 toward the main forest trail.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D0
 ~
 ~
@@ -862,7 +862,7 @@ and west from here.  Looking down and over the edge of the cliff, you find that
 you were right about what lies at the bottom of the cliff, the sea!  To the
 north the trail cuts through a huge grassy field.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 2
 D0
 ~
 ~
@@ -901,7 +901,7 @@ be hard pressed to follow it far.  A number of bushes are trampled on and some
 medium sized branches have been knocked down.  Obviously there has been a battle
 here rather recently.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 3
 D1
 ~
 ~
@@ -918,7 +918,7 @@ The Bar~
 the Innkeeper, but as of late, he only serves the few adventurers that manage to
 survive a trip through the forest.  
 ~
-258 40 0 0 0 0
+258 40 0 0 0 1
 D1
 ~
 ~
@@ -950,7 +950,7 @@ lead from the edge of the cliff to the city gate are the only entrance or exit
 from the town.  The trail also runs west far into the distance, skirting the
 southern edge of a huge field, which seems to go on forever.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 4
 D1
 ~
 ~
@@ -965,7 +965,7 @@ West of Town~
    The road runs east toward the huge seaport atop the plateau and west, topping
 a tall hill.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 4
 D1
 ~
 ~
@@ -982,7 +982,7 @@ A Dark and Gloomy Trail~
 by.  The birds you heard singing before are now quiet, all you can hear now is
 the sound of your own heavy breathing.  
 ~
-258 1 0 0 0 0
+258 1 0 0 0 3
 D0
 ~
 ~
@@ -1000,7 +1000,7 @@ surrounding you.  Trees brush against you on either side, feeling almost like
 they tug at your clothing.  The trail seems to continue north, although it seems
 much more sensible to go south.  
 ~
-258 1 0 0 0 0
+258 1 0 0 0 3
 D0
 The trail continues.
 ~
@@ -1017,7 +1017,7 @@ A Dead End Trail~
 any further exploration impossible.  It does seem strange, though, that a trail
 through the woods would end so abruptly.  
 ~
-258 1 0 0 0 0
+258 1 0 0 0 3
 D2
 ~
 ~
@@ -1029,7 +1029,7 @@ Entrance to the Maze~
 These walls run north and south from where you stand farther than you can see in
 either direction.  
 ~
-258 0 0 0 0 0
+258 0 0 0 0 4
 D3
 ~
 ~

--- a/lib/world/wld/259.wld
+++ b/lib/world/wld/259.wld
@@ -7,7 +7,7 @@ home in the midst of a forest such as this is beyond your comprehension.  Be
 careful on those steps, they are old and gray and appear to be rotted in many
 places.  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D0
 ~
 ~
@@ -44,7 +44,7 @@ Northeast Corner of the House~
 things that appear to be just about to fall into decay.  Listening for any sound
 from within the house reveals nothing, it appears that it may be deserted.  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D2
 ~
 ~
@@ -62,7 +62,7 @@ be deserted, however you still have the sensation of being watched.  You cannot
 see any sort of entrance from here, save the windows, and just in case someone
 does live here, it would be best to leave those windows intact.  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D0
 ~
 ~
@@ -82,7 +82,7 @@ Northwest Corner of the House~
 must be the doors that lead into the cellar.  No other entrances are visible to
 you from your current vantage point.  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D1
 ~
 ~
@@ -100,7 +100,7 @@ mostly chipped or worn away, leaving the doors a sort of dirty, brown and white
 and gray combo color.  Leaves blow past you, the breeze which carries them
 smelling of something familiar - almost like blood.  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D0
 ~
 ~
@@ -125,7 +125,7 @@ The walls of the house are of chipped wood siding, the paint that once covered
 the walls flaking and peeling,completely gone even in some places.  You cannot
 see any other ways into the house from here except the cellar.  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D0
 ~
 ~
@@ -143,7 +143,7 @@ type which is built for politicians or persons of extreme wealth.  It has long
 since fallen into decay - a crumbling, wasted ruin.  There could be no chance
 that anyone might still live here - could there?  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D1
 ~
 ~
@@ -165,7 +165,7 @@ enter into this place?  There is obviously no one living here anymore - at least
 it seems that way.  You hear a small skittering and a thump from within.  
 Probably just a rat or a squirrel.  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D0
 ~
 ~
@@ -646,7 +646,7 @@ way the entire structure sways beneath you as you climb to the front door, you
 wonder if maybe this wasn't a bad idea.  Better hurry up that front door and get
 inside before the whole thing collapses!  
 ~
-259 0 0 0 0 0
+259 0 0 0 0 3
 D4
 ~
 ~
@@ -662,7 +662,7 @@ Top of the Steps at the Front Door~
 creak and groan under your weight, swaying with every step that you take no
 matter how careful you are.  
 ~
-259 4 0 0 0 0
+259 4 0 0 0 3
 D3
 ~
 door~
@@ -770,7 +770,7 @@ It must be told that many an adventurer has turned from this cellar in fear,
 without humiliation or any feelings of inadequacies - this is not a pleasant
 place.  
 ~
-259 4 0 0 0 0
+259 4 0 0 0 3
 D4
 ~
 door~

--- a/lib/world/wld/260.wld
+++ b/lib/world/wld/260.wld
@@ -4,7 +4,7 @@ Grasslands~
 largest open area in all of Dibrova.  You can the propellor of a windmill high
 above the grass off to the northwest.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -45,7 +45,7 @@ Grasslands~
    Tall, brown grass grows all around you.  These grasslands must respresent the
 largest open area in all of Dibrova.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 ~
 ~
@@ -65,7 +65,7 @@ Grasslands~
 largest open area in all of Dibrova.  You can see what looks to be a tall
 windmill way off to the northeast.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 A small shadowy path leads away to the north.
 ~
@@ -91,7 +91,7 @@ Grasslands~
    Tall, brown grass grows all around you.  These grasslands must respresent the
 largest open area in all of Dibrova.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 A small shadowy path leads away to the north.
 ~
@@ -117,7 +117,7 @@ Grasslands~
 largest open area in all of Dibrova.  You see a windmill close by to the
 southwest.  The shimmering dome to the north envolopes the sacred city of XXXX.
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 The narrow trail leads east to a somewhat lighter part of the forest.
 ~
@@ -140,7 +140,7 @@ largest open area in all of Dibrova.  You can see the top of a windmill far off
 in the distance to the southeast.  The shimmering dome to the north envolopes
 the sacred city of XXXX.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 The narrow trail leads east to a somewhat lighter part of the forest.
 ~
@@ -161,7 +161,7 @@ Grasslands~
    Tall, brown grass grows all around you.  These grasslands must respresent the
 largest open area in all of Dibrova.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 A small shadowy path leads away to the north.
 ~
@@ -188,7 +188,7 @@ largest open area in all of Dibrova.  The shimmering dome to the north envolopes
 the sacred city of XXXX.  To the north through the dome you can see the southern
 wall protecting the city.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 ~
 ~
@@ -203,7 +203,7 @@ Grasslands~
    Tall, brown grass grows all around you.  These grasslands must respresent the
 largest open area in all of Dibrova.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 A small shadowy path leads away to the north.
 ~
@@ -224,7 +224,7 @@ Grasslands~
    Tall, brown grass grows all around you.  These grasslands must respresent the
 largest open area in all of Dibrova.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 A small shadowy path leads away to the north.
 ~
@@ -246,7 +246,7 @@ Grasslands~
 in the breeze.  You see the topmost section of windmill way far off to the
 northwest.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -272,7 +272,7 @@ Grasslands~
    The long blades of grass seem to go on forever, making long, graceful waves
 in the breeze.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 Grass.
 ~
@@ -293,7 +293,7 @@ Grasslands~
    The long blades of grass seem to go on forever, making long, graceful waves
 in the breeze.  You can see a windmill far off to the northeast.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -316,7 +316,7 @@ Grasslands~
    The long blades of grass seem to go on forever, making long, graceful waves
 in the breeze.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -343,7 +343,7 @@ in the breeze.  What looks to be a windmill lies far off to the southwest.  The
 shimmering dome to the north envolopes the sacred city of XXXX.  To the north
 through the dome you can see the southern wall protecting the city.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 ~
 ~
@@ -366,7 +366,7 @@ in the breeze.  You see the windmill directly southeast.  The shimmering dome to
 the north envelopes the entire city of XXXX.  Just to the north you can see the
 southern gate of the city.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 Grass.
 ~
@@ -388,7 +388,7 @@ Grasslands~
    The long blades of grass seem to go on forever, making long, graceful waves
 in the breeze.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -414,7 +414,7 @@ in the breeze.  The shimmering dome to the north envolopes the sacred city of
 XXXX.  To the north through the dome you can see the southern wall protecting
 the city.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 ~
 ~
@@ -435,7 +435,7 @@ Grasslands~
    The long blades of grass seem to go on forever, making long, graceful waves
 in the breeze.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -460,7 +460,7 @@ Grasslands~
    The long blades of grass seem to go on forever, making long, graceful waves
 in the breeze.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -485,7 +485,7 @@ Grasslands~
    Tufts of grass as high as your waist brush against you as you traverse this
 vast grassland area, which must be hundreds of miles in length.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -506,7 +506,7 @@ Grasslands~
 vast grassland area, which must be hundreds of miles in length.  To the east a
 small trail cuts it's way through the brush, almost unnoticeable .
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 ~
 ~
@@ -528,7 +528,7 @@ Grasslands~
 vast grassland area, which must be hundreds of miles in length.  You see a
 windmill far off the north.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands.
 ~
@@ -552,7 +552,7 @@ Grasslands~
    Tufts of grass as high as your waist brush against you as you traverse this
 vast grassland area, which must be hundreds of miles in length.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands.
 ~
@@ -576,7 +576,7 @@ vast grassland area, which must be hundreds of miles in length.  The shimmering
 dome to the north envolopes the sacred city of XXXX.  To the north through the
 dome you can see the southern wall protecting the city.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D3
 More grass.
 ~
@@ -590,7 +590,7 @@ vast grassland area, which must be hundreds of miles in length.  You see a
 windmill directly south of you.  The shimmering dome to the north envolopes the
 sacred city of XXXX.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 ~
 ~
@@ -610,7 +610,7 @@ Grasslands~
    Tufts of grass as high as your waist brush against you as you traverse this
 vast grassland area, which must be hundreds of miles in length.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands.
 ~
@@ -636,7 +636,7 @@ Grasslands~
 vast grassland area, which must be hundreds of miles in length.  The shimmering
 dome to the north envolopes the sacred city of XXXX.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D1
 ~
 ~
@@ -656,7 +656,7 @@ Grasslands~
    Tufts of grass as high as your waist brush against you as you traverse this
 vast grassland area, which must be hundreds of miles in length.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands.
 ~
@@ -682,7 +682,7 @@ Grasslands~
    Tufts of grass as high as your waist brush against you as you traverse this
 vast grassland area, which must be hundreds of miles in length.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands.
 ~
@@ -708,7 +708,7 @@ Grasslands~
 sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -733,7 +733,7 @@ Grasslands~
 sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -782,7 +782,7 @@ Grasslands~
 sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -807,7 +807,7 @@ sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  A windmill lies directly
 west of you.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -832,7 +832,7 @@ sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  A windmill lies far off to
 the east from here.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -858,7 +858,7 @@ Grasslands~
 sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -883,7 +883,7 @@ Grasslands~
 sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -904,7 +904,7 @@ Grasslands~
 sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -930,7 +930,7 @@ Grasslands~
 sneak up on someone, if that were something you wanted to do.  Now that you
 think about it, it may be wise to watch your step.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -955,7 +955,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -978,7 +978,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1001,7 +1001,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1024,7 +1024,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1048,7 +1048,7 @@ Grasslands~
 north, east and west.  To the south, you cannot see their end.  A windmill lies
 far off to the west from here.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1068,7 +1068,7 @@ Grasslands~
 north, east and west.  To the south, you cannot see their end.  The windmill
 lies directly east from you.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1091,7 +1091,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1114,7 +1114,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1137,7 +1137,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1156,7 +1156,7 @@ Grasslands~
    All the way to the horizon the grasslands stretch, ending in forest to the
 north, east and west.  To the south, you cannot see their end.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1175,7 +1175,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1200,7 +1200,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1220,7 +1220,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1245,7 +1245,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1266,7 +1266,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1283,7 +1283,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1304,7 +1304,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1329,7 +1329,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1354,7 +1354,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1379,7 +1379,7 @@ Grasslands~
    You have any direction which you can choose to travel - any way that you wish
 to go is wide open grasslands.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 Grasslands - for a looonnngg way.
 ~
@@ -1400,7 +1400,7 @@ Grasslands~
    A more peaceful setting could not be imagined.  The breeze blowing through
 this beautiful field, birds singing.  The calm before the storm, eh?  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1423,7 +1423,7 @@ Grasslands~
    A more peaceful setting could not be imagined.  The breeze blowing through
 this beautiful field, birds singing.  The calm before the storm, eh?  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1442,7 +1442,7 @@ Grasslands~
    A more peaceful setting could not be imagined.  The breeze blowing through
 this beautiful field, birds singing.  The calm before the storm, eh?  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1465,7 +1465,7 @@ Grasslands~
    A more peaceful setting could not be imagined.  The breeze blowing through
 this beautiful field, birds singing.  The calm before the storm, eh?  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1485,7 +1485,7 @@ Grasslands~
 this beautiful field, birds singing.  The calm before the storm, eh?  The
 windmill lies directly northwest from here.  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1509,7 +1509,7 @@ Grasslands~
 this beautiful field, birds singing.  The calm before the storm, eh?  There is a
 windmill way off to the northeast.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 3
 D0
 ~
 ~
@@ -1532,7 +1532,7 @@ Grasslands~
    A more peaceful setting could not be imagined.  The breeze blowing through
 this beautiful field, birds singing.  The calm before the storm, eh?  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1552,7 +1552,7 @@ Grasslands~
 this beautiful field, birds singing.  The calm before the storm, eh?  A small
 path leads west into the woods.  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1575,7 +1575,7 @@ Grasslands~
    A more peaceful setting could not be imagined.  The breeze blowing through
 this beautiful field, birds singing.  The calm before the storm, eh?  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1594,7 +1594,7 @@ Grasslands~
    A more peaceful setting could not be imagined.  The breeze blowing through
 this beautiful field, birds singing.  The calm before the storm, eh?  
 ~
-260 9 0 0 0 0
+260 9 0 0 0 3
 D0
 ~
 ~
@@ -1618,7 +1618,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1642,7 +1642,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1662,7 +1662,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1686,7 +1686,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1706,7 +1706,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  A windmill lies way off to the northwest.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1730,7 +1730,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  The windmill lies directly northeast of you.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1754,7 +1754,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1774,7 +1774,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1798,7 +1798,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1822,7 +1822,7 @@ Grasslands~
 Windmill far in the distance and the forest trees which surround the area on
 three sides.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1841,7 +1841,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1864,7 +1864,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1879,7 +1879,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1902,7 +1902,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1917,7 +1917,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D2
 ~
 ~
@@ -1932,7 +1932,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  The windmill lies directly north of you.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1955,7 +1955,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1974,7 +1974,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -1997,7 +1997,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -2020,7 +2020,7 @@ Grasslands~
    Brown grass is everywhere, all around you.  You may go in any direction you
 please.  
 ~
-260 64 0 0 0 0
+260 64 0 0 0 2
 D0
 ~
 ~
@@ -2038,7 +2038,7 @@ thought was a large field is actually tree tops!  The path continues east,
 becoming more and more enclosed as you move in that direction.  To the west the
 path heads uphill into a huge grassy field.  
 ~
-260 0 0 0 0 0
+260 0 0 0 0 3
 D1
 ~
 ~
@@ -2054,7 +2054,7 @@ Obscure Path~
 Just east of you, you think you may see some sort of break in the trees, as the
 forest you entered into seems to have come upon you quite suddenly.  
 ~
-260 0 0 0 0 0
+260 0 0 0 0 3
 D3
 ~
 ~

--- a/lib/world/wld/261.wld
+++ b/lib/world/wld/261.wld
@@ -533,7 +533,7 @@ size of three men side by side rise from the forest floor, towering high above
 you.  Birds sing, branches creak, and you have to wonder...  -What the Hell am I
 doing here?!  -
 ~
-261 0 0 0 0 0
+261 0 0 0 0 3
 S
 T 26100
 #26122
@@ -892,7 +892,7 @@ Entrance to a Large Home~
 definately large by most standards.  The door lies directly west of you or you
 may head back along the path through the forest to the grasslands.  
 ~
-261 0 0 0 0 0
+261 0 0 0 0 1
 D1
 ~
 ~
@@ -908,7 +908,7 @@ A Twisty Path~
 married couple who used to be Head Enchanter and Enchantress to the Lord at
 Lord's Keep, maybe this is it...  The path also heads north through the forest.
 ~
-261 0 0 0 0 0
+261 0 0 0 0 3
 D0
 ~
 ~
@@ -924,7 +924,7 @@ Twisty Path~
 anywhere.  There are a great many leaves strewn in the path, giving you the
 impression that not many people travel this way very often.  
 ~
-261 0 0 0 0 0
+261 0 0 0 0 3
 D1
 ~
 ~
@@ -939,7 +939,7 @@ Start of a Twisty Path~
    You stand at the edge of the field and the edge of a forest.  The way to the
 forest is west, and the grasslands spread out to your east.  
 ~
-261 0 0 0 0 0
+261 0 0 0 0 3
 D1
 ~
 ~

--- a/lib/world/wld/262.wld
+++ b/lib/world/wld/262.wld
@@ -20,7 +20,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D1
 The woods continue to the east.
 ~
@@ -39,7 +39,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continues to the south.
 ~
@@ -60,7 +60,7 @@ luck in not being caught in the tangled boughs and matted twigs beneath.  To the
 north you can see the spires of a huge castle rising high above the forest
 around you.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 ~
 ~
@@ -78,7 +78,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D1
 The woods continue to the east.
 ~
@@ -97,7 +97,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -126,7 +126,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -155,7 +155,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -174,7 +174,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -198,7 +198,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -222,7 +222,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -251,7 +251,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -280,7 +280,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -309,7 +309,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -328,7 +328,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -352,7 +352,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -381,7 +381,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -410,7 +410,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -434,7 +434,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -453,7 +453,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -477,7 +477,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -501,7 +501,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D1
 The woods continue to the east.
 ~
@@ -520,7 +520,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D1
 The woods continue to the east.
 ~
@@ -544,7 +544,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D1
 The woods continue to the east.
 ~
@@ -563,7 +563,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continues to the north.
 ~
@@ -592,7 +592,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continues to the north.
 ~
@@ -621,7 +621,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -645,7 +645,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D1
 The woods continue to the east.
 ~
@@ -664,7 +664,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -693,7 +693,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -722,7 +722,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -751,7 +751,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -780,7 +780,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -799,7 +799,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -818,7 +818,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -842,7 +842,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -871,7 +871,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -900,7 +900,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -929,7 +929,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -958,7 +958,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -977,7 +977,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -996,7 +996,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1020,7 +1020,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1049,7 +1049,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1073,7 +1073,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -1092,7 +1092,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1121,7 +1121,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1150,7 +1150,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -1169,7 +1169,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1193,7 +1193,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -1212,7 +1212,7 @@ the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  A
 large keep lies just west of here.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1231,7 +1231,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1260,7 +1260,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1289,7 +1289,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1318,7 +1318,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D2
 The woods continue to the south.
 ~
@@ -1337,7 +1337,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1351,7 +1351,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1370,7 +1370,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1389,7 +1389,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1413,7 +1413,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1437,7 +1437,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~
@@ -1461,7 +1461,7 @@ side, a sort of darkend green glimmer.  Ocassionally a slender beam of sun has
 the luck to slip in through some opening in the leaves far above, and still more
 luck in not being caught in the tangled boughs and matted twigs beneath.  
 ~
-262 32768 0 0 0 0
+262 32768 0 0 0 3
 D0
 The woods continue to the north.
 ~

--- a/lib/world/wld/263.wld
+++ b/lib/world/wld/263.wld
@@ -4,7 +4,7 @@ Outside the West Gate~
 equality.  The Western Road runs west from here into farmlands.  To the north is
 a deep, tangled forest.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -30,7 +30,7 @@ Western Road~
    Just west of you is a fork in the road, which splits northwest and southwest
 from the main road.  East of you is the entrance to the city of Jareth.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -77,7 +77,7 @@ Western Road~
 from here, you see the gates to the city of Jareth.  To the south begins a long,
 dusty trail which heads out into a very desolate looking plains area.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -96,7 +96,7 @@ on their mind would be that they might be waylaid or attacked.  Northeast from
 here, you see the gates to Jareth, west the road continues toward a large lake
 and the many farms of this area.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -111,7 +111,7 @@ Western Road~
    The road runs east and west from here.  To the north, a small farm lies
 nestled in a large pasture.  From the smell of it, it must be a dairy farm.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -176,7 +176,7 @@ Western Road~
 the west, you see a large lake, and to the south a dirt driveway leads to a
 large farmhouse.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -270,7 +270,7 @@ if Farmer Girschwyn finds you here, he may get the wrong idea.  To the east is a
 huge field of corn which you may enter into.  Be careful, though, it looks like
 it would be pretty easy to get lost in there.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -286,7 +286,7 @@ Pasture~
 graze or sleep everywhere and anywhere.  To the north is the dirt court, and
 east is more field.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -319,7 +319,7 @@ Western Road~
 west is the shore of a huge lake.  The path seems to split, heading around the
 lake in both directions.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -335,7 +335,7 @@ Lake's Edge~
 heading north, one heading south.  The trail also heads east through the fertile
 farmlands of Jareth.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -354,7 +354,7 @@ Lake's Edge~
    The road heads west and north from here, around the lake.  You see a farm to
 the southwest.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -370,7 +370,7 @@ Lake's Edge~
 into the lake.  Across the road from the dock is farmstead, with rows upon rows
 of wheat and corn growing in the fields just south of here.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -386,7 +386,7 @@ Lake's Edge at the Dock~
 fishing.  Just south of you is a moderate-sized farmstead.  The road runs east
 and west from here.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -410,7 +410,7 @@ Dock~
 comfortable.  Doesn't seem to bother Erik, though, the little guy seems
 perfectly content here, swaying on this old construct.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D2
 ~
 ~
@@ -423,7 +423,7 @@ needed to plow, plant, mow the fields which this farm is responsible for
 maintaining.  South and east of you are wheat and corn fields, respectively.  
 Just west of you is a house.  The road is just north of you.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -446,7 +446,7 @@ Corn Field~
    Row upon row of corn surrounds you.  The leaves tickle you as you brush by
 them, the stalks swaying gently with the breeze.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D3
 ~
 ~
@@ -458,7 +458,7 @@ Wheat Field~
 ground, strewn with mud and leaves, looks as if it has seen some large machinery
 come through lately.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -481,7 +481,7 @@ Lake's Edge~
    The road runs east and west from here, around the lake.  A farm lies just
 southeast of you, to the northeast you see a dock which leads out into the lake.
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -496,7 +496,7 @@ Lake's Edge~
    The road turns here, heading north and east around the lake.  Just north of
 here, the road splits off from the lake and heads west into the farmlands.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -511,7 +511,7 @@ Lake's Edge~
    The road splits here, heading north and south around the lake, but also
 heading off west into more farmland.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -531,7 +531,7 @@ Lake's Edge~
 the south you see that the road splits away from it's course around the lake and
 heads west out into farmland.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -548,7 +548,7 @@ continue north and west from here.  Strangely enough, a path seems to lead right
 into the water, and it looks as if the path continues on into the depths of the
 lake.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -563,7 +563,7 @@ Lake's Edge~
    The road turns again, running along the lake's edge.  You may head east or
 south from your current locale.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -579,7 +579,7 @@ Lake's Edge~
 You think you may see a small path leading north throught the high grass and
 into the forest, but you can't be sure.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -600,7 +600,7 @@ along seems quite large, and across on the opposite shore, you think you may see
 a bit of aqueduct work.  This lake is most probably the water source for most of
 the farmers in the area.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -617,7 +617,7 @@ lake's edge demands.  You may head west or south from here.  To the south, you
 see that the road splits away from it's travels around the lake and heads east
 into the country.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D2
 ~
 ~
@@ -634,7 +634,7 @@ region.  East of you, the road splits, following around a large lake's edge.
 To the north, you see the last farmstead on this western edge of Jareth's City
 Limits.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -655,7 +655,7 @@ seen better days, assuredly.  The yard is littered with debris, some of which
 you probably should not even try guessing it's origin, and the smell - whoa.  
 There is a barn north of here, it's rickety walls barely standing.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -672,7 +672,7 @@ black suede shoes if you did.  The amount of excrement piled everywhere in this
 barn makes keeping your feet clean an impossibility.  West of you is a pig yard
 and east is the chicken yard.  South exits into open, clean air.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -692,7 +692,7 @@ Chicken Yard~
 almost trip and fall.  All the chickens cluster around you, waiting for you to
 throw them some seeds.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D3
 ~
 ~
@@ -704,7 +704,7 @@ Pig Wallows~
 The pigs here roll on their back in shallow puddles, looking as pigs in...  
 Well, you know.  Kind of makes you glad you never decided to be a farmer, eh?  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -717,7 +717,7 @@ entered, leading eventually the city itself.  West of you the unknown begins.
 The land on either side of the road seems to be getting a bit more soft and wet,
 as if you may be coming into a swampy region.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -736,7 +736,7 @@ Western Road~
    The road still heads to the east and west from here, however there is a small
 path leading through some twisty, gnarled trees to your north.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D0
 ~
 ~
@@ -757,7 +757,7 @@ farmsteads dotting the countryside, where the land flattens out and allows for
 that sort of work to be done.  The way west leads toward the ever-present Dragon
 Tooth Mountains, which seem to surround this whole land.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 2
 D1
 ~
 ~
@@ -774,7 +774,7 @@ to be more prevalent the farther north you go.  The way becomes darker from the
 trees that seem to close in around the path and your senses scream at you to go
 back.  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 3
 D2
 ~
 ~
@@ -805,7 +805,7 @@ S
 Gnarled and Twisty Path~
    This zone not yet complete - come again soon!  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 3
 D2
 ~
 ~
@@ -818,7 +818,7 @@ south, becoming completely enclosed by trees and tall growth.  It heads north
 deeper into the dark forest, but a word to the wise, south looks much more safe
 and inviting.  
 ~
-263 65 0 0 0 0
+263 65 0 0 0 3
 D2
 ~
 ~
@@ -834,7 +834,7 @@ that ahead lies trouble, pain, and possibly death.  The lake and the farmlands
 south of you begin to look very friendly through the trees, now.  This is your
 chance to turn back...  
 ~
-263 0 0 0 0 0
+263 0 0 0 0 3
 D2
 ~
 ~

--- a/lib/world/wld/264.wld
+++ b/lib/world/wld/264.wld
@@ -4,7 +4,7 @@ On a Forest Slope~
 forest which at this point is not in sight.  To the east is a more level section
 of forest where you at least have a better fighting chance.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -41,7 +41,7 @@ On a Forest Slope~
 even is one at the bottom of this hill.  You realize that although you haven't
 been in the forest that long, you are hopelessly lost.  
 ~
-264 0 0 0 0 0
+264 0 0 0 0 3
 D0
 ~
 ~
@@ -65,7 +65,7 @@ In a Quiet Forest~
 and strength - it's immensity.  Not a bird calls, not a creature skitters, just
 the wind, creaking through the dark branches overhead.  
 ~
-264 0 0 0 0 0
+264 0 0 0 0 3
 D0
 ~
 ~
@@ -89,7 +89,7 @@ In a Quiet Forest~
 and strength - it's immensity.  Not a bird calls, not a creature skitters, just
 the wind, creaking through the dark branches overhead.  
 ~
-264 0 0 0 0 0
+264 0 0 0 0 3
 D0
 ~
 ~
@@ -113,7 +113,7 @@ Downhill in a Forest~
 distance down as well.  All around you, the darkness prohibits any kind of sight
 distance.  Makes it kind of spooky.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -138,7 +138,7 @@ level part of the forest you could hear the occassional skitter of a squirrel,
 the squak of a buzzard, even the cry of a Demon Dog was better than this
 complete silence.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -163,7 +163,7 @@ level part of the forest you could hear the occassional skitter of a squirrel,
 the squak of a buzzard, even the cry of a Demon Dog was better than this
 complete silence.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -188,7 +188,7 @@ level part of the forest you could hear the occassional skitter of a squirrel,
 the squak of a buzzard, even the cry of a Demon Dog was better than this
 complete silence.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -214,7 +214,7 @@ the forest roof and beyond, still as thick as four men at that point.  You hold
 your light a little closer to the tree and see that it has some sort of markings
 on it.  Off to the west, you can see some sort of glow.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -246,7 +246,7 @@ one which looks to be the oldest in this forest, if size is any indicator.  You
 look down into the vines.  It almost looks as if something is moving down there.
 In fact, it appears that something is glowing to the south.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -271,7 +271,7 @@ further travel in any direction.  Down in the ditch, you see something small and
 shiny, although from here you cannot see exactly what the item is.  Is that some
 sort of glow to the east?  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -296,7 +296,7 @@ dig into the soil of the forest feeding out it's life.  Shining your light
 ahead, you think you may see furtive movement behind one of the vines.  You may
 even see some kind of light off to the north.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -319,7 +319,7 @@ Heading Downhill~
    The forest still heads downhill into the fell, the depths of which contain
 only the devil knows what.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -344,7 +344,7 @@ no one home right now, or if there is anyone home, they are being very quiet and
 very still.  Looking around you, you realize that you may be just a little lost.
 Make that a lot lost.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -368,7 +368,7 @@ Lost in the Forest~
 gives some sort of reminder to you where you are, but all you can see in any
 direction is dark, twisted trees and the hill, always leading down.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -392,7 +392,7 @@ A Faint Path~
 floor of this forest, you think you see some sort of trail.  It appears that the
 trail leads east and west, toward something...  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -417,7 +417,7 @@ sort of life.  Although the greenery is only needles, it still gives you pause
 and makes you glad that at least in one part of this awful place, something
 lives in accordance with nature.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -443,7 +443,7 @@ the sun is still shining, where you do not have to fear for your life every step
 of the way.  It is easy to forget there are still places like that - at least
 while you are down here.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -468,7 +468,7 @@ if you could get up on the boulder, you might get a good view of the way
 downhill.  The only other option is to just continue down hill and hope for the
 best.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -493,7 +493,7 @@ your head.  You notice that although they are peeling quite badly, the peeling
 seems to have been scuffed or pulled off in some spots.  What kind of animal
 could climb vines that high and that thin?  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -517,7 +517,7 @@ A Quiet Section of the Forest~
 easier feeling than the parts that were noisy.  In fact, it creeps you out.  
 Where are all the animals?  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -541,7 +541,7 @@ Near a Rabbit Hole~
 know.  Seems strange that a rabbit could survive in a place like this, with the
 lack of greenery anywhere.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -566,7 +566,7 @@ The huge trunk is blasted in half about twenty feet above your head.  The tree
 was so large that when it fell, one of it's branches fell to make a natural
 bridge across a large ditch.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -590,7 +590,7 @@ Leaf Strewn Slope~
 every inch of the way, making it impossible for you to move quietly at all.  So
 much for remaining inconspicuous.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -614,7 +614,7 @@ Leaf Strewn Slope~
 every inch of the way, making it impossible for you to move quietly at all.  So
 much for remaining inconspicuous.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -638,7 +638,7 @@ An Abandoned Campsite on the Hillside~
 have at one time been a firepit for someone or a group of someones.  Or a group
 of its.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -664,7 +664,7 @@ first place.  Most people with some shred of common sense wouldn't even have
 given it a second thought when they saw those rungs in the stone, they would've
 turned right around.  Maybe you should've, too.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -690,7 +690,7 @@ first place.  Most people with some shred of common sense wouldn't even have
 given it a second thought when they saw those rungs in the stone, they would've
 turned right around.  Maybe you should've, too.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -714,7 +714,7 @@ Heading Down a Leaf Strewn Slope~
 valley.  Whatever is down there, it can't be all that appealing, having to hide
 away like this from the rest of the world.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -738,7 +738,7 @@ On a Hill in the Forest~
 valley.  Whatever is down there, it can't be all that appealing, having to hide
 away like this from the rest of the world.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -766,7 +766,7 @@ be considered meager at best out in the world above, here it seems to burn with
 a fierce light, one that makes you squint.  You see that all along the lane
 there are similiar lanterns on posts as well.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 3
 D0
 ~
 ~
@@ -787,7 +787,7 @@ along the street, but try as you might, you cannot see a single business or
 tavern of any sort.  Strange that a village, even one in the middle of nowhere,
 would not have an inn or something.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -807,7 +807,7 @@ Voce Lane~
 There is one, in fact, just east of you now.  To the north is a small bit of the
 lane that leads back out into the forest and back up the hill.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -827,7 +827,7 @@ Voce Lane~
 sort of folk could live in such seclusion.  You think you may hear a bit of
 singing off to the southwest.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -844,7 +844,7 @@ building you have seen thus far in this village.  The singing you have been
 hearing comes from that building, or at least from that general direction.  The
 road runs north and south from you as well.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -865,7 +865,7 @@ comes from the northwest.  It would be quite a beautiful sound were it not
 coming from somewhere in this dark and gloomy village deep in this dark and
 sinister forest.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -881,7 +881,7 @@ Voce Lane~
 To the north the lane runs through the center of the village, south the lane
 leads out into the forest, sloping upward out of this hollow.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -903,7 +903,7 @@ ahead into the village and notice, to your alarm, that there seems to be no inn
 or tavern of any kind.  Strange that a village, even a small one like this,
 would have no place to rest.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -926,7 +926,7 @@ at best, seems to blaze with light down here in the darkest realms of the
 forest.  You may climb back up the slope or investigate this small forest
 village.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~
@@ -1316,7 +1316,7 @@ To the northwest there is another large building of some sort, it almost looks
 to be a temple itself.  Voce Lane, the main street through the village, is just
 east of you.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D1
 ~
 ~
@@ -1335,7 +1335,7 @@ evil forest, almost get killed, search their way into this village through the
 hollow, and then start singing?  Maybe it would be best not to open those doors,
 after all.  
 ~
-264 1 0 0 0 0
+264 1 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/265.wld
+++ b/lib/world/wld/265.wld
@@ -4,7 +4,7 @@ Steps Leading Down to the Sea~
 top of the steps looms, while below you, the steps continue for what seems an
 eternity.  
 ~
-265 0 0 0 0 5
+265 0 0 0 0 0
 D4
 ~
 ~
@@ -32,7 +32,7 @@ Down the Cliff-Face~
 depending on the way you're heading.  It looks as if there may be some sort of
 cave down from here.  
 ~
-265 0 0 0 0 5
+265 0 0 0 0 0
 D4
 ~
 ~
@@ -49,7 +49,7 @@ now.  There appears to be an opening in the rock to your east.  Inside you can
 only see darkness, so it is possible that it is simply a natural fissure, but
 then again, who knows?  
 ~
-265 0 0 0 0 5
+265 0 0 0 0 0
 D1
 ~
 ~
@@ -69,7 +69,7 @@ On the Steps~
 as a breeze ruffles your clothing.  You begin to feel a bit better about your
 day - the sea can do that to a person.  
 ~
-265 0 0 0 0 5
+265 0 0 0 0 0
 D4
 ~
 ~
@@ -84,7 +84,7 @@ The Base of the Steps~
    You stand at the bottom of a set of steps cut into the face of the cliff
 here.  The beach runs along east to west here as far as you can see.  
 ~
-265 0 0 0 0 5
+265 0 0 0 0 0
 D1
 ~
 ~
@@ -600,7 +600,7 @@ In the Kracken's Den~
 not just in a small spot, ALL of the water is moving from some kind of monstrous
 movement under the water.  
 ~
-265 0 0 0 0 6
+265 0 0 0 0 0
 D2
 ~
 ~

--- a/lib/world/wld/266.wld
+++ b/lib/world/wld/266.wld
@@ -155,7 +155,7 @@ your south, the forest growing right up to the edge and up the edge in some
 spots.  There is a set of rungs grooved into the cliff face here.  It looks as
 if you may be able to climb up!  
 ~
-266 5 0 0 0 0
+266 5 0 0 0 3
 D0
 ~
 ~
@@ -180,7 +180,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -205,7 +205,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -230,7 +230,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -255,7 +255,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -280,7 +280,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -305,7 +305,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -330,7 +330,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -355,7 +355,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -380,7 +380,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -405,7 +405,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -430,7 +430,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -455,7 +455,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -482,7 +482,7 @@ the corner of your eye.  Always just out of sight.  The cliff face runs along to
 your south, the forest growing right up to the edge and up the edge in some
 spots.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -505,7 +505,7 @@ the corner of your eye.  Always just out of sight.  The cliff face runs along to
 your south, the forest growing right up to the edge and up the edge in some
 spots.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -526,7 +526,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -551,7 +551,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -576,7 +576,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -601,7 +601,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -626,7 +626,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -651,7 +651,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -676,7 +676,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -702,7 +702,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  Off to the east is a deep
 hollow, dark and foreboding.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -723,7 +723,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -748,7 +748,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -773,7 +773,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -798,7 +798,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 0 0 0 0 0
+266 0 0 0 0 3
 D0
 ~
 ~
@@ -826,7 +826,7 @@ your south, the forest growing right up to the edge and up the edge in some
 spots.  To the east there is some sort of break in the forest, maybe a clearing
 or something, although it doesn't look like it gets any lighter...  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -849,7 +849,7 @@ the corner of your eye.  Always just out of sight.  To the south is a strange
 opening in the trees, almost as if it lead to a meadow or field of some sort,
 but it couldn't be, because it is still just as dark as ever in that direction.
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -874,7 +874,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -899,7 +899,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -925,7 +925,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  North is a deep hollow, one
 which looks to hold a great many dark secrets.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -947,7 +947,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  To the south the forest
 slopes steepy downhill into a deep valley or hollow.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -969,7 +969,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The cliff face runs along
 beside you on the south, hemming you into the forest.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -990,7 +990,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1015,7 +1015,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1040,7 +1040,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1067,7 +1067,7 @@ the corner of your eye.  Always just out of sight.  Towering high above the
 trees to your west is a huge, wood sided house which seems to lean to one side.
 It looks very old and very unsafe.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1092,7 +1092,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1117,7 +1117,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1142,7 +1142,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1169,7 +1169,7 @@ the corner of your eye.  Always just out of sight.  South of you a large house
 rises from the forest floor, it's top floor higher than the towering trees all
 around you.  The house looks very old and very unsafe.  Also uninviting.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1195,7 +1195,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  To the west is the cliff
 face, solid and unyielding, penning you into this awful place.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1217,7 +1217,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  To the north is a huge
 house, very old and ugly.  There are no lights of any kind coming from it.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1242,7 +1242,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1267,7 +1267,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1293,7 +1293,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The cliff face runs along
 beside you on the south, hemming you into the forest.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1315,7 +1315,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The cliff face runs along
 beside you on the south, hemming you into the forest.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1336,7 +1336,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1363,7 +1363,7 @@ the corner of your eye.  Always just out of sight.  To the west is some sort of
 deep fell or hollow where the forest slopes downward out of sight toward the
 rocky cliff far to the west.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1388,7 +1388,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1416,7 +1416,7 @@ house to your east, one that stands extremely tall in this monstrous forest.
 The house looks to be in deplorable condition, it leans to one side looking as
 if it might fall over at any time.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1441,7 +1441,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1466,7 +1466,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1525,7 +1525,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  To the west is the cliff
 face, solid and unyielding, penning you into this awful place.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1547,7 +1547,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky cliff runs along
 beside you on the west.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1570,7 +1570,7 @@ the corner of your eye.  Always just out of sight.  The cliff face is to the
 west, hemming you into this evil forest.  To the south is some sort of hollow
 which leads downhill into territory that you cannot see from here.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1594,7 +1594,7 @@ west side, an ever present reminder that you are trapped in this valley.  To the
 north there is some sort of hollow, or slope that leads downward into deeper
 forest.  Looks very ominous, caution is advised.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1618,7 +1618,7 @@ abrupt turn here, curving itself north and east, running along your south and
 west sides.  It looks as if this forest may be completely enclosed by this
 strange rock formation.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1636,7 +1636,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky cliff makes a turn
 heading north and west, blocking you movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1653,7 +1653,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1679,7 +1679,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky cliff makes a turn
 heading north and west, blocking you movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1696,7 +1696,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1721,7 +1721,7 @@ withered and brittle.  Strangely enough, with all the lingering death around
 you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1747,7 +1747,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  To your north is a deep,
 dark valley.  It looks exteremely uninviting from here, best to just pass it by.
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1769,7 +1769,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  To the north the forest runs
 downhill into a deep fell.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1792,7 +1792,7 @@ the corner of your eye.  Always just out of sight.  To the south is a deep
 hollow, many miles across and quite deep from the looks of it.  Of course, it is
 hard to tell by looks since it is so dark here.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1816,7 +1816,7 @@ is such a presence, such a large obstacle, you feel that this valley must have
 been created on purpose by some god, some higher power, to punish the
 inhabitants for wrongdoings.  Or something.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1838,7 +1838,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky wall still runs
 along on the north side.  You feel like a caged animal.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1860,7 +1860,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  There is some sort of inner
 valley to the south, one that looks very deep and very dark.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -1882,7 +1882,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1904,7 +1904,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1926,7 +1926,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1948,7 +1948,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1970,7 +1970,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -1992,7 +1992,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -2014,7 +2014,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -2036,7 +2036,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky wall turns here,
 running south and east, keeping you from continuing north or west any farther.
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~
@@ -2056,7 +2056,7 @@ here, hemming you in and hindering any movement east or north.  Over time, rocks
 have fallen off from the cliffsides and piled up at the base.  A set of small
 tracks seem to come and go from beneath two large rocks.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D2
 ~
 ~
@@ -2078,7 +2078,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rock wall runs along to
 the east.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -2102,7 +2102,7 @@ movement to the east.  To the west is a deep hollow, a very large one from the
 looks of it although it is hard to tell for sure in this darkness.  Looks almost
 like a valley inside this valley.  
 ~
-266 0 0 0 0 0
+266 0 0 0 0 3
 D0
 ~
 ~
@@ -2120,7 +2120,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  To the east is the rocky
 wall that holds you captive in this God-Forsaken forest.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -2142,7 +2142,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky cliff makes a turn
 heading north and west, blocking you movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D0
 ~
 ~
@@ -2160,7 +2160,7 @@ you, there seems to be a great deal of movement around you, but always out of
 the corner of your eye.  Always just out of sight.  The rocky face runs along
 north of you preventing any further movement in that direction.  
 ~
-266 1 0 0 0 0
+266 1 0 0 0 3
 D1
 ~
 ~

--- a/lib/world/wld/267.wld
+++ b/lib/world/wld/267.wld
@@ -31,7 +31,7 @@ as far as you can see.  Hundred of beautifuly garbed women of all shades
 languish on the shore; they have stony-dull eyes that stare right past you.  
 Something looks not-quite-so-right in this pristine place.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 2
 D1
 To your east you can see a huge mound of dirt.
 ~
@@ -56,7 +56,7 @@ Beachside Harem~
 and you can hear screaming from down in the depths.  A large forest lies to
 your east, and a trail can be vaguely seen.    
 ~
-267 1 0 0 0 0
+267 1 0 0 0 4
 D1
 To your east you can see a beach road that leads into the forest.
 ~
@@ -82,7 +82,7 @@ fill every part of the area outside the path.  Strange noises and utterly
 blood-chilling screams fill the air.  It is very dark here.  The path leads on
 to your west, and a strange mound lies to your east.    
 ~
-267 1 0 0 0 0
+267 1 0 0 0 2
 D1
 The beach road continues on.
 ~
@@ -101,7 +101,7 @@ priceless vases, and piles of money and jewelry everywhere.  Beautiful, silent
 women dance before you, twirling in silk gowns that barely hide their beauty.
 A sound can be heard over all the racket, shouting, "Keep working!  "
 ~
-267 521 0 0 0 0
+267 521 0 0 0 1
 D4
 You can just see from the hole in the ground that you are right by a path that leads into the woods.
 ~
@@ -117,7 +117,7 @@ fill every part of the area outside the path.  Strange noises and utterly
 blood-chilling screams fill the air.  It is very dark here.  A large hill rises
 to your east, and the beach road lies to your west.    
 ~
-267 5 0 0 0 0
+267 5 0 0 0 2
 D1
 A large hill rises to your east.
 ~
@@ -135,7 +135,7 @@ Creepy Road~
 Perhaps it's the total and complete silence.  Or perhaps it's the skeletons
 strown haphazardly about.  You just don't know.    
 ~
-267 4 0 0 0 0
+267 4 0 0 0 2
 D1
 The creepy road continues east.
 ~
@@ -157,7 +157,7 @@ Creepy Road~
 Perhaps it's the total and complete silence.  Or perhaps it's the skeletons
 strown haphazardly about.  You just don't know.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 2
 D1
 The creepy road continues east.
 ~
@@ -180,7 +180,7 @@ Perhaps it's the total and complete silence.  Or perhaps it's the skeletons
 strown haphazardly about.  You just don't know.  A large building towers above
 you to the east.    
 ~
-267 4 0 0 0 0
+267 4 0 0 0 2
 D1
 You know, like we said, a large building lieing to your east and all.
 ~
@@ -209,7 +209,7 @@ To your south, you can see the beginnings of a rock-strewn-path...  Continuing
 further down, you can see the end of the hill.  The forest covers up most of
 the view from here.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 4
 D4
 Looking up, you can see the zenith of Vice Hill.
 ~
@@ -229,7 +229,7 @@ your south, you can see the beginnings of a rock-strewn path...  Continuing
 further down, you can see the end of the hill.  The forest covers up most of
 the view from here.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 4
 D4
 Looking up, you can see the zenith of Vice Hill.
 ~
@@ -513,7 +513,7 @@ dark openings of two tunnels to your east and west.  Of course, you could
 always go south up to the relative safety of the hill.  A huge tree here looks
 climbable, and you can vaguely see a net at the top.    
 ~
-267 4 0 0 0 0
+267 4 0 0 0 4
 D0
 You can see a dangerous-looking tarry road to your north.
 ~
@@ -546,7 +546,7 @@ Tarry Road~
 thicker and thicker as you venture north.  If you go south, you'll probably be
 able to turn back before it's too late.    
 ~
-267 517 0 0 0 0
+267 517 0 0 0 2
 D0
 It looks very dangerous and squishy that way, but you could probably survive
 it.
@@ -566,7 +566,7 @@ thicker and thicker as you venture south.  If you go north, you'll probably be
 able to turn back before it's too late.  There is a sign on the side of the
 road here.    
 ~
-267 517 0 0 0 0
+267 517 0 0 0 2
 D0
 The tar looks even more dangerous that way, but survivable.
 ~
@@ -590,7 +590,7 @@ Tarry Road~
 of escape--either go forward, or don't move at all.  Right ahead of you is a
 bubbling, boiling tar pit--it looks quite disgusting.  PANIC!    
 ~
-267 517 0 0 0 0
+267 517 0 0 0 2
 D0
 Looks like that would be a VERY bad idea. I don't think you could escape
 that one.
@@ -611,7 +611,7 @@ you might, you can't get them out!  Each sinks lower and lower until your
 entire legs are encased in the pit.  You scream for help, but no one can hear
 you.    
 ~
-267 548 0 0 0 0
+267 548 0 0 0 2
 S
 #26728
 Vice Hill~
@@ -620,7 +620,7 @@ it still looks quite sinister.  You notice a rocky road to your south, and you
 can ascend the hill to take a look around you.  A road hangs a bit above you to
 your left by no supports!  Hmm...  A beautifuly made road is to your west.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 4
 D0
 You can see the beautiful Vice Hill.
 ~
@@ -655,7 +655,7 @@ substance line the path--it doesn't look as if a piece of paper could be
 inserted between them.  The trees have been trimmed back to allow easy passage.
 Even among all this beauty, you sense a sinister presence.    
 ~
-267 5 0 0 0 0
+267 5 0 0 0 1
 D1
 To your east you can see the bottom of Vice Hill.
 ~
@@ -674,7 +674,7 @@ of diabolocal canopy.  You can hear--drums?  --some sort of pulsing beat in the
 distance.  A soft chanting can be heard in the far distance, but you can see no
 sign of life.  Lonliness sends you into a panicky state.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 1
 D2
 The strange trail continues on.
 ~
@@ -700,7 +700,7 @@ substance line the path--it doesn't look as if a piece of paper could be
 inserted between them.  The trees have been trimmed back to allow easy passage.
 Even among all this beauty, you sense a sinister presence.    
 ~
-267 5 0 0 0 0
+267 5 0 0 0 1
 D0
 The high path continues on.
 ~
@@ -719,7 +719,7 @@ of diabolocal canopy.  You can hear--drums?  --some sort of pulsing beat in the
 distance.  A soft chanting can be heard in the far distance, but you can see no
 sign of life.  Lonliness sends you into a panicky state.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 1
 D0
 The strange trail continues on..
 ~
@@ -745,7 +745,7 @@ substance line the path--it doesn't look as if a piece of paper could be
 inserted between them.  The trees have been trimmed back to allow easy passage.
 Even among all this beauty, you sense a sinister presence.    
 ~
-267 5 0 0 0 0
+267 5 0 0 0 1
 D0
 The high path continues on.
 ~
@@ -764,7 +764,7 @@ of diabolocal canopy.  You can hear--drums?  --some sort of pulsing beat in the
 distance.  A soft chanting can be heard in the far distance, but you can see no
 sign of life.  Lonliness sends you into a panicky state.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 1
 D0
 The strange trail continues on..
 ~
@@ -790,7 +790,7 @@ substance line the path--it doesn't look as if a piece of paper could be
 inserted between them.  The trees have been trimmed back to allow easy passage.
 Even among all this beauty, you sense a sinister presence.    
 ~
-267 5 0 0 0 0
+267 5 0 0 0 1
 D0
 The high path continues on.
 ~
@@ -809,7 +809,7 @@ of diabolocal canopy.  You can hear--drums?  --some sort of pulsing beat in the
 distance.  A soft chanting can be heard in the far distance, but you can see no
 sign of life.  Lonliness sends you into a panicky state.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 1
 D0
 The strange trail continues on.
 ~
@@ -835,7 +835,7 @@ substance line the path--it doesn't look as if a piece of paper could be
 inserted between them.  The trees have been trimmed back to allow easy passage.
 Even among all this beauty, you sense a sinister presence.    
 ~
-267 5 0 0 0 0
+267 5 0 0 0 1
 D0
 The high path continues on.
 ~
@@ -854,7 +854,7 @@ of diabolocal canopy.  You can hear--drums?  --some sort of pulsing beat in the
 distance.  A soft chanting can be heard in the far distance, but you can see no
 sign of life.  Lonliness sends you into a panicky state.    
 ~
-267 4 0 0 0 0
+267 4 0 0 0 1
 D0
 The strange trail continues on.
 ~
@@ -880,7 +880,7 @@ tarry brine to your north, and to all other directions a sinister, black forest
 is eerily silent.  If you look very carefully, you can see the harbours to your
 north and east.  The exits descend in all directions.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 4
 D0
 The hill descends down into a tarry road, filled with the gooey stuff.
 ~
@@ -1450,7 +1450,7 @@ Most of the island is covered in forest, and extends around a huge hill.  The
 far, far north shows some absolutely huge trees, and a rather large, black pool
 of what can only be tar.  You can go back into the building by going east.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 1
 D1
 You see the creepy hallway.
 ~
@@ -1801,7 +1801,7 @@ extremely high up from the ground.  You hear birds chirping right by you, and
 feel very peaceful here--that is, as long as you are in the trees.  You may go
 north or down.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 3
 D0
 The netting continues through the trees here.
 ~
@@ -1826,7 +1826,7 @@ extremely high up from the ground.  You hear birds chirping right by you, and
 feel very peaceful here--that is, as long as you are in the trees.  You may go
 north or south on through the trees.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 3
 D0
 The netting continues through the trees here.
 ~
@@ -1851,7 +1851,7 @@ extremely high up from the ground.  You hear birds chirping right by you, and
 feel very peaceful here--that is, as long as you are in the trees.  You may go
 north or south on through the trees.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 3
 D0
 The netting continues through the trees here.
 ~
@@ -1877,7 +1877,7 @@ feel very peaceful here--that is, as long as you are in the trees.  You may go
 north or south on through the trees.  You can see a very dangerous tar pit
 right below you.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 3
 D0
 The netting continues through the trees here.
 ~
@@ -1902,7 +1902,7 @@ extremely high up from the ground.  You hear birds chirping right by you, and
 feel very peaceful here--that is, as long as you are in the trees.  You may go
 north or south on through the trees.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 3
 D0
 The netting continues through the trees here.
 ~
@@ -1927,7 +1927,7 @@ extremely high up from the ground.  You hear birds chirping right by you, and
 feel very peaceful here--that is, as long as you are in the trees.  You may go
 north to a dock, or south on through the trees.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 3
 D0
 The netting ends at a dock.
 ~
@@ -1952,7 +1952,7 @@ to your south, keeping you from falling through the trees.  You can see a large
 tar pit to your south--good thing there's that netting to keep you from falling
 into it.    
 ~
-267 0 0 0 0 0
+267 0 0 0 0 1
 D2
 The netting begins to your south.
 ~

--- a/lib/world/wld/269.wld
+++ b/lib/world/wld/269.wld
@@ -5,7 +5,7 @@ part of the world.  There are several rumors as to where it leads,
 but no one knows for sure.  Looking south, you gaze into a panorama
 of a rocky, cactus-dotted land, shimmering in the heat of the day.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D2
 A huge cactus-dotted desert spreads out before you.
 ~
@@ -31,7 +31,7 @@ The Beginning Of The Southern Desert~
 appear, you are thankful that they do not grow on the path.
 To the south, you see a desert, teeming with desert life.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -248,7 +248,7 @@ mother nature, you ignore your thirst and plod onward.
    To the south the mountains rise up out of the earth like
 an ill specter.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 To the north you look down onto flatter ground.
 ~
@@ -325,7 +325,7 @@ The Foothills~
 becomes easier. Far off to the east you think you see blue.
 to the south the dusty road continues. 
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 The road leads north into the Southern Desert.
 ~
@@ -343,7 +343,7 @@ A Bend In The Fading Road~
 You are surrounded by sage brush, and heat. You can barely make out 
 a path to the south.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 The path leads north into the heart of the desert mountains.
 ~
@@ -360,7 +360,7 @@ A Dusty Road~
    Here the land is harsh and hot, reminding you of your
 4th-grade teacher.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 You see a 'T' in the road to the east. 
 ~
@@ -377,7 +377,7 @@ A Dusty 'T' Intersection~
    The dusty road here splits to the east and to the west. The
 desert continues to the south.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 The road leads north into the desert.
 ~
@@ -394,7 +394,7 @@ The Southern Desert~
    The desert stretches out in every direction, a rugged terrain 
 reminding you of the moon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -410,7 +410,7 @@ The Southern Desert~
 reminding you of the moon. You can barely see mountains on the east 
 horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -426,7 +426,7 @@ The Southern Desert~
 reminding you of the moon.  You can barely see mountains on the east 
 horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -442,7 +442,7 @@ The Southern Desert~
 reminding you of the moon.  The mountains to the east are snow-capped,
 and rocky.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D1
 You see mountains to the east.
 ~
@@ -458,7 +458,7 @@ S
 The Southern Desert~
    The desert stretches out in every direction but east.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D3
 The Southern desert stretches out to the western horizon.
 ~
@@ -470,7 +470,7 @@ An Overgrown Trail~
    You are walking down a trail, overgrown with cactus and other dry 
 plants.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see a more-travelled path to the north.
 ~
@@ -487,7 +487,7 @@ Way Out In The Southern Desert~
    Here the air is as dry as your step-mother's humor.
 (Thank God she's not here to watch you mud.)
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -503,7 +503,7 @@ An Overgrown Trail~
 plants.
 A path leads east from here, off into the distance.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -524,7 +524,7 @@ A Faded Footpath~
 The trail leads south, east, and west with no obvious intent 
 or purpose.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -543,7 +543,7 @@ Way Out In The Desert~
    You have travelled out so far now that you have almost forgotten 
 what water looks and tastes like.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -562,7 +562,7 @@ Way Out In The Desert~
    You are nowhere near where everyone else wants to be.
 How do you feel about that?
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see the trail here leads north.
 ~
@@ -579,7 +579,7 @@ The Southern Desert~
 reminding you of the moon.  Far off to the south-west you can 
 barely see a mesa, sitting on the horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -595,7 +595,7 @@ The Southern Desert~
 reminding you of the moon.  Off to the south you can 
 see a mesa, rising up from the horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -612,7 +612,7 @@ The Southern Desert~
 reminding you of the moon.  Off to the south-west you can 
 see a mesa, sitting on the horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -628,7 +628,7 @@ The Southern Desert~
 reminding you of the moon.  A way off to the south-west you can 
 just see a mesa, sitting on the horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -644,7 +644,7 @@ The Southern Desert~
 reminding you of the moon.  Quite a way off to the south-west you can 
 just see a mesa, sitting on the horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -660,7 +660,7 @@ The Southern Desert~
 reminding you of the moon.  Far off to the south-west you can 
 barely see a mesa, sitting on the horizon.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 ~
 ~
@@ -674,7 +674,7 @@ S
 Way Out In The Southern Desert~
    The desert stretches out in every direction.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see more desert to the north.
 ~
@@ -700,7 +700,7 @@ S
 Way Out In The Southern Desert~
    The desert stretches out in every direction.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see more desert to the north.
 ~
@@ -719,7 +719,7 @@ S
 Way Out In The Southern Desert~
    The desert stretches out in every direction.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see more desert to the north.
 ~
@@ -740,7 +740,7 @@ Near A Rocky Mesa~
 reminding you of the moon.  To the south the mesa looms nearer,
 you think you can hear strange singing blowing in the wind.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 ~
 ~
@@ -755,7 +755,7 @@ S
 Way Out In The Southern Desert~
    The desert stretches out in every direction.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see more desert to the north.
 ~
@@ -773,7 +773,7 @@ North Of A Rocky Mesa~
 jut up through the desert floor.
    The mesa to the south seems ominously silent...
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 To the north you see the desert.
 ~
@@ -789,7 +789,7 @@ S
 Way Out In The Southern Desert~
    The desert stretches out in every direction.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see more desert to the north.
 ~
@@ -810,7 +810,7 @@ In The Brush~
    You are completely surrounded by tumbleweeds now, and 
 the world is deathly silent.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 You see more brush to the north.
 ~
@@ -837,7 +837,7 @@ In The Brush~
    Here you decide not to go any further, due to the increasing 
 number of brambles getting caught in your clothes.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 You see more brush to the north.
 ~
@@ -865,7 +865,7 @@ The Mesa~
 to about the height of 200 feet, there is no way you could ever climb
 it. Directly to the south you spot a small hole.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 ~
 ~
@@ -884,7 +884,7 @@ S
 The Southern Desert~
    This is the largest desert you have ever seen...
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -899,7 +899,7 @@ The Southern Desert~
    The path has disappeared completely, leaving you free to
 choose any direction at all.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 This is the largest desert you have ever seen...
 ~
@@ -926,7 +926,7 @@ The Southern Desert~
    The small trail you have been painstakingly following
 leads to the north and south, and a smaller trail wanders to the west.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -941,7 +941,7 @@ The Southern Desert~
    The small trail you have been painstakingly following
 leads to the north and south, with no end in sight. 
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -957,7 +957,7 @@ Cactus Land~
 stay away from all the pricks.
 The trail leads east and south from here.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 You see a desert path, deserted.
 ~
@@ -974,7 +974,7 @@ The Southern Desert~
    The desert stretches out in every direction, and a faint trail
 runs off to the west.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -995,7 +995,7 @@ A Cactus-Infested Area~
 stay away from all the pricks.
 The trail leads north and south from here.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -1011,7 +1011,7 @@ A Cactus-Infested Area~
 stay away from all those darn pricks.
 The trail leads north and east from here.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -1026,7 +1026,7 @@ The Southern Desert~
    The desert stretches out in every direction, and a faint trail
 runs off to the west. The main path leads north and south.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -1051,7 +1051,7 @@ In The Brush~
    The sage brush and tumbleweeds here press in all around you,
 making it a bit hard to walk.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 ~
 ~
@@ -1075,7 +1075,7 @@ In The Brush~
    The sage brush and tumbleweeds here press in all around you,
 making it a bit hard to walk.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 4
 D0
 ~
 ~
@@ -1098,7 +1098,7 @@ The Southern Desert~
    The desert stretches out in every direction, and the main
 path leads north and south.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -1113,7 +1113,7 @@ The Southern Desert~
    The desert stretches out in every direction, and the main
 path leads north and south.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -1128,7 +1128,7 @@ The Southern Desert~
    The desert stretches out in every direction, and the main
 path leads north and south.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -1143,7 +1143,7 @@ The Southern Desert~
    The desert stretches out in every direction, and the main
 path leads north and east.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 ~
 ~
@@ -1159,7 +1159,7 @@ A Brush-Filled Trail~
    The desert stretches out in every direction, and the main
 path leads east; westward it begins to diminish....
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 You can't see far into the silent brush to the east...
 ~
@@ -1175,7 +1175,7 @@ A Brush-Filled Trail~
    The desert stretches out in every direction, and you can no 
 longer make out a path.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see the desert...
 ~
@@ -1202,7 +1202,7 @@ A Clearer Trail~
    The trail here is clearing a little, you carefully notice 
 broken twigs and brush-marks on the desert floor.
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D0
 You see the desert...
 ~
@@ -1234,7 +1234,7 @@ About half way up it you can see the outlines of a sealed door.
    Looking about, you wonder why you begin to 
 hear noises...
 ~
-269 0 0 0 0 0
+269 0 0 0 0 2
 D1
 You see the front end of a stone wigwam of some sort.
 ~

--- a/lib/world/wld/27.wld
+++ b/lib/world/wld/27.wld
@@ -2136,7 +2136,7 @@ be heard gurgling amidst nearby rocks and leading into a small luminous pond.
 Plant life blooms abundantly here, grasses and mosses covering every surface,
 colourful flower blossoms and tree sprouts beginning to show through the green.
 ~
-27 0 0 0 0 0
+27 0 0 0 0 2
 D1
 ~
 ~
@@ -2149,7 +2149,7 @@ trees and plant life.  Many varieties of animal can be glimpsed wandering
 through the grasses and brush, the signs of humanoid civilization visible in the
 form of distant villages.  
 ~
-27 0 0 0 0 0
+27 0 0 0 0 2
 D2
 ~
 ~
@@ -2175,7 +2175,7 @@ ground, the aftermath of a felling in recent years.  Brown grasses rustle
 restlessly in the somewhat smoky air, and the peaks of a mountain range are
 only just visible to the north.  
 ~
-27 0 0 0 0 0
+27 0 0 0 0 3
 D0
 ~
 ~

--- a/lib/world/wld/270.wld
+++ b/lib/world/wld/270.wld
@@ -17,7 +17,7 @@ S
 The Foothills~
    You stand in the foothills surrounding the Icy-Mountain.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D1
 ~
 ~
@@ -32,7 +32,7 @@ The Foothills~
    You stand in the foothills of the Icy-Mountain.  The mountain 
 rises high towards the sky immediately south of here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D1
 ~
 ~
@@ -47,7 +47,7 @@ The Foothills~
     You stand in the foothills of the Icy-Mountain.  The mountain 
 rises high towards the sky immediately south of here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D1
 ~
 ~
@@ -62,7 +62,7 @@ The Foothills~
    You stand in the foothills of the Icy-Mountain.  The mountain 
 rises high towards the sky immediately south and west of here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D2
 ~
 ~
@@ -101,7 +101,7 @@ The Foothills~
    You stand in the foothills of the Icy-Mountain.  The mountain 
 rises high towards the sky immediately east of here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -187,7 +187,7 @@ The Foothills~
    You are in the foothills surrounding the Icy-mountain, which 
 rises towards the sky just west of you.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -254,7 +254,7 @@ The Foothills~
 is a mountain trail leading up along the side of the mountain 
 east of you.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -355,7 +355,7 @@ S
 The Foothills~
    You are in the foothills east of the Icy-mountain.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -370,7 +370,7 @@ The Foothills~
    You are in the foothills.  There is a mountain rising to your 
 easthand side.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -385,7 +385,7 @@ The Foothills~
    You are in the foothills surrounding the Icy-mountain.  There 
 is a trail leading up the montain north of here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -408,7 +408,7 @@ The Foothills~
    You are in the foothills surrounding the Icy-mountain.  There 
 is a path leading up along the mountainside north of you.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -426,7 +426,7 @@ S
 The Foothills~
    You are in the foothills surrounding the Icy-mountain.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D1
 ~
 ~
@@ -440,7 +440,7 @@ S
 The Foothills~
    You are in the foothills surrounding the Icy-mountain.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D1
 ~
 ~
@@ -458,7 +458,7 @@ S
 The Foothills~
    You are in the foothills surrounding the Icy-mountain.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D2
 ~
 ~
@@ -487,7 +487,7 @@ The Wasteland Hills~
    You are in some completely wasted, tiresome, boring and 
 totally ugly hills.  There are some droppings left here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -511,7 +511,7 @@ The Wasteland Hills~
 north you barely make out the contours of a pointy mountain and 
 its foothills.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D1
 ~
 ~
@@ -526,7 +526,7 @@ The Wasteland Hills~
    You are on a path in the hills.  Apart from down to the south 
 there is nothing but brown, dull and wasted hills surrounding you.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D1
 ~
 ~
@@ -547,7 +547,7 @@ hills.  North of here you can barely make out the shape of
 a pointy mountain with some rather large foothills just in
 front of it.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -565,7 +565,7 @@ S
 The Foothills~
    You are in the foothills surrounding the mountainside.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -603,7 +603,7 @@ The Foothills~
    You are in the foothills surrounding the mountain.  A large
 claymore is lying on the ground here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -622,7 +622,7 @@ The Wasteland Hills~
    You are surrounded by smooth hills right in the middle of 
 absolute nowhere.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -637,7 +637,7 @@ The Wasteland hills~
    You are on a little path leaing through the smooth, brown hills 
 of complete waste.  Right beneath you is some wasteland fields.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -655,7 +655,7 @@ S
 The Wasteland Fields~
    You are on the wast, wasted fields in the middle of nowhere.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D1
 ~
 ~
@@ -670,7 +670,7 @@ The Wasteland Fields~
    You are on the vast, wasted fields in the middle of nowhere. 
 Above you is quite clearly some hills.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D2
 ~
 ~
@@ -689,7 +689,7 @@ S
 The Foothills~
    You are in the foothills.  Where else?
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -704,7 +704,7 @@ The Foothills~
    You are in the foothills.  North of here a small path is finding 
 its way up along the Icy-mountain.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -722,7 +722,7 @@ S
 The Foothills~
    You are in the foothills surrounding the large pointy Icy-mountain.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 4
 D0
 ~
 ~
@@ -736,7 +736,7 @@ S
 The Wasteland Fields~
    You are in the brown, tiresome fields.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D2
 ~
 ~
@@ -750,7 +750,7 @@ S
 The Wasteland Fields~
    You are surrounded by fields!!!
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D0
 ~
 ~
@@ -768,7 +768,7 @@ S
 The Wasteland Fields~
    You are on a large field which do not seem to have an end to it.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D2
 ~
 ~
@@ -782,7 +782,7 @@ S
 The Wasteland Fields~
    You are on a large field.  Is there possibly an end to it??
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D0
 ~
 ~
@@ -797,7 +797,7 @@ The Wasteland Fields~
    You are on a large field, which as you clearly can tell is 
 nothing but waste.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D1
 ~
 ~
@@ -812,7 +812,7 @@ The Wasteland Fields~
    You are on a humongous, almost corroded field.  There is a little
 stalk of wheat growing here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D0
 ~
 ~
@@ -834,7 +834,7 @@ S
 The Wasteland fields~
    You are on a vast field and it sure is vast.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D0
 ~
 ~
@@ -852,7 +852,7 @@ S
 The Wasteland Fields~
    You are in the fields to your utter dissatisfaction.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D2
 ~
 ~
@@ -866,7 +866,7 @@ S
 The Wasteland Fields~
    You are in some fields.  They do not look fertile at all.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D0
 ~
 ~
@@ -880,7 +880,7 @@ S
 The Wasteland Fields~
    You are in waste which happens to have the form of fields.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D2
 ~
 ~
@@ -895,7 +895,7 @@ The Wasteland Fields~
    You are in the middle of a large, brown field, not nice 
 looking, but it just isn't.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D1
 ~
 ~
@@ -907,7 +907,7 @@ The Wasteland Fields~
 in complete waste.  Only some aufwuchs on a stone seem to be able 
 to exist here.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D1
 ~
 ~
@@ -928,7 +928,7 @@ ground with the sound of a soft howl.  The vegetation seem to have
 lost the battle to some greater force as it gradually disappears 
 towards the east.
 ~
-270 0 0 0 0 0
+270 0 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/271.wld
+++ b/lib/world/wld/271.wld
@@ -6,7 +6,7 @@ the town of Sundhaven find it their pleasure to lounge here.  The dark marble
 temple rises like a shadow to the north, the vivid colors of roses eastwards,
 and the library lies to the west.  There is a stone arch to the south.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -143,7 +143,7 @@ the temple rises among the town smoke, and a set of steps to the north leads up
 to the northern square before the cliffs edge.  Black willows grow in small
 clusters to the east and west.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D2
 ~
 ~
@@ -170,7 +170,7 @@ The temple garden~
    An impressionistic splash of red, black and gold meets the eye, accompanied
 by the intoxicating fragrance of roses growing nearly wild in this garden.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D3
 ~
 ~
@@ -183,7 +183,7 @@ half grown over with dark green ivy.  Before you to the south are the stone
 steps leading up to the town gallows, and northwards lies the courtyard of the
 temple.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -201,7 +201,7 @@ air.  The cliffs and the northern gate of the town lie north of here, the lane
 paralleling the cliffs runs east and west, and the entrance to the temple is
 southwards.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -228,7 +228,7 @@ foggy wetland.  The graveyard for the dead of Sundhaven lies near the foot of
 the cliffs, and in the far distance you can make out the blue line of the sea
 closing the horizon.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 gate
@@ -245,7 +245,7 @@ A lane bordering the cliffs~
 fills the heavily trafficked lane with a salty scent.  The path is lined with a
 few oaks, and shops lie to the north and south.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -296,7 +296,7 @@ which a pleasant scent is drifting, and the road continues, narrowing, to the
 west towards the homes of the residents.  Eastwards lies shops and the northern
 gate; a shaded lane travels to the south.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -322,7 +322,7 @@ park is a quiet, relaxing place, with the exception of the occasional explosion
 coming from a pale tower rising to the northwest, accompanied by a brilliant
 flash of light.    
 ~
-271 1 0 0 0 0
+271 1 0 0 0 2
 D2
 ~
 ~
@@ -340,7 +340,7 @@ the cliff lane runs east-west.  An occasional explosion from a pale stone tower
 to the north startles you, and piques your curiousity about that strange place.
   
 ~
-271 1 0 0 0 0
+271 1 0 0 0 2
 D0
 ~
 ~
@@ -422,7 +422,7 @@ intervals, to the joy of hidden enemies and law-abiding citizens.  You note
 there is plenty of room for spectators.  Besides the east-west road, a stone
 arch stands to the north, and a well-travelled path leads southwards.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D1
 ~
 ~
@@ -447,7 +447,7 @@ stone is barely holding together.  Moss and weeds have all but overgrown the
 rock-strewn surface.  Balmy, roguish scents are drifting out of a dark,
 ivy-clothed building to the east.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -495,7 +495,7 @@ The southern path~
 black-tipped grass.  By night the moths gather by a fatal instinct round the
 glow of torches lining the way, beating their wings heavily.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -512,7 +512,7 @@ with traces of human filth as you pass into the poorer section of Sundhaven.
 The shanties and town dump add a mild stench to the air, and attest to the
 virtual burglaries of the poor by the rich..  And often by the poor.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -549,7 +549,7 @@ The town dump~
 almost visible brown haze among the heaps of trash, clouding your senses.  
 Those who call it home certainly smell as decayed as it does.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D1
 ~
 ~
@@ -571,7 +571,7 @@ The town dump~
 pleasantries...  Suffice it to say that very little that should be alive here
 is, and vice-versa.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -590,7 +590,7 @@ repelling you in another direction automatically such that it takes a great
 conscious effort for you to turn that way.  The path heads north into the
 town's mainstream, and south closer to the wildlands beyond it.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -611,7 +611,7 @@ coverings on their feet, attracting all sorts of loafers and siteseers who come
 on days off to relax and watch the festivities at the gallows.  A bloody trail
 leads into a building to the south.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D1
 ~
 ~
@@ -637,7 +637,7 @@ A sandy bend before the east gate~
 to be forged from some heavy metal and painted white.  The ground is a mix of
 shuffled black and gold sand where the two roads meet.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -658,7 +658,7 @@ no entrance can be seen from here, and the black stone of the weapons shop is
 westwards.  The road is treeless and wide, the air laiden with smoke and the
 shouts of bartering.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -679,7 +679,7 @@ their business.  The armoury stands to the west, emitting heat from the fires
 of the forge.  Occasional drunken shouts and laughter can be heard from a
 smoking lodge to the east.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -704,7 +704,7 @@ road, reducing the sinking effect of mud during the rains.  The air here is
 heavy with the smell of delicious food, fresh bread baking, and something
 spicier, to the east.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -728,7 +728,7 @@ A bend in the road~
 small, blackened stone structure to the north.  Patches of gold sand are
 scattered about.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -752,7 +752,7 @@ A lane bordering the cliffs~
 travels east and west paralleling the cliffs just around the shops to the
 north.  Faint bird cries are issuing from the building to the south.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -777,7 +777,7 @@ summer fades to autumn.  Between the trees to the west, something sparkles
 tauntingly from the dark doorway of a small shop.  Eastwards the dome of the
 temple can be seen rising.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -799,7 +799,7 @@ pickpocket or two, for the lane is broad and the shadows of the trees leave
 plenty of hiding places.  However, the frequent presence of guards gives a
 feeling of security.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -820,7 +820,7 @@ dappled light on the ground, which shifts languidly back and forth in the
 breeze.  To the west stands the old post office, and the lane continues north
 and south.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -842,7 +842,7 @@ by the din of the town going about its daily business.  The ornate west gate
 lies just to the west, a road paved with black sand runs east and north is a
 lane shaded by oak and ash trees.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -863,7 +863,7 @@ the unpleasant affects of copious mud during the frequent rains and heavy fogs
 of the region.  The road is so heavily travelled it has almost been packed down
 into a hard surface.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D1
 ~
 ~
@@ -911,7 +911,7 @@ The east gate of Sundhaven~
 from iron and painted bone-white.  A hot desert wind blows through the grating
 sporadically, giving hint to the vast regions beyond.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D1
 ~
 gate
@@ -929,7 +929,7 @@ to the west, bordered by slender elms.  The ivy so plentiful in the town is
 twined and braided about its intricate coils and carvings, which consist
 largely of prowling cats and eclipsed circle designs.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D1
 ~
 ~
@@ -1030,7 +1030,7 @@ The rooftop at Mekala's~
 circle about above your head, curious about the food but too shy to descend.  
 A few tables stand adorned with simple white tablecloths and red candles.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D5
 ~
 ~
@@ -1133,7 +1133,7 @@ cliff and the lands beyond in its pale jaws.  Far beyond the whiteness opens
 out to reveal a welcome azure that is the mantle of the sea.  A trail
 disappears downwards into the mist.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 4
 D2
 ~
 gate
@@ -1148,7 +1148,7 @@ graveyard near the foot of the cliff to the north, and beyond it, the pearl
 blue sea, clothing the far horizon.  The mages have made this a favored place
 for recreational studies.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D2
 ~
 ~
@@ -1220,7 +1220,7 @@ wind.  To the west rise the bluffs and gardens of the homes of Sundhaven's
 varied people; citizens can also be seen passing eastwards into the town
 itself.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 1
 D0
 ~
 ~
@@ -1242,7 +1242,7 @@ you bluffs rise, pale grey and dark sandstone, smooth from the sculpturing of
 winds, and dotted with purple heather and green mosses.  A path strays through
 the clifftop hills.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 2
 D1
 ~
 gate
@@ -1260,7 +1260,7 @@ you bluffs rise, pale grey and dark sandstone, smooth from the sculpturing of
 winds, and dotted with purple heather and green mosses.  A path strays through
 the clifftop hills.    
 ~
-271 0 0 0 0 0
+271 0 0 0 0 2
 D1
 ~
 ~

--- a/lib/world/wld/272.wld
+++ b/lib/world/wld/272.wld
@@ -92,7 +92,7 @@ A path of black grass~
 black, wiry grass, that at first site gives the place a ravaged, charred look.
 However, the vegetation is living, just endowed with a dark hue.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 ~
@@ -113,7 +113,7 @@ is little way to explain the odd feeling of foreboding about this place.  No
 birds sing, no rat scurries in the open, the leaves rustle barely enough to
 break the silence.  Yet an odd presence makes itself felt.    
 ~
-272 1 0 0 0 0
+272 1 0 0 0 3
 D0
 ~
 ~
@@ -200,7 +200,7 @@ white and red colors.  There is a grassy space in the center, circled by smooth
 grey stones, where children play and older residents of the town picnic and
 enjoy themselves.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 ~
@@ -272,7 +272,7 @@ Passing through a vine-wreathed gate~
 little-travelling.  You wonder if there is anything of use to you out this
 remote way, apparently passing out of the residential area.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -306,7 +306,7 @@ dense illumination.  Here the lane is lined with poles hung with lanterns
 giving off a mild golden glow, swinging in the breeze.  The wind passes more
 strongly along a lane to the north.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -323,7 +323,7 @@ hanging golden lanterns that provide a bright radiance.  A few white stone
 houses, small but cozy-looking, lie just east and west, enjoying the
 luminescence.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 ~
@@ -367,7 +367,7 @@ A wide cart path~
 trade....  Is it a path for wide carts, or a wide path for carts?  Westwards, a
 dense forest is blurred with low-hanging clouds.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 gate~
@@ -383,7 +383,7 @@ An untravelled path~
 between the dull grey stones.  You can only wonder if there is much of note out
 this direction, as a sense of barrenness is prominent.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -403,7 +403,7 @@ An untravelled path~
 between the dull grey stones.  You can only wonder if there is much of note out
 this direction, as a sense of barrenness is prominent.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -419,7 +419,7 @@ An untravelled path~
 between the dull grey stones.  You can only wonder if there is much of note out
 this direction, as a sense of barrenness is prominent.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D2
 ~
 ~
@@ -437,7 +437,7 @@ deserted, it is lonely, yet a particularly green bluff forms a plateau just
 above you.  It calls to you in an eerie way, yet emits a chaotic aura that
 might be best left alone.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 4
 D4
 ~
 ~
@@ -454,7 +454,7 @@ the only sound is that of the wind whistling over the moors.  A haunting,
 otherworldly presence has made this bluff its home, casting what malevolence it
 yet can on the mortal world, and giving the bluff its name.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D5
 ~
 ~
@@ -467,7 +467,7 @@ oaks and maples with leaves the color of honey.  To the north a black gate is
 closed against the clamor of the world, and the road continues east to town,
 and west where it vanishes into a fog banked forest.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 3
 D0
 ~
 ~
@@ -487,7 +487,7 @@ The black orchard gate~
 the shallow wind.  Beyond, rows of brambles are stretching past the range of
 your vision.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 gate~
@@ -504,7 +504,7 @@ in lines and stretching their thorny tendrils across your path.  The limbs
 trail low, heavy with fruit in temperate climate.  High stone walls protect
 this precious bower from the destructive noise and thoughts of ordinary humans.
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -525,7 +525,7 @@ blackberry shrubs that seem to form a protective shroud of thorns about the
 area.  Ivy vines hang loose from its many-cornered limbs.  Some images have
 been carved into the oak.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -558,7 +558,7 @@ in lines and stretching their thorny tendrils across your path.  The limbs
 trail low, heavy with fruit in temperate climate.  High stone walls protect
 this precious bower from the destructive noise and thoughts of ordinary humans.
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 ~
@@ -579,7 +579,7 @@ in lines and stretching their thorny tendrils across your path.  The limbs
 trail low, heavy with fruit in temperate climate.  High stone walls protect
 this precious bower from the destructive noise and thoughts of ordinary humans.
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -597,7 +597,7 @@ repelling you in another direction automatically such that it takes a great
 conscious effort for you to turn that way.  The path heads north into the
 town's mainstream, and south closer to the wildlands beyond it.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 1
 D0
 ~
 ~
@@ -635,7 +635,7 @@ in black iron and covered with ivy.  Beyond it, days distant, the mountains of
 black glass rise shrouded in permanent night.  Northwards lies the spread of
 the town of Sundhaven, hooded in wreaths of cooking smoke.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 1
 D0
 ~
 ~
@@ -846,7 +846,7 @@ in lines and stretching their thorny tendrils across your path.  The limbs
 trail low, heavy with fruit in temperate climate.  High stone walls protect
 this precious bower from the destructive noise and thoughts of ordinary humans.
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 ~
@@ -859,7 +859,7 @@ in lines and stretching their thorny tendrils across your path.  The limbs
 trail low, heavy with fruit in temperate climate.  High stone walls protect
 this precious bower from the destructive noise and thoughts of ordinary humans.
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D2
 ~
 ~
@@ -871,7 +871,7 @@ A wide cart path~
 trade....  Is it a path for wide carts, or a wide path for carts?  Westwards, a
 dense forest is blurred with low-hanging clouds.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 ~
@@ -1087,7 +1087,7 @@ the southeast you think you can catch glimpses of the thatched roofs of yet
 another village, this one smaller and more humble.  A trail south along the
 cobblestone wall seems to head in that direction.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D2
 ~
 ~
@@ -1104,7 +1104,7 @@ Sundhaven.  Moss, nourished by frequent rainfall, hides portions of the wall
 under its green tendrils.  A stony path can be made out to the north, and the
 wall makes its way southwards to a corner.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -1121,7 +1121,7 @@ the north and west.  Ivy growing along the wall here brushes your arm as you
 pass.  Dense shrubbery lining the path to the east renders that way
 unnavigable.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 ~
@@ -1138,7 +1138,7 @@ cobblestone wall of Sundhaven, which runs eastwards to a corner.  The gate of
 the town must be somewhere near.  You can make out the buzz of city life,
 hushed by the stone barrier, from the north.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D1
 ~
 ~
@@ -1155,7 +1155,7 @@ town wall of Sundhaven and southwards to a short drop.  Moss completely covers
 and overflows from the oaks, brushing the hair and helms of all but the
 shortest races of beings.    
 ~
-272 1 0 0 0 0
+272 1 0 0 0 3
 D0
 ~
 ~
@@ -1173,7 +1173,7 @@ place looks well-travelled by some hardy population of small-footed creatures.
 One path continues in a north-south vein over the cliff, another breaks off and
 leads east.    
 ~
-272 1 0 0 0 0
+272 1 0 0 0 3
 D2
 ~
 ~
@@ -1190,7 +1190,7 @@ with spanish moss.  (Except this was before Spain.  ) It comes to an end before
 the bubbling ebbs of a tiny stream, pouring gently forth from a hole in the
 rock on which you are poised, and flows southward.    
 ~
-272 1 0 0 0 0
+272 1 0 0 0 3
 D0
 ~
 ~
@@ -1484,7 +1484,7 @@ ivy.  The busy murmur of citylife can be heard from beyond.  Southwards, the
 cobblestone road crosses a meadow of sorts before disappearing into a line of
 dark woods.    
 ~
-272 0 0 0 0 0
+272 0 0 0 0 2
 D0
 ~
 gate~

--- a/lib/world/wld/274.wld
+++ b/lib/world/wld/274.wld
@@ -3,7 +3,7 @@ Entrance to Smurfville~
    You see before you several tiny houses with little blue people scurrying
 about their tasks.  Everyone seems SO happy.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 Onward to smurf village.
 ~
@@ -25,7 +25,7 @@ Smurfberry Patch~
 picket fences block passage to the south and west.  You can continue on to the
 north or east, where more of the smurfberry patch awaits.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 You see more smurfberries growing in nice neat rows.
 ~
@@ -48,7 +48,7 @@ Everywhere you look there are neat litte smurfberry bushes with ripe
 smurfberries on them.  To the south there is a small picket fence keeping you
 from the wild jungle beyond.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 You see more smurfberries growing in nice neat rows.
 ~
@@ -74,7 +74,7 @@ Smurfberry Patch~
    You are in the south-east corner of this wonderfully cute smurfberry patch.
   
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 You see more smurfberries growing in nice neat rows.
 ~
@@ -96,7 +96,7 @@ Smurfy Road~
 smurfy well in the distance and to the east you see some nice smurfy houses
 aligned in a perfect row.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 1
 D0
 Smurfy Road leads off to the north.
 ~
@@ -201,7 +201,7 @@ Smurfberry Patch~
    Oh goodie, even more smurfberry patch!  To the east, you see a white picket
 fence.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 You see more smurfberries growing in nice neat rows.
 ~
@@ -226,7 +226,7 @@ S
 Smurfberry Patch~
    Everywhere you look, there are neat rows of Smurfberry bushes.
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 You see more smurfberries growing in nice neat rows.
 ~
@@ -257,7 +257,7 @@ Entrance to Smurfberry Patch ~
    You see ordered rows of bushes growing what appear to be Smurfberries.  The
 patch continues to the north, south and west.  To the east lies Smurfy Road.  
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 You see more smurfberries growing in nice neat rows.
 ~
@@ -289,7 +289,7 @@ Smurfy Road~
 north, you see a cute little smurfy well.  To the west is what appears to be a
 Smurfberry Patch.  To the east, you see yet another row of well-kept houses.  
 ~
-274 0 0 0 0 0
+274 0 0 0 0 1
 D0
 You see the road leading to a smurfy well.
 ~
@@ -393,7 +393,7 @@ Smurfberry Patch~
 more rows of smurfberry bushes, neatly aligned.  To the north and west you see
 a small white picket fence preventing you from going farther.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D1
 You see more smurfberries growing in nice neat rows.
 ~
@@ -414,7 +414,7 @@ Smurfberry Patch~
    The smurfberry patch extends to the south, east, and west.  There is a white
 picket fence to the north, blocking your passage in that direction.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D1
 You see more smurfberries growing in nice neat rows.
 ~
@@ -441,7 +441,7 @@ Smurfberry Patch~
 more rows of smurfberry bushes, neatly aligned.  To the north and east you see
 a small white picket fence preventing you from going farther.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D2
 You see more smurfberries growing in nice neat rows.
 ~
@@ -464,7 +464,7 @@ looks like the central meeting place for the Smurfs.  This appears to be the
 northern end of Smurfville.  There is a sinister-looking road leading off to
 the north.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 1
 D0
 The path leading north appears to be rarely used, as it is overgrown with 
 weeds.
@@ -521,7 +521,7 @@ Road to Gargamel's Castle~
    You are on a not-too-well paved road leading to a large sinister-looking
 castle to the north.  Eerie theme music is filtering down from the castle.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D0
 You see Gargamel's castle looming in the distance.
 ~
@@ -537,7 +537,7 @@ S
 A T-intersection~
    You are on a T-intersection of two rarely-used paths.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D1
 You hear the Barney theme song drifting on the wind.
 ~
@@ -560,7 +560,7 @@ Barney's Playland~
 walls of this once well-lit area.  Several indistinguishable corpses litter the
 ground and a putrid stench hangs in the air.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 2
 D3
 You see a path leading away from this disaster.
 ~
@@ -574,7 +574,7 @@ appears to be mostly deserted, with possibly a few inhabitants.  The entrance
 to the castle is unguarded, but you are not sure you want to see what's inside.
   
 ~
-274 1 0 0 0 0
+274 1 0 0 0 2
 D0
 You see a large iron door leading into the abode of Gargamel.
 ~
@@ -628,7 +628,7 @@ Papa Smurf Lane~
    This is a cute, smurfy road with houses to the north and south.  The road
 continues to the east and west.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 1
 D0
 You see Vanity Smurf's house.
 ~
@@ -656,7 +656,7 @@ Papa Smurf Lane~
 continues to the west.  To the east you see the formidable house of Papa Smurf.
   
 ~
-274 0 0 0 0 0
+274 0 0 0 0 1
 D0
 You see Athletic Smurf's house.
 ~
@@ -684,7 +684,7 @@ Smurfette Lane~
    This is a cute, smurfy road with houses to the north and south.  The road
 continues to the east and west.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 1
 D0
 You see Artistic Smurf's house.
 ~
@@ -711,7 +711,7 @@ Smurfette Lane~
    This is a cute, smurfy road with houses to the north and south.  The road
 continues to the east and west.    
 ~
-274 0 0 0 0 0
+274 0 0 0 0 1
 D0
 You see Fireman Smurf's house.
 ~

--- a/lib/world/wld/275.wld
+++ b/lib/world/wld/275.wld
@@ -25,7 +25,7 @@ power comes DANGER!!"
 A feeling of hope and uneasiness pervades your body as you think about the
 city of New Sparta!
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see a bustling harbourplace.
 ~
@@ -41,7 +41,7 @@ as suddenly as they appeared.
    The harbourplace continues to the east and west.  To the north you 
 see the downtown section of New Sparta.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 To the north lies Broadway, the main street of New Sparta.
 ~
@@ -73,7 +73,7 @@ confident that this city is at least 1000 times better than Midgaard.
 the economically challenged neighborhood (note the PC terminology).
 Broadway continues to the north.
 ~
-275 4 0 0 0 0
+275 4 0 0 0 1
 D0
 You see Broadway continues.
 ~
@@ -102,7 +102,7 @@ of those annoying salespeople here, but there are more and more foreign
 tourists flashing their cameras.
    The harbour continues to the south and west.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D2
 You see the harbour continuing to the south.
 ~
@@ -124,7 +124,7 @@ camera back and the man yells expletives back at you in a strange
 tongue.
    To the harbour continues to the south and east.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D1
 You see the central harbourplace.
 ~
@@ -142,7 +142,7 @@ Broadway~
 entrance to the Cafe.  When you turn to face the west you see the
 entrance to the Pharmacy.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 Broadway continues.
 ~
@@ -187,7 +187,7 @@ to you rich and sheltered people.
    You see the entrance to the thieves guild to the south.  The alley
 continues to the west.  Broadway lies to the east.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D1
 You see Broadway.
 ~
@@ -211,7 +211,7 @@ By The Shore~
 with other various sea vessels.  To the south you can see the river.
    To the north is the east end of the harbourplace.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see the east end of the harbour.
 ~
@@ -226,7 +226,7 @@ here shooting an Old Midgaard beer commercial (It is REALLY too bad
 it is not a topless beach!).  
    To the north is the west end of the harbourplace.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see the west end of the harbour.
 ~
@@ -241,7 +241,7 @@ a bunch of bored college students).
    To the east is the Weapons Shop, and to the west is the Seven-
 Eleven.  Broadway continues north and south of here.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 More Broadway.
 ~
@@ -327,7 +327,7 @@ part of town.  Considering the situation here, you wonder how
 much worse it can get.
    Tin Can Alley continues to the east and west.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D1
 Still Tin Can Alley.
 ~
@@ -348,7 +348,7 @@ stadium.
    Broadway continues north and south; First Avenue extends west
 towards Hell's Kitchen and east to the stadium.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 More Broadway.
 ~
@@ -459,7 +459,7 @@ in New Sparta (like the public beach) and how much you'd rather be there!
    To the south is Baltimore Ave. and Tin Can Alley continues east 
 towards Broadway.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D1
 You see Tin Can Alley.
 ~
@@ -529,7 +529,7 @@ town has one), a wonderful place to spend your money on a rainy day
    To the east is Pee Wee's Peep Show and to the south, Baltimore 
 Avenue continues.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see Tin Can Alley.
 ~
@@ -569,7 +569,7 @@ district, but did you expect the good people of New Sparta to put up with
 anymore!!!).  There is some graffiti on the south wall.
    Baltimore Avenue is to the north.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see Baltimore Avenue.
 ~
@@ -590,7 +590,7 @@ First Avenue~
    You are on the west side of First Avenue.  In the distance to the
 east you can see the WarDome. Broadway is to the west.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D1
 You see the entrance to the WarDome.
 ~
@@ -613,7 +613,7 @@ conditions (rain, sleet, wind and hail).  A large electronic screen
 adorns the side of the edifice, promoting today's event.
    First street is to the west, east takes you into the WarDome.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D1
 You see the inside of WarDome.
 ~
@@ -682,7 +682,7 @@ game.  The stands overlook New Sparta's goal line.
    The West Stands continue north, and the southwest corner of
 the stadium is to the south.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see more of the West Stands.
 ~
@@ -706,7 +706,7 @@ section of WarDome.  Various spectators are here, viewing the
 game.  The stands overlook New Sparta's defensive zone.
    The West Stands continue north and south.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see more of the West Stands.
 ~
@@ -732,7 +732,7 @@ you wonder if you should go down....
    The West Stands continue north and south, stairs go down to the
 field level.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see more of the West Stands.
 ~
@@ -761,7 +761,7 @@ section of WarDome.  Various spectators are here, viewing the
 game.  The stands overlook Orcland's defensive zone.
    The stands continue north and south.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the West Stands.
 ~
@@ -786,7 +786,7 @@ but the best place to eye the hometown cheerleaders.
    The West Stands continue to the south, to the north is the
 northwest corner of WarDome.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the northwest corner of WarDome.
 ~
@@ -994,7 +994,7 @@ this is not the place to be for the faint of heart.
    The Blue Seats continue to the east, to the west is the exit 
 from WarDome.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the corner of the Warriors' end zone.
 ~
@@ -1019,7 +1019,7 @@ climb down the steps leading towards the playing field.
    The Blue Seats continue east and west, stairs go down to the
 field level.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the Warriors' end zone.
 ~
@@ -1052,7 +1052,7 @@ anyone has ever seen or heard.  You Clerics had better cover
 your ears.
    The Blue Seats continue west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the Warriors' end zone.
 ~
@@ -1114,7 +1114,7 @@ The 50-Meter Line~
 game.  To the south is the Warriors' zone, to the north is the
 Raiders'.  Centrefield is east, and the tunnel is west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the Raiders' zone.
 ~
@@ -1142,7 +1142,7 @@ The Warriors' Zone~
 50-Meter Line, to the south is the end zone.  The field also
 continues east.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the 50-Meter Line.
 ~
@@ -1167,7 +1167,7 @@ logo, a fierce warrior.
    The end zone continues to the east.  To the north is the Warriors'
 defensive zone.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the defensive zone.
 ~
@@ -1185,7 +1185,7 @@ The Warriors' Zone~
 field, to the south is the end zone.  The field also continues east 
 and west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see Centrefield.
 ~
@@ -1215,7 +1215,7 @@ logo, a fierce warrior.
    The end zone continues to the east and west.  To the north is 
 the Warriors' defensive zone, to the south is the tunnel.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the defensive zone.
 ~
@@ -1246,7 +1246,7 @@ course, just the Bloodbowl logo painted on the surface of the field.
    The respective defensive zones are to the north and south, and
 the 50-Meter Line runs east-west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see Orcland's defensive zone.
 ~
@@ -1274,7 +1274,7 @@ The Raiders' Zone~
 field, to the north is the end zone.  The field continues east and
 west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see Orcland's end zone.
 ~
@@ -1302,7 +1302,7 @@ The 50-Meter Line~
 game.  To the south is the Warriors' zone, to the north is the
 Raiders'.  Centrefield is to the west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the Raiders' zone.
 ~
@@ -1327,7 +1327,7 @@ logo, a fierce warrior.
    The end zone continues to the west.  To the north is the Warriors'
 defensive zone.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the defensive zone.
 ~
@@ -1345,7 +1345,7 @@ The Warriors' Zone~
 50-Meter Line, to the south is the end zone.  The field also
 continues west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see the 50-Meter Line.
 ~
@@ -1368,7 +1368,7 @@ The Raiders' Zone~
 50-Meter Line, to the north is the end zone.  The field also
 continues west.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see Orcland's end zone.
 ~
@@ -1394,7 +1394,7 @@ of a pirate's flag.
    The end zone continues to the west.  To the south is the Raiders'
 defensive zone.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D2
 You see the defensive zone.
 ~
@@ -1415,7 +1415,7 @@ of a pirate's flag.
    The end zone continues to the east.  To the south is the Raiders'
 defensive zone.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D1
 The end zone continues.
 ~
@@ -1433,7 +1433,7 @@ The Raiders' Zone~
 50-Meter Line, to the north is the end zone.  The field also
 continues east.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D0
 You see Orcland's end zone.
 ~
@@ -1459,7 +1459,7 @@ of a pirate's flag.
    The end zone continues east and west.  To the south is the Raiders'
 defensive zone.
 ~
-275 8 0 0 0 0
+275 8 0 0 0 1
 D1
 The end zone continues.
 ~
@@ -1484,7 +1484,7 @@ everywhere.
    Broadway continues to the north and south. The armoury is to the
 east and the magic shop is to the west.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see Broadway.
 ~
@@ -1548,7 +1548,7 @@ Broadway~
 is to the east and the New Spartan Bank is to the west.  Broadway
 continues to the north and south.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 Broadway continues.
 ~
@@ -1576,7 +1576,7 @@ Intersection of Broadway and Second Avenue~
 Avenue leads west to the dump and east to the church and fire station.    
    Broadway runs north-south and Second Avenue runs east-west.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 Broadway continues.
 ~
@@ -1607,7 +1607,7 @@ upper class neighborhood of New Sparta.
 the entrance to the Museum of National History and to the west
 is the entrance to the Waldorf Astoria.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 Broadway continues.
 ~
@@ -1674,7 +1674,7 @@ Broadway~
 west and the Goethe Library is to the east.  Broadway continues to
 the north and south.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see more of Broadway.
 ~
@@ -1767,7 +1767,7 @@ doubles as the entrance to the park. You see the park to the north,
 Broadway to the south, a department store to the west and the City
 Hall of New Sparta is to the east.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see Goethe's Garden.
 ~
@@ -2146,7 +2146,7 @@ From the condition of the street, it seems that the inhabitants haven't
 been paying their taxes lately.
    Broadway is to the west and the end of Second Avenue is to the east.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D1
 You see the east end of Second Avenue.
 ~
@@ -2163,7 +2163,7 @@ The East End Of Second Avenue~
    This is the east end of the very short Second Avenue.  The Church 
 is to the north and the fire station is to the south.
 ~
-275 0 0 0 0 0
+275 0 0 0 0 1
 D0
 You see the church.
 ~

--- a/lib/world/wld/276.wld
+++ b/lib/world/wld/276.wld
@@ -94,7 +94,7 @@ started building on this section of the road.
    To the east is the intersection of Broadway and Second Ave and to the 
 west you smell something bad.
 ~
-276 0 0 0 0 0
+276 0 0 0 0 1
 D1
 We already told you in the description that Broadway is there.
 ~
@@ -112,7 +112,7 @@ Second Avenue~
 you can't tell whether the smell is coming from the dump to the west,
 the pigs to the south, or from the animals to the north.
 ~
-276 0 0 0 0 0
+276 0 0 0 0 1
 D0
 You hear lots of barking and meowing.
 ~
@@ -180,7 +180,7 @@ trash, radioactive or otherwise.  Go ahead -- feel free to dump here
 too, but don't stay too long 'cause the radiation can be fatal.
    Second Avenue runs east.
 ~
-276 0 0 0 0 0
+276 0 0 0 0 1
 D1
 You see Second Avenue.
 ~
@@ -247,7 +247,7 @@ Goethe.
    To the north is the Statue of Goethe, and to the south is
 Broadway.
 ~
-276 0 0 0 0 0
+276 0 0 0 0 1
 D0
 You see the Statue of Goethe.
 ~
@@ -267,7 +267,7 @@ honour his genius and humanitarianism, and to his contribution
 to the foundation of New Sparta.
    To the south is Goethe's Garden.
 ~
-276 0 0 0 0 0
+276 0 0 0 0 1
 D2
 You see Goethe's Garden.
 ~
@@ -294,7 +294,7 @@ and you wonder if it is safe to find out what's going on.
    The Intersection of First and Broadway is to the east and Hell's
 Kitchen is to the west.
 ~
-276 0 0 0 0 0
+276 0 0 0 0 1
 D1
 You see the Intersection of First and Broadway.
 ~
@@ -318,7 +318,7 @@ rather be than in Hell's Kitchen.
    You decide that the only real exit is to First Avenue which is 
 to the east.
 ~
-276 1 0 0 0 0
+276 1 0 0 0 1
 D1
 You see First Avenue.
 ~

--- a/lib/world/wld/277.wld
+++ b/lib/world/wld/277.wld
@@ -4,7 +4,7 @@ A Dimly Lit Path~
 silently in the mild air.  Ahead the lights and sounds of a peaceful village can
 be heard faintly, smells of farm animals and cooking food wafting on the breeze.
 ~
-277 0 0 0 0 0
+277 0 0 0 0 3
 D0
 The dimly lit path leads north through the dense forest.
 ~
@@ -43,7 +43,7 @@ deep, dark forest all around.  The bustling sounds of people and the workings of
 a little village can be heard coming from the north, the light shining brighter
 from that direction.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 3
 D0
 The dimly lit path leads north through the dense forest.
 ~
@@ -61,7 +61,7 @@ A Dimly Lit Path~
 to the north.  Waving shadows dance across the ongoing path, growing less and
 less noticeable as the radiating light from the northern village increases.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 3
 D0
 The dimly lit path leads to a village.
 ~
@@ -80,7 +80,7 @@ amongst peaceful animals and gently waving crops.  Lush grasses thrive here,
 wisps of smoke unfurling from the tiny embedded chimneys in the hillsides.  
 Bywater road can be seen travelling from east to west.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D1
 To the east runs Bywater Road.
 ~
@@ -104,7 +104,7 @@ well evidenced by the worn surface, smoothed by the constant travels of hobbit
 feet.  Much of the lush, flourishing Shire stretches to the west, and a little
 general store stands to the north.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 The general store lies to the north.
 ~
@@ -142,7 +142,7 @@ sounds of Shire life breaking the quietness.  A few wooden steps lead to the
 north and a little blacksmith's shop there, while to the south lies a pleasant
 looking nursery.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 Steps lead to a friendly looking weaponry and armory.
 ~
@@ -200,7 +200,7 @@ orchard trees filling the air with the scent of plant life, as well as the
 buzzing of various bees about their work.  A large, imposing building lies to
 the east and a homey looking Inn stands further to the south.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 ~
 ~
@@ -263,7 +263,7 @@ fruits.  Bright pollen sparkles here and there like tiny fireflies dancing in
 the breeze.  The sounds of an instructor's monotone voice can be heard faintly,
 perhaps from the grounds to the east.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 To the north runs Bywater Road.
 ~
@@ -287,7 +287,7 @@ passage through much of Shiredom.  Strong smells of baking and frying mushrooms
 permeate the air from the residences to the east and west.  To the south, the
 Ivy Bush inn stands, much fabled for its hospitality and services.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 To the north runs Bywater Road.
 ~
@@ -373,7 +373,7 @@ straggling bits of grass and plantlife gradually pushing at the borders as they
 flourish.  Cattle can be seen grazing lazily amongst the fields, small rabbits
 and other creatures scurrying about obliviously.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D1
 To the east you see the entrance to the Shire.
 ~
@@ -411,7 +411,7 @@ west road.  The ruts of wagon wheels line the path here as though this section
 is well travelled, a small grocery shop to the south catering to hungry
 venturers.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 Brandywine Bridge offers safe passage across the tumultuous river.
 ~
@@ -455,7 +455,7 @@ Brandywine River winding through the land to the north.  The air is crisp and
 slightly moist, the only sounds the babbling river and louder trickling from a
 southern watermill.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D1
 To the east runs Bywater Road.
 ~
@@ -538,7 +538,7 @@ and deer peacefully grazing in the far stretching fields.  Sounds of joyful
 celebration can be heard coming from the west, wisps of smoke unfurling like
 banners on the horizon.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 4
 D1
 To the east runs Bywater Road.
 ~
@@ -557,7 +557,7 @@ serenly past.  Splashes of white and yellow stand out brightly where patches of
 clover and daisies grow, puffy dandelion heads explode into seedlings, sending
 miniature twirling parachutes through the air.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 2
 D2
 You see a grassy field.
 ~
@@ -571,7 +571,7 @@ colourful banners strewn about the trees.  It seems to be a birthday party
 judging by the joyful chants and songs that spontaneously erupt, filling the air
 with the sound of laughter and merriment.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 2
 D0
 You see a grassy field.
 ~
@@ -600,7 +600,7 @@ clapping coming from the north.  Little pieces of coloured party confetti floats
 in the breeze along with the seedlings, smells of fresh cooking and baking
 saturating the air.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 2
 D0
 You see a grassy field.
 ~
@@ -614,7 +614,7 @@ clover and vibrant red poppies dancing in the breeze.  The sounds of partying
 and joyful shouts fill the air, several tables laid out to the east and the
 smell of all sorts of food wafting temptingly.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 2
 D1
 You see a grassy field.
 ~
@@ -629,7 +629,7 @@ invitingly refreshing, pale smooth pebbles lining the ground beneath and tall
 reeds bending in the breeze, caressing the water as it rushes past.  Delving
 Lane extends to the north, while Bywater Road can be seen to the south.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 You see Delving Lane.
 ~
@@ -649,7 +649,7 @@ art of innkeeping, offers rest and comfort to the east.  Little fireflies dance
 in clusters here beneath the larger trees, glowing lights winking in and out of
 exis tance from the shadows.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 You see Delving Lane.
 ~
@@ -673,7 +673,7 @@ east.  The road is gently paved here, cobbled stone carefully laid to ease the
 passage of riders and wagons.  An unpleasant smell lingers in the air of various
 farm animals, the sounds of braying and mooing coming from the west.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 You see Delving Lane.
 ~
@@ -702,7 +702,7 @@ flowers of various colours blooming on either side, and large trees lining the
 path, shading it with long graceful branches.  Little sunflower seeds lie
 scattered around, as if some traveller stopped for a brief snack.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 A large, magnificent house meets your steady gaze.  Above the round door a
 sign reads 'Bag End'.
@@ -781,7 +781,7 @@ hands.  The grass has been left to grow wild and plentiful, kept trimmed by the
 constant munching of the various cattle animals here.  The smell of a pig pen is
 unmistakeable in the air, sounds of scuffling and grunts coming from the south.
 ~
-277 0 0 0 0 0
+277 0 0 0 0 2
 D0
 You see a large barn.
 ~
@@ -805,7 +805,7 @@ touches.  Various slops and leftovers have been spilt on the ground, being
 scavenged and trodden into the mud by the resident farm animals, their smell
 hanging rankly in the air.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 You see a grassy field.
 ~
@@ -824,7 +824,7 @@ winds through the grass.  A small residence can be seen at the northern end of
 the trail.  The rest of the land seemingly left to the farm animals, the noisy
 din of pigs grunting and scuffling coming from the east.  
 ~
-277 0 0 0 0 0
+277 0 0 0 0 1
 D0
 To the north you see a modest house.
 ~

--- a/lib/world/wld/278.wld
+++ b/lib/world/wld/278.wld
@@ -6,7 +6,7 @@ lie along the walk, and the cutting, salty smell of the ocean stings your nose.
 You feel a sense of rejuvenation as you stare out into the sea.  You know many
 adventures lie ahead.    
 ~
-278 0 0 0 0 0
+278 0 0 0 0 1
 D0
 To your north you can see the deep, wide ocean.
 ~
@@ -195,7 +195,7 @@ The Impassible Current~
 what you try to do, it won't stop churning!  Oh NO!  The current drags you and
 the boat down.    
 ~
-278 516 0 0 0 0
+278 516 0 0 0 1
 S
 #27809
 In the ocean~
@@ -1075,6 +1075,6 @@ Schylla's Trap~
    The water here swirls into a churning whirlpool.  Try as you might, you
 cannot escape the boiling mass of water--Schylla has got you.    
 ~
-278 516 0 0 0 0
+278 516 0 0 0 1
 S
 $~

--- a/lib/world/wld/279.wld
+++ b/lib/world/wld/279.wld
@@ -6,7 +6,7 @@ large sign reminds visitors to be sure to visit the cathedral of Paris here.
 The street continues on to the east, the Champs Elysees lies to the north, and
 off to the south the town of Lyon can be seen.   
 ~
-279 4 0 0 0 0
+279 4 0 0 0 1
 D0
 ~
 ~
@@ -33,7 +33,7 @@ branching trees that grow on either side. Delicate flower petals drift lazily
 in the air, partially obscuring the more distant views of this continuing east
 to west path.    
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D1
 ~
 ~
@@ -50,7 +50,7 @@ west. At the side an immense stone wall can be seen, a massive steeple rising
 from above it. No ordinary structure, it is beautifully designed and carefully
 decorated, obviously belonging to a very important cathedral of Paris. 
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D1
 ~
 ~
@@ -68,7 +68,7 @@ evangelists.  Above the door is a breathtakingly huge rose window, alight with
 flickering candlefire from the streets below.  The street continues on to the
 east and the west, the southern way leading into the cathedral.  
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D1
 ~
 ~
@@ -88,7 +88,7 @@ The End of Notre Dame Street~
 around except for the large steeple visible to the east. Everything is still
 and quiet here, seemingly a way not travelled very often.   
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D3
 ~
 ~
@@ -705,7 +705,7 @@ waters rippling leisurely below. The river of Cena stretches lazily either side
 of the bridge, the water so calm and clean that it mirrors the surroundings
 perfectly. A large crossroads sign stands prominently here. 
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -727,7 +727,7 @@ trickling water and talking people fill the atmosphere, along with delicate
 birdsong. A large board welcomes visitors to this place, proclaiming the town
 as the best maker of wines in all France.
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -745,7 +745,7 @@ People continue quietly about their normal daily living, working at their trade
 or simply bustling about on some errand. The heart of the city seems to stretch
 to the south, and the city of Paris lies to the north.   
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -784,7 +784,7 @@ dogwalkers. Fragile flowers sway in the breezes, filling the atmosphere with a
 heady perfumed aroma and tall, leafy trees stand around, somewhat shielding
 this little grassy area from the paving and concrete of the city around.   
 ~
-279 0 0 0 0 0
+279 0 0 0 0 3
 D1
 ~
 ~
@@ -798,7 +798,7 @@ heard, along with the mellow sounds of chattering people. To the east a small
 magic shop displays its wares in the window, and to the west is a small
 miscellaneous shop.   
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -835,7 +835,7 @@ The End of the Principal Street~
 and the west. The clattering sound of carriages can be heard from the station
 that lies to the south, advertising trips to any city of France.  
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -911,7 +911,7 @@ their breakfast. Damp and cold, the menacing shadows look like the perfect
 place for ambushers. Little rodents run here and there, beady eyes glistening
 in the dark, the ground wet and mushy with goodness knows what.  
 ~
-279 297 0 0 0 6
+279 297 0 0 0 0
 D1
 ~
 ~
@@ -928,7 +928,7 @@ shadows giving the impression that thieves and criminals are plotting an
 imminent attack. The smell too, is overpowering, stagnating in this airless
 part of the tunnel and decaying into an even fouler stench.  
 ~
-279 361 0 0 0 6
+279 361 0 0 0 0
 D3
 ~
 ~
@@ -943,7 +943,7 @@ their tops can hardly be seen, gigantic trunks planted in the ground like the
 columns of a grand hall. To the north lies a golden gate, a prominent notice
 fixed to the bars.   
 ~
-279 4 0 0 0 0
+279 4 0 0 0 3
 D0
 ~
 gate~
@@ -967,7 +967,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.   
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -993,7 +993,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -1019,7 +1019,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -1045,7 +1045,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -1071,7 +1071,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -1097,7 +1097,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -1123,7 +1123,7 @@ high children's voices giggling and playing. Flickering fire lights the area,
 casting the surrounding dark trees of Champs Elysees in a welcoming, almost
 protective glow.    
 ~
-279 0 0 0 0 0
+279 0 0 0 0 2
 D2
 ~
 ~
@@ -1141,7 +1141,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -1167,7 +1167,7 @@ rustling overhead leaves, cold droplets of moisture glistening on every surface
 like dew. All around, everything appears the same, tall dark trunks and leafy
 plant life fading into darker shadows.
 ~
-279 1 0 0 0 0
+279 1 0 0 0 3
 D0
 ~
 ~
@@ -1192,7 +1192,7 @@ grounded centrally before the plaza of the concorde that lies to the north.
 This is the entrance to the historical center of the city of Paris, where the
 revolution of France started in the XVIII century.  
 ~
-279 4 0 0 0 0
+279 4 0 0 0 2
 D0
 ~
 ~
@@ -1210,7 +1210,7 @@ themselves, cool leafy branches fanning the air as they sway. Two wooden
 benches stand either side of the square, painted a pale white, a little note
 pinned to each.   
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -1239,7 +1239,7 @@ Plaza Louis XIV~
 off from the surrounding houses.  Nearby revolutionaries can be seen running
 through the town, ducking inside open doorways or hiding within the alleyways.
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -1257,7 +1257,7 @@ people's anger toward the monarchy was expressing itself in the atmosphere.
 Fluttering of wings breaks the silence every now and again, pigeons landing to
 gobble dropped seeds before hurrying away.  
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -1274,7 +1274,7 @@ and crumbs obviously left for the abundant bird population. Patches of neatly
 gardened grass lie here and there, sprinkled with droplets of moisture and
 vibrantly green. 
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -1295,7 +1295,7 @@ from nearby candles avoids it.  A huge statue of the king stands proudly here,
 its once smooth surface worn with the scratchings of birds, one or two nests
 visible in the higher nooks and crannies.  
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -1320,7 +1320,7 @@ layer of perpetual moisture from the air. The grey granite paving adds to the
 feeling of discontent and misery that hangs in the air, flickering light from
 the candle lamps casting everything in dancing shadows.  
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 ~
@@ -1343,7 +1343,7 @@ stone ground, creepings of moss beginning to grow like dark green veins along
 the paving. To the west stands a large building, apparently a large
 headquarters or school.  
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D1
 ~
 ~
@@ -1363,7 +1363,7 @@ The Entrance to Musketeer H.Q.~
 still. There appears to be no security at all, much of the place open to public
 exploration, a little unguarded door lies to the north.   
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D0
 ~
 door~
@@ -1388,7 +1388,7 @@ windows looming from the horizon to the east. Blossoming flowers and shrubbery
 border the paving here, natural hues of grassy green and the colourful splashes
 of red and purple blooms brightening the place.  
 ~
-279 0 0 0 0 0
+279 0 0 0 0 1
 D1
 ~
 ~

--- a/lib/world/wld/281.wld
+++ b/lib/world/wld/281.wld
@@ -4,7 +4,7 @@ A paved path~
 paved path leads toward the east.  To the northeast is a large building, 
 its yard lined by an old fence of stone.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 1
 D1
 ~
 ~
@@ -26,7 +26,7 @@ Before a small gate~
 the fence.  A sign has been fastened on the gate, reading "Galeaufir's
 Tavern".  A brown path leads to the east, toward light forest.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D0
 You see the yard of the tavern.
 ~
@@ -49,7 +49,7 @@ here and there.  The paving leads straight toward the tavern, but there
 is also a faint trail to the west.  This could be a place to have fun,
 at least some voices of singing are heard from inside the building.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D0
 You see the tavern.
 ~
@@ -72,7 +72,7 @@ On the lawn~
 foliage covers the yard in massive shadows.  The corner of the tavern is
 close to the west.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D1
 You see the yard before the tavern.
 ~
@@ -85,7 +85,7 @@ By the side of the tavern~
 can be seen further to the west - masses of people and clamour.  To the 
 is a small, wooden, and cell-like building, obviously a lavatory.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D0
 You see a small, wooden building.
 ~
@@ -276,7 +276,7 @@ forest to the east, and begins to wriggle its way there.  A mild
 chirping can be heard from somewhere nearby.
    The city of XXXX is further away to the west.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D1
 You see the forest.
 ~
@@ -295,7 +295,7 @@ very narrow, wriggling by the side of some large stones.  Passing by
 a wagon of any kind would be impossible.  To the east grows dense 
 thicket.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 2
 D0
 You see more forest.
 ~
@@ -318,7 +318,7 @@ A path~
 some sandy ground.  Also, from the same direction was heard something
 that sounded peculiar talk...
 ~
-281 4 0 0 0 0
+281 4 0 0 0 2
 D1
 You see a small dell.
 ~
@@ -336,7 +336,7 @@ A small dell~
 water, approximately flown here a few months ago.  The path continues to 
 the east, climbing over great roots.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D1
 You see a small intersection of trails.
 ~
@@ -354,7 +354,7 @@ An intersection of paths~
 and east.  Since the foliage dominates your vision more or less, only the 
 highest of Towers of Midgaard can be seen farther to the west.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see a grassy path.
 ~
@@ -378,7 +378,7 @@ grooves that are yet visible on it, this way was probably used much, a
 long time ago. 
    Leaning against a greyish tree, there is a rottening, wooden sign.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see a hillside of some kind descending there.
 ~
@@ -404,7 +404,7 @@ A low hillside~
 toward what looks a small marshland down there.  For some reason it does 
 not look very fascinating.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 4
 D2
 You see the grassy path.
 ~
@@ -426,7 +426,7 @@ away to the north seems to be an another hillside, growing high trees.
    Remainders of a bridge-like structure still lie here, leading
 across the marsh.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 3
 D0
 You see more marshland.
 ~
@@ -449,7 +449,7 @@ Stepping on some hammocks~
 thus you are able to move on.  Close to the east grows a large, somewhat
 peculiar bush that covers your vision quite totally.  
 ~
-281 0 0 0 0 0
+281 0 0 0 0 3
 D3
 You see the marshland.
 ~
@@ -487,7 +487,7 @@ the north is an another hillside, high and much more steeper than the
 one you just descended.  It grows some deep brown hay and tall birches.  
 A faint trail climbs on it.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 3
 D2
 You see more marshland.
 ~
@@ -505,7 +505,7 @@ A steep hillside~
 twisted branches.  A figure of grey building begins to discern slowly 
 to the northwest.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 4
 D0
 You see the yard of a decayed building.
 ~
@@ -525,7 +525,7 @@ of the other wooden parts are mostly gone, and the greyish walls break
 off so badly that you somewhat wonder how the building still stands.  An 
 open doorway gives passage inside.  To the north lies an old pen.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D0
 You see a rottening pen.
 ~
@@ -547,7 +547,7 @@ Inside an old pen~
    The muddy ground here is covered in wooden fragments and old junk, 
 nothing of interest.  To the north the forest gets thicker.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D2
 You see the yard of the building.
 ~
@@ -608,7 +608,7 @@ A weak trail~
 you feel yourself tiny and pitiful compared to those old giants.  The trail
 here is quite narrow.  
 ~
-281 4 0 0 0 0
+281 4 0 0 0 2
 D1
 You see more forest.
 ~
@@ -625,7 +625,7 @@ A weak trail~
    You step forward.  To the north is a small square, and to the south
 there is a grove of somekind.  The trail itself leads to the west and east.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see a square.
 ~
@@ -653,7 +653,7 @@ A weak trail~
 leading through the dark green arch of the gigantic trees.  To the south
 lies a small grove.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see more forest.
 ~
@@ -676,7 +676,7 @@ A square of mushrooms~
 of deep brown mushrooms grow here, seemingly alluring the animals of the 
 forest, for many of them appear munched.  The trail lies to the southeast.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D1
 You see more forest.
 ~
@@ -695,7 +695,7 @@ apart slowly, and you hear birds singing here and there.  Way farther
 to the north raises a tremendous, grey figure, the mountainside of
 Great Aesarthwe.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D1
 You see trees getting more apart.
 ~
@@ -718,7 +718,7 @@ A weak trail~
 on your cheeks.  The trail leads north toward the mountain, and west, into 
 the deeper forest.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see the forest becoming lighter.
 ~
@@ -731,7 +731,7 @@ A lighter forest~
 side begins to ascend, very gentle at first.  Rippling of water can be heard 
 from nearby.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see a small brook.
 ~
@@ -767,7 +767,7 @@ Walking on stony soil~
    As you walk on, the mountainside begins to change much more steeper 
 before you.  However it seems that you can advance easily enough.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 4
 D2
 You see the brook.
 ~
@@ -913,7 +913,7 @@ roots, from which various fibres with soil still hang down.  There
 are small footprints on the ground.  While an improvised ladder leads 
 up, there is a small, wooden door the east.
 ~
-281 5 0 0 0 0
+281 5 0 0 0 1
 D1
 You see a dwelling of some kind.
 ~
@@ -931,7 +931,7 @@ Inside the hollow trunk~
 completely hollow, and enables you to move about.  Some kind of ladder 
 leads down from here.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 1
 D3
 You see the grove.
 ~
@@ -950,7 +950,7 @@ foliage spreads in every direction like a gigantic green ball.  Its trunk
 is gnarled and carries the scars of hundreds of years.  A small hole appears 
 to penetrate into the pith of the tree.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D0
 You see the forest.
 ~
@@ -977,7 +977,7 @@ On the hill~
    You are standing on a low and barren hill.  There are several foot-
 prints on it.  There is a small grove to the north. 
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see the grove.
 ~
@@ -993,7 +993,7 @@ but also somewhat sad.
 nearly swarms life.  A faint track leads to the north, and to the
 west there lies a ditch.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D0
 You see the forest.
 ~
@@ -1016,7 +1016,7 @@ A grassy ditch~
 Low bushes grow around.  The ditch leads west, while there is a grove to 
 the east.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 3
 D1
 You see a small grove.
 ~
@@ -1034,7 +1034,7 @@ Walking in the ditch~
 south you can see a grassy hillside, on where a narrow path descends.  
 The ditch leads west and east.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 3
 D1
 You see the ditch.
 ~
@@ -1056,7 +1056,7 @@ A grassy ditch~
    You are standing on the bottom of a small and grassy ditch.  There 
 is some thicket growing around.  The ditch leads to the east.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 3
 D0
 You see some bushes.
 ~
@@ -1074,7 +1074,7 @@ Through some bushes~
 spiders and gadflies.  Most of these bushes are unusually tough, lashing 
 your face with an unpleasant force.  There is a small ditch to the south.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 3
 D2
 You see a small ditch.
 ~
@@ -1092,7 +1092,7 @@ The brink of the grassy hillside~
 to descend gently.  Below there lies what appears very dense forest.
 To the north is a ditch.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 4
 D0
 You see the ditch.
 ~
@@ -1109,7 +1109,7 @@ Descending the hillside~
    You start climbing down a small worn-out path on the hillside.  Despite 
 the fresh footprints all around, the way doesn't appear very busy.   
 ~
-281 0 0 0 0 0
+281 0 0 0 0 4
 D4
 You see the top of the hillside.
 ~
@@ -1127,7 +1127,7 @@ On a grey trunk~
 penetrating into the forest as if it were a straight bridge.  You begin 
 to walk on it.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D1
 You see the trunk leading there.
 ~
@@ -1147,7 +1147,7 @@ giant overturned years ago.
    Now, there lies the rhizome.  The roots appear to give passage to 
 the south.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D2
 You see a narrow path.
 ~
@@ -1166,7 +1166,7 @@ stones make your walking quite difficult, and you are worried about
 your feet.  The foliages form a green and inpenetrable "wall" around 
 the path which seems to descend to the east. 
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see the trunk.
 ~
@@ -1184,7 +1184,7 @@ Under some massive roots~
 an ancient trench.  Tremendous, gnarled roots from some brown and black
 arches above.  The path leads both to the west and east.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D1
 You see a small meadow.
 ~
@@ -1202,7 +1202,7 @@ A small meadow~
 slowly in the wind.  The path leads towards the north, where you make out 
 some high osiers.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see the osiers.
 ~
@@ -1220,7 +1220,7 @@ On a trail through high osiers~
 walk on it easily.  Now your trip begins to wind downwards, from where you 
 can hear some voices.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 3
 D2
 You see the small meadow.
 ~
@@ -1241,7 +1241,7 @@ most of them black.  Also you notice that the crater is full of small
 folk, everyone directing towards a structure of some kind further away 
 to the east. 
 ~
-281 4 0 0 0 0
+281 4 0 0 0 2
 D1
 You see the crater.
 ~
@@ -1262,7 +1262,7 @@ totem or a statue of some kind.  Yet you do not know what this all is
 about, but no doubt this place must be of great importance and sanctity 
 for these people.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D1
 You see the crater.
 ~
@@ -1284,7 +1284,7 @@ Before the wooden steps~
    Just before you lie firm, wooden steps, ascending onto the dias.  
 Simple, but elegant symbols have been encarved on them.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D3
 You see the crater.
 ~
@@ -1301,7 +1301,7 @@ Before the wooden steps~
    Just before you lie firm, wooden steps, ascending onto the dias.  
 Simple, but elegant symbols have been encarved on them.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 2
 D0
 You see the crater.
 ~
@@ -1323,7 +1323,7 @@ leaves and garments.
    The brownies assemble to the foot of the dais and you feel the
 atmosphere running high.
 ~
-281 4 0 0 0 0
+281 4 0 0 0 1
 D0
 You see the steps down.
 ~
@@ -1347,7 +1347,7 @@ S
 Descending the steps~
    You start descending from the dais.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D2
 You see the plateau.
 ~
@@ -1363,7 +1363,7 @@ S
 Descending the steps~
    You start descending from the dais.
 ~
-281 0 0 0 0 0
+281 0 0 0 0 1
 D1
 You see the plateau.
 ~

--- a/lib/world/wld/283.wld
+++ b/lib/world/wld/283.wld
@@ -86,7 +86,7 @@ you walk on is creaking with every step, and the shudders and the walls look
 chipped, and just bent out of shape.  Well, going inside would be better than
 staying out here in the rain all night, wouldn't it?    
 ~
-283 192 0 0 0 0
+283 192 0 0 0 1
 D0
 The front door is north.
 ~
@@ -534,7 +534,7 @@ you walk on it, and then it starts to get louder.  The stairs lead down to the
 ground.  When you look over the side you can see a path, and then in the
 distance a small outhouse.    
 ~
-283 69 0 0 0 0
+283 69 0 0 0 1
 D2
 You can go back inside if you wish.
 ~
@@ -553,7 +553,7 @@ north to the outhouse.  A path leads east from here too, which doesn't look to
 be going anywhere.  The lightning is still striking, and therefore the thunder
 is still hurting your ears.    
 ~
-283 69 0 0 0 0
+283 69 0 0 0 2
 D0
 A path leads to the outhouse.
 ~
@@ -577,7 +577,7 @@ really stinks.  The path is getting you all muddy again, as the rain pours down
 harder than before.  The outhouse is north and another path breaks off this one
 and heads east.    
 ~
-283 69 0 0 0 0
+283 69 0 0 0 2
 D0
 The outhouse is north.
 ~
@@ -620,7 +620,7 @@ your eyes.  It is very dark outside, and lightning flashes nearby.  Thunder
 shortly follows, making a very loud "BOOM".  To the east is where the stairs
 lead up to the back deck.    
 ~
-283 69 0 0 0 0
+283 69 0 0 0 2
 D1
 The bottom of the stairs is east.
 ~
@@ -645,7 +645,7 @@ in this area and it's raining pretty hard now.  Suddenly, lightning strikes a
 tree, which makes a loud noise before falling to the ground with a loud "THUD".
   
 ~
-283 65 0 0 0 0
+283 65 0 0 0 2
 D1
 You can go back east if you want to...
 ~
@@ -663,7 +663,7 @@ A Path Through the Forest~
 Winds blow around leaves and other small objects, as lightning and thunder do
 their work.  Rain pours down on you, getting you all wet and very cold.    
 ~
-283 69 0 0 0 0
+283 69 0 0 0 2
 D3
 The path goes east some more.
 ~
@@ -1024,7 +1024,7 @@ passage leading out here.  The night is still very stormy, as you try to walk
 as carefully as you can without fatally falling off.  That might hurt a little,
 don't you agree?    
 ~
-283 193 0 0 0 0
+283 193 0 0 0 1
 D0
 You can travel north on this roof.
 ~
@@ -1043,7 +1043,7 @@ you are going to be picked up and thrown into the ground at any moment, so you
 try to move slowly and steadily.  Carefully you make your way around a section
 of the roof that is unfinished, and try to head north.    
 ~
-283 192 0 0 0 0
+283 192 0 0 0 1
 D0
 The roof goes north more.
 ~
@@ -1063,7 +1063,7 @@ escape from this nightmare.  The roof ends by the looks of it...  North of
 here.  The rain is making it very slippery up here, as you can barely walk
 without slipping a little.    
 ~
-283 129 0 0 0 0
+283 129 0 0 0 1
 D0
 The roof heads north a bit.
 ~
@@ -1087,7 +1087,7 @@ here have been washed away from the rain, making it look bare.  It's beginning
 to get very slipper up here.  By the looks of it, there seems to be nowhere to
 go from here.  A small chimney is directly east of you.    
 ~
-283 65 0 0 0 0
+283 65 0 0 0 1
 D2
 The roof extends south.
 ~
@@ -1106,7 +1106,7 @@ big enough for one to fit in it.  It is made of big red bricks which are also
 chipped.  All over.  No smoke is coming up, so why not check out where it
 leads?    
 ~
-283 449 0 0 0 0
+283 449 0 0 0 1
 D1
 The roof is over there.
 ~
@@ -1125,7 +1125,7 @@ and the ground, as the lightning flashes and the thunder booms.  The porch is
 made of wood just like everything else in this dumb old house.  There is a
 small railing lining the outside of the balcony, so people don't fall off.    
 ~
-283 709 0 0 0 0
+283 709 0 0 0 1
 D2
 Nothing special back there...
 ~
@@ -1178,7 +1178,7 @@ Oops!~
 gust of wind comes along and hits you hard.  Unprepared, you lose your grip on
 the very wet ropes, and fly head first into the ground below you.  OUCH!!!!!  
 ~
-283 741 0 0 0 0
+283 741 0 0 0 1
 D4
 You see nothing special...
 ~
@@ -1190,7 +1190,7 @@ At the Well~
    You are now standing at a well in the back yard of the house.  The
 thunderstorm still rocks on as you examine the well.    
 ~
-283 577 0 0 0 0
+283 577 0 0 0 2
 D1
 Nothing special there...
 ~

--- a/lib/world/wld/284.wld
+++ b/lib/world/wld/284.wld
@@ -5,7 +5,7 @@ There is no vegetation inside the circle, strangely enough.  A low cumulous of
 swirling mist engulfs you from the knees down, making it look as though you are
 partially buried.    
 ~
-284 5 0 0 0 0
+284 5 0 0 0 3
 D5
 ~
 mound~
@@ -27,7 +27,7 @@ rule of the hubristic Lord Suzerain.  In virtually every corner you see ruins
 of some sort or another intermingled with old, age-whitened bones from all
 manner of beasts.  Exits lead in all cardinal directions.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -61,7 +61,7 @@ has been erected here, abutting the east wall of the city - it looks quite deep
 and wide.  The water is a crystaline blue which exudes holiness, something
 quite strange for such an evil city.  Exits lead West, North and South.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -86,7 +86,7 @@ order.  And the smell, oh boy!  It's all you can do to keep from losing your
 lunch right now.  The corpses are stacked too high to exit East, but you can
 pass North, South or West.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -111,7 +111,7 @@ A culdesac~
 is a large fountain, and a door lies to the North, beneath a large tavern sign
 depicting the unspeakable.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell~
 tavern~
@@ -127,7 +127,7 @@ The twisting hedges.~
    You are standing amongst a row of twisting hedges about 7 feet tall.  
 Pathways through the hedges lead in all cardinal directions.    
 ~
-284 5 0 0 0 0
+284 5 0 0 0 1
 D0
 The twisting hedges.~
 ~
@@ -150,7 +150,7 @@ The twisting hedges.~
    You are standing amongst a row of twisting hedges about 7 feet tall.  
 Pathways through the hedges lead in all cardinal directions.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 The twisting hedges.~
 ~
@@ -177,7 +177,7 @@ The twisting hedges.~
    You are standing amongst a row of twisting hedges about 7 feet tall.  
 Pathways through the hedges lead in all cardinal directions.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 The twisting hedges.~
 ~
@@ -204,7 +204,7 @@ The twisting hedges.~
    You are standing amongst a row of twisting hedges about 7 feet tall.  
 Pathways through the hedges lead in all cardinal directions.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 The twisting hedges.~
 ~
@@ -227,7 +227,7 @@ The twisting hedges.~
    You are standing amongst a row of twisting hedges about 7 feet tall.  
 Pathways through the hedges lead in all cardinal directions.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 The twisting hedges.~
 ~
@@ -252,7 +252,7 @@ your spine.  The walls, floor and ceiling are a viscous, blood-red mass that
 eludes description.  A rift in the ceiling above you causes a slight breeze to
 ruffle your hair.  A magic portal stands south, leading into the unknown.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -276,7 +276,7 @@ causes you to stagger uncontrollably, while the ceiling rhythmically pumps
 upwards and downwards.  You can feel the lifeblood draining from your body.  
 To stay here long would surely mean the end of you.    
 ~
-284 16389 0 0 0 0
+284 16389 0 0 0 1
 D0
 The bottomless pit.~
 ~
@@ -408,7 +408,7 @@ The streets of Ghenna.~
    You are standing on a non-descript city street in Ghenna.  The road
 continues East and West, rolling gently over a dale.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D1
 Too dark to tell.
 ~
@@ -428,7 +428,7 @@ north which seems to be moving somehow.  Next to the bar a stairwell disappears
 into blackness above.  The ceiling is vaulted, and sports three candeled
 chandeliers, which hang like victims above you.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -452,7 +452,7 @@ sturdy, the bar is very pliant to the touch, and it seems to be MOVING ever so
 slightly, as if it were ALIVE!  A stairwell is here, leading upwards into
 blackness.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D2
 Too dark to tell.
 ~
@@ -826,7 +826,7 @@ The mouth of a large cave.~
 mouth of a large cave about 100 feet in diameter.  A steady trickle of blood
 runs down the stone steps which lead upwards - Dare you enter?    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 A labyrinth of bodies.~
 ~
@@ -1188,7 +1188,7 @@ The streets of Ghenna.~
    You are standing on a city street in Ghenna.  Paved with cobble- stones, the
 road is slick with the blood of many a wayward adventurer.  Watch your step!  
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D1
 Too dark to tell.
 ~
@@ -1237,7 +1237,7 @@ The streets of Ghenna.~
    You are standing on of the many streets in Ghenna.  A high wall blocks the
 passage westward, but you may exit North, South or East.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -1261,7 +1261,7 @@ batters your feet unmercifully.  To the west is the city wall, while a
 burnedout building is East of you, barely capable of standing in the slight
 breeze which whips through here.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -1285,7 +1285,7 @@ that is bleached white with age.  To the West you can see the cobblestone
 streets of Ghenna.  You might want to exit this building soon, as it could
 crumble at any moment.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D3
 The streets of Ghenna.~
 ~
@@ -1296,7 +1296,7 @@ The streets of Ghenna.~
    You are standing on a corner street in Ghenna.  To the west lies the city
 wall while to the North is a door.  The street continues South, and East.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 ~
 red~
@@ -1318,7 +1318,7 @@ The dominatrix's abode.~
 Whips, chains and handcuffs are displayed prominently on each of the 3 walls.
 A position chair sits in the middle of the room for your hedonistic desires.  
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D2
 Too dark to tell.
 ~
@@ -1331,7 +1331,7 @@ A street in Ghenna.~
 city entrance.  The rubble from fallen buildings has made any other exits
 impossible.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D1
 Too dark to tell.
 ~
@@ -1351,7 +1351,7 @@ the South.  The building to the North, however, looks a bit more intact.  The
 street ends towards the East, near a mountain of rubble.  To the West, the
 street goes on for some distance.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -1464,7 +1464,7 @@ A city street in Ghenna.~
 your exit.  You may leave North, South and West.  Be careful not to trip over
 the many corpses that line these streets.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -1486,7 +1486,7 @@ A road in Ghenna.~
    This road is quite narrow, but seems to open up towards the South.  A fallen
 building stands to the West, and the city wall blocks the exit north.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D1
 Too dark to tell.
 ~
@@ -1503,7 +1503,7 @@ A north-south street in Ghenna.~
    This narrow lane runs North to South.  The city wall towers above you to the
 east, and a door lies West, beneath a glowing red light.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -1525,7 +1525,7 @@ A bend in the road.~
    You are at a bend in the road.  The city wall lies north, and east of you
 prohibiting exits in those directions.  A narrow lane leads Westward.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D2
 Too dark to tell.
 ~
@@ -1690,7 +1690,7 @@ A slimey footpath.~
 ectoplasm - its really gross.  The path is so slippery that you cant ascend to
 where there is a covered walkway above you.  Your only option is to go West.  
 ~
-284 5 0 0 0 0
+284 5 0 0 0 1
 D3
 Too dark to tell.
 ~
@@ -1703,7 +1703,7 @@ A slimey footpath.~
 animals that apparently became bogged down here.  There are exits to the North,
 and East.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -1721,7 +1721,7 @@ A slimey footpath.~
 the red slime.  Maybe this wasn't such a good idea...  You can exit towards the
 West, or to the South.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D2
 Too dark to tell.
 ~
@@ -1738,7 +1738,7 @@ A slimey footpath.~
    The slime seems to be lessening a bit here, though the way is still as
 slippery as can be.  A clearing can be seen to the South.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D1
 Too dark to tell.
 ~
@@ -1756,7 +1756,7 @@ consists of red clay dirt, with a few boulders lying around you.  Apparently it
 is a primitive pathway of some sort, for to the South you can see what appears
 to be the mouth of a cave.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 Too dark to tell.
 ~
@@ -1773,7 +1773,7 @@ The mouth of a small cave.~
 promontory.  A rough hewn staircase leads Downwards, while to the North is a
 small clearing.    
 ~
-284 1 0 0 0 0
+284 1 0 0 0 1
 D0
 A small clearing.~
 ~
@@ -1790,7 +1790,7 @@ An underground cavern.~
 Moisture trickles down the smooth rock walls in large rivulets, and water drips
 on your head from the ceiling above.  A passageway leads South.    
 ~
-284 9 0 0 0 0
+284 9 0 0 0 1
 D2
 Too dark to tell.
 ~
@@ -2045,7 +2045,7 @@ A dead end.~
    The street dead ends here in a twisted mass of brambles.  A high city wall
 looms over you to the West.  It seems the only exit is North.    
 ~
-284 9 0 0 0 0
+284 9 0 0 0 1
 D0
 Too dark to tell.
 ~

--- a/lib/world/wld/287.wld
+++ b/lib/world/wld/287.wld
@@ -6,7 +6,7 @@ reason the goblins have not tried to follow you, being too weak to move it.
 You, however, can still shove it aside, should you wish to slither north.  The
 wide passage to the south looks much, much more inviting, however.  
 ~
-287 281 0 0 0 0
+287 281 0 0 0 5
 D0
 The crawlway opens into a large cave, crudely hewn from the stone.
 ~
@@ -65,7 +65,7 @@ small tunnel to the south.  To the east, a larger cave continues to a bend.
 That boulder troubles you.  Anxiously you examine its support, and notice some
 writing on the wall.  There is a NEWLY CARVED SIGN here.  Read it!  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D0
 The tunnel widens and lowers to the north, seemingly to a dead end.
 ~
@@ -110,7 +110,7 @@ narrow for a surefooted cat, and slippery as fish skin.  It is not too late to
 turn back!  A narrow crevasse leads down the cliff, but only an acrobat could
 turn round and descend it.  Your nose brushes an inscription.  
 ~
-287 393 0 0 0 0
+287 393 0 0 0 5
 D0
 The wise (if poor) man may return north to a larger cave.
 ~
@@ -146,7 +146,7 @@ can only read three: one in orcish, another in common, and a third, written
 large by a firm hand, in the secret dwarven tongue.  Looking closer, you see
 another, in ogrish.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D2
 You see a glimmer of daylight, not very far away.
 ~
@@ -220,7 +220,7 @@ and south.  A milestone stands near.  A sign stands at the intersection of this
 fine road, and the path to the mountain cave.  The dirt road to the south used
 to be blocked but now the way has been cleared.  
 ~
-287 64 0 0 0 0
+287 64 0 0 0 1
 D0
 A grass-grown path leads to a cave in the north.
 ~
@@ -255,7 +255,7 @@ in the mountains.  You would need wings to go down there.  This gorge certainly
 serves Ofingia well as a moat; the bridge has a wooden section that may easily
 be removed during a siege.  
 ~
-287 64 0 0 0 0
+287 64 0 0 0 1
 D1
 Ofingia's gate is right across the river.
 ~
@@ -981,7 +981,7 @@ that doing in a water-carved cave?  It has a sign on it that might explain who
 would put a door here.  The floor is quite flat, and the sand which covers it
 everywhere else is absent here.  Maybe it deserves a second look.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D1
 You may go back east. What a boring place.
 ~
@@ -1013,7 +1013,7 @@ Down, Down, to Goblin-Town!~
 yourself in.  There is no escape now but deeper in, and farther down.  There is
 a faint smell of goblins about this place.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D2
 You see a stone hallway.
 ~
@@ -1025,7 +1025,7 @@ The Stone Hallway~
    The walls are carved from limestone, and drip water, so this cave is always
 very damp, and very cold.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D0
 The walls are just as damp to the north.
 ~
@@ -1042,7 +1042,7 @@ The Stone Hallway~
    The walls are carved from limestone, and drip water.  You are beginning to
 fear for your health, and cold is not your greatest worry.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D1
 The walls are just as damp to the east.
 ~
@@ -1059,7 +1059,7 @@ The Stone Hallway~
    You hear a peculiar scratching and tapping coming from a hole in the cave
 floor.  A strong, foul-smelling draft rises from it.  To the west is a door.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D1
 The walls are just as damp to the east.
 ~
@@ -1087,7 +1087,7 @@ Often arms are also stored here, in case of an invasion.  The guards are so bad,
 however, that Goblin town places little trust in this, their first line of
 defense.  
 ~
-287 8 0 0 0 0
+287 8 0 0 0 1
 D1
 You can only go east.
 ~
@@ -1100,7 +1100,7 @@ The Stone Hallway~
 but you can not reach its warm fires now.  Only through worse danger will you
 leave these caves.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D0
 The walls are just as damp to the north.
 ~
@@ -1117,7 +1117,7 @@ The Stone Hallway~
    The limestone walls in this room are cracked and seep icy water.  Your boots
 are soaking wet by the time you have walked twenty-five yards.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D1
 The walls are just as damp to the east.
 ~
@@ -1139,7 +1139,7 @@ The Stone Hallway~
 around you and go on.  No turning back now!  The floor is drier here; the
 seepage drips around a square panel on the floor.  
 ~
-287 8 0 0 0 0
+287 8 0 0 0 2
 D1
 A glowing stone door is balanced on posts of steel and bolted shut.
 ~
@@ -1171,7 +1171,7 @@ storehouse of some sort, for you see no guards.  It is a large room.  The
 door-light does not reach far, and your torch casts long shadows.  Plenty of
 room for creepy things to hide.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D3
 There is a glowing door to the west.
 ~
@@ -1183,7 +1183,7 @@ The Spiral Tunnel~
    This tunnel spirals slowly clockwise, delving deeper into the bowels of the
 mountain.  You must be very far down now.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D4
 Icy water seeps round this stone slab, soaking your jacket.
 ~
@@ -1201,7 +1201,7 @@ The Spiral Tunnel~
 goblin city.  Whatever madness brought you here, it is too late to curse your
 foolishness, for goblins lie both before you and behind.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D4
 A stream of water flows from this direction.
 ~
@@ -1219,7 +1219,7 @@ The Spiral Tunnel~
 still tastes good after walking so far.  The gloom of these caverns is beginning
 to darken your mind, and you long for the common room of the Grunting Boar Inn.
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D4
 The endless tunnel spirals upward.
 ~
@@ -1238,7 +1238,7 @@ still tastes good after walking so far.  The cavern-gloom is beginning to darken
 your mind, and you long for the common room of the Grunting Boar Inn.  Here the
 tunnel jogs to the east.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D1
 The endless spiral runs east.
 ~
@@ -1255,7 +1255,7 @@ The Spiral Tunnel~
    There is no use counting how far this tunnel has spiralled down.  Goblins
 must be near, though; you can smell it.  Here the tunnel jogs down and west.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D3
 The endless spiral runs west.
 ~
@@ -1273,7 +1273,7 @@ The Spiral Tunnel~
 You do not want to know.  The stench of goblin-caves is very bad here, but
 bearable.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D4
 The endless spiral climbs higher.
 ~
@@ -1303,7 +1303,7 @@ strength to keep going and now found an exit from the horrible spiral tunnel.
 It is hotter here than it was higher up, and the filthy stench of goblin caves
 wafts from a hole in the floor.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D4
 The endless spiral climbs upwards.
 ~
@@ -1320,7 +1320,7 @@ Upper Goblin-Town~
    You reach the first level of the goblin city.  Now you must fight for your
 life, adventurer!  Draw your weapon and stay on your guard!  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D2
 A hallway leads south.
 ~
@@ -1346,7 +1346,7 @@ S
 A Small Armory~
    The Goblins keep a few weapons here, perhaps those they do not like to use.
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D1
 An iron door leads east.
 ~
@@ -1358,7 +1358,7 @@ A Dark Hall in Goblin-Town~
    This hall is deadly dangerous.  The goblins try to chase you into a corner,
 but you dart from shadow to shadow.  You must escape!  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D0
 The hallway leads north.
 ~
@@ -1380,7 +1380,7 @@ A Small Storeroom~
    You are not sure what is stored in this room, but there are plenty of crude
 chests to open.  Many appear to be of dwarven make; plunder, no doubt.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D3
 A black door leads back west.
 ~
@@ -1393,7 +1393,7 @@ A Dark Hall in Goblin-Town.~
 But they are locked-wait, perhaps you can pick them, or do you carry the keys?
 If not, stand and fight!  Hope is not lost.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D0
 A hallway continues north.
 ~
@@ -1415,7 +1415,7 @@ A Small Room~
    This is another storeroom, of some sort.  This entire level is, like a ship's
 hold, devoted to storage.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D0
 The only exit is a stone door to the north.
 ~
@@ -1427,7 +1427,7 @@ A Guard Room~
    Not now!  Not another guard room!  But this is where one should be; after
 all, there hasn't been any other on this floor.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D1
 There is a steel door to the east.
 ~
@@ -1444,7 +1444,7 @@ A Landing~
    A stairwell plunges down to the next level here.  To the west, a steel door
 forbids your passage.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D3
 A steel door blocks this way.
 ~
@@ -1833,7 +1833,7 @@ A Rough Tunnel~
 through.  Rubble litters the floor.  This cave is dark, so you must light your
 lantern again.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D0
 The tunnel continues north.
 ~
@@ -1856,7 +1856,7 @@ A Rough Tunnel~
 through.  Rubble litters the floor.  This cave is dark, so you must walk by
 lantern-light if you have not the ability to see in darkness.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D0
 The tunnel continues north.
 ~
@@ -1873,7 +1873,7 @@ A Rough Tunnel~
    Here the walls are roughly hewn, where the goblins mine for iron.  Rubble and
 ore litters the floor.  This cave is still unlit.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D0
 The tunnel continues north.
 ~
@@ -1890,7 +1890,7 @@ A Rough Tunnel~
    Your lamp casts odd shadows on the rough-hewn walls of this passage.  The
 tapping of goblin miners at work can be heard here and there.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D0
 You hear rushing water to the north and feel a faint draft.
 ~
@@ -1917,7 +1917,7 @@ and it is run by several sturdy trolls turning a horse-mill.  Slag heaps lie all
 about this huge cave, and glowing pig iron in trenches threatens to burn the
 soles off your shoes.  
 ~
-287 8 0 0 0 0
+287 8 0 0 0 2
 D0
 A steel door leads north.
 ~
@@ -1935,7 +1935,7 @@ A Corner In the Mines~
 If you wanted to, you could more easily dive in; your lantern glints off the
 surface of a lake not far below.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D1
 The tunnel continues east.
 ~
@@ -1962,7 +1962,7 @@ A Rough Tunnel~
    The walls become slightly smoother here long enough for someone to scratch a
 few words in the common speech into the stone.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D1
 The tunnel continues east.
 ~
@@ -1993,7 +1993,7 @@ smoke hangs in the air.  No doubt the goblins have some strange magic to break
 the stony ore from the walls.  The walls are pockmarked with shallow holes, and
 the rubble is similarly marked.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 3
 D0
 A faint glimmer of light comes from the north.
 ~
@@ -2014,7 +2014,7 @@ The Mine Shaft~
    Here the mine passage ends.  A pale glow shines around a trapdoor in the
 floor.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 2
 D2
 A rubble-strewn tunnel bends round a corner.
 ~
@@ -2040,7 +2040,7 @@ a round inverted bowl, fifty feet across, and about 15 feet high.  To the north
 a small stream flows out through a tunnel.  Of all the numerous influences that
 feed this lake, none are large enough, or low enough, for you to leave through.
 ~
-287 204 0 0 0 0
+287 204 0 0 0 6
 D0
 The stream flows fast, but not too much to swim in.
 ~
@@ -2053,7 +2053,7 @@ On the Underground Stream~
 is darker here, but since the current pushes you east, you don't much need to
 see.  
 ~
-287 201 0 0 0 0
+287 201 0 0 0 6
 D1
 The stream slows slightly to the east.
 ~
@@ -2068,7 +2068,7 @@ You had better leave the stream while you can.  As the walls narrow, the stream
 rushes faster and faster, and you hear a great thrashing noise like a mill wheel
 close by to the east.  
 ~
-287 201 0 0 0 0
+287 201 0 0 0 6
 D0
 Looks like gravel.
 ~
@@ -2087,7 +2087,7 @@ whitewater drowning.  There is no way to turn back now; the current is just too
 strong.  Then you see the ground drop away up ahead, and will soon discover how
 it feels to go over Niagara Falls without even a barrel.  
 ~
-287 200 0 0 0 0
+287 200 0 0 0 6
 S
 #28789
 The Ledge~
@@ -2095,7 +2095,7 @@ The Ledge~
 flank this small stream.  A crevasse nearby looks like it could be chimneyed
 with a lot of effort.  
 ~
-287 9 0 0 0 0
+287 9 0 0 0 1
 D2
 The stream flows quickly east.
 ~
@@ -2112,7 +2112,7 @@ The Crevasse~
    It is rough climbing, and you won't try to go down this way, but you have
 made good progress.  
 ~
-287 201 0 0 0 0
+287 201 0 0 0 5
 D4
 You can keep climbing up.
 ~
@@ -2129,7 +2129,7 @@ The Crevasse~
    Tiring, you climb more slowly, but still go upwards at a good pace.  You are
 nearly half way up.  
 ~
-287 201 0 0 0 0
+287 201 0 0 0 5
 D4
 You can keep climbing up, but you certainly won't do this again!
 ~
@@ -2145,7 +2145,7 @@ S
 The Crevasse~
    Tiring, you climb more slowly, but still go upwards at a good pace.  
 ~
-287 201 0 0 0 0
+287 201 0 0 0 5
 D4
 You can keep climbing up, but you certainly won't do this again!
 ~
@@ -2162,7 +2162,7 @@ Up the Cliff We Go~
    Every move is sheer torture as you haul yourself up this rough crevasse in
 the cliff-face, but you are nearly to the top!  
 ~
-287 201 0 0 0 0
+287 201 0 0 0 5
 D4
 You can keep climbing up, but you will NEVER do this again!
 ~

--- a/lib/world/wld/288.wld
+++ b/lib/world/wld/288.wld
@@ -68,7 +68,7 @@ Inside the Crystal Ball~
 world of stars and wonders!  As you look around, you figure out there is no
 choice but to go forward.  
 ~
-288 0 0 0 0 0
+288 0 0 0 0 2
 D0
 ~
 ~
@@ -81,7 +81,7 @@ comets and meteors wander around you.  You realize that this world may not be
 the true galaxy after all but just another fantasy zone.  Exits lie in most
 directions.
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -100,7 +100,7 @@ On an InterGalactic Walkway~
    You are on a well-paved path which seems to have been made deliberately for
 visitors like you.  The walkway continues north and a small exit lies west.  
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -120,7 +120,7 @@ End of the InterGalactic Walkway~
 see that there is still a small path which leads north and one to the west.  
 To the east lies a bridge.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -143,7 +143,7 @@ At the Undeveloped Part of the Galaxy~
    This place looks deserted, covered with space debris.  Not a sign of life is
 around.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D2
 ~
 ~
@@ -160,7 +160,7 @@ bridge itself shines brightly and makes you feel that you are walking on a path
 of light.  An entrance to an ancient building lies north and to the east lies
 the Milky Way.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -180,7 +180,7 @@ On the Bridge of Nebulae~
 make one just to show that they are as capable as the stars.  North lies a
 throne room.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 1
 D0
 ~
 ~
@@ -212,7 +212,7 @@ At the Start of the Milky Way~
 by streams of mist the moment you tread on it.  You can't see well in here ...
 Luckily you haven't fallen yet!    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 4
 D0
 ~
 ~
@@ -227,7 +227,7 @@ Along the Milky Way~
    You are still travelling inside this path of mist.  You notice a small
 opening to the east.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 4
 D0
 ~
 ~
@@ -246,7 +246,7 @@ At the End of the Milky Way~
    Just as you started enjoying this journey inside the mist, you have come to
 the end of it.  West leads to a bridge and east leads to somewhere else.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 4
 D1
 ~
 ~
@@ -265,7 +265,7 @@ A Small Clearing~
    You are inside a small clearing.  You can see that there are signs of a
 living creature nearby.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 2
 D0
 ~
 ~
@@ -280,7 +280,7 @@ An Edge of the Galaxy~
    You are on the very edge of the galaxy.  Nothing is here except that there
 is a path which leads down.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D2
 ~
 ~
@@ -300,7 +300,7 @@ Very Near to a Gigantic Star~
 its beauty, the star keeps on growing ...  Suddenly you realize that you'd
 better leave.    
 ~
-288 4 0 0 0 0
+288 4 0 0 0 1
 D0
 ~
 ~
@@ -332,7 +332,7 @@ The Star Cluster~
    You are inside the home of the stars.  All you can see around you are stars
 and nothing else.  Your eyes become pretty hurt as you look at them.    
 ~
-288 8 0 0 0 0
+288 8 0 0 0 1
 D0
 ~
 ~
@@ -347,7 +347,7 @@ An Edge of the Galaxy~
    There's not much to see here at the edge of the galaxy.  Exits lie north,
 east and south.
 ~
-288 0 0 0 0 0
+288 0 0 0 0 2
 D0
 ~
 ~
@@ -366,7 +366,7 @@ Corner of the Galaxy~
    You wonder why the galaxy is limited.  All you have done in Astronomy
 courses now prove worthless.  Well, who told you to take one at the start?    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -385,7 +385,7 @@ Lost in Space~
    You are now lost in space.  Compasses don't work here, sorry.  What's more
 you can sense darkness engulfing you.  You'd better get out quick.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 2
 D0
 ~
 ~
@@ -411,7 +411,7 @@ The Homes of the Pleiades~
    This is where the famous Seven Sisters live.  You'd better not disturb them.
   
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D1
 ~
 ~
@@ -426,7 +426,7 @@ Western Side of the Temple~
    You are still wandering around this temple.  You notice exits lie in all
 directions except west.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -445,7 +445,7 @@ Orion's Hunting Lodge~
    This is dedicated to the Great Hunter of all time -- Orion.  Scattered on
 the floor is the famous hunting equipment used by him.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -460,7 +460,7 @@ Northern Side of the Temple~
    You are still wandering around this temple.  You notice exits lie in all
 directions except north.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D1
 ~
 ~
@@ -480,7 +480,7 @@ The Offering Chamber~
 young girl here, chained to the wall, as if she is waiting for execution.  You
 look up and realize the chains are sent down directly from above.  
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -508,7 +508,7 @@ The Entrance of the Ancient Temple~
 gods in Mount Olympia, but it is now deserted as someone took over this part of
 the Universe.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -531,7 +531,7 @@ Hercules' Mighty Throne~
    You stand before the throne of a long-forgotten hero.  It is full of bounty
 that he got from the Ten Labours.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D2
 ~
 ~
@@ -546,7 +546,7 @@ Eastern Side of the Temple~
    You are still wandering around this temple.  You notice exits lie in all
 directions except east.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -565,7 +565,7 @@ Perseus' Chamber~
    It is the chamber of the prince, Perseus.  However, he seems not to be here.
 Maybe he has gone to get Pegasus to save Andromeda?    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -613,7 +613,7 @@ On a Hill~
    Suddenly you find yourself on a hillside.  As you look around, you notice
 that Spring has descended upon you.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 4
 D0
 ~
 ~
@@ -632,7 +632,7 @@ Inside a Spanish Bull-Ring~
    You are inside what used to be a ground for bull fighting.  But you notice
 there are no Matadors around.  Maybe they are all dead?    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 2
 D1
 ~
 ~
@@ -659,7 +659,7 @@ Along the seashore~
    You start to feel the heat of Summer.  Amongst the rocky beach you notice
 hidden forms which could be camouflaged crabs.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 2
 D1
 ~
 ~
@@ -674,7 +674,7 @@ Within the Deep Jungle~
    Nearby you can hear the roar of an animal.  Peering through the dense
 overgrowth you think you glimpse a pair of menacing eyes.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 3
 D1
 ~
 ~
@@ -685,7 +685,7 @@ Inside a Luxurious Bedroom~
    A peaceful feeling overtakes you.  You see a magnificent four-poster bed.  
 It's a double bed and there is only room for one more!  Well, what now ...  ?
 ~
-288 8 0 0 0 0
+288 8 0 0 0 1
 D3
 ~
 ~
@@ -697,7 +697,7 @@ The Supreme Court~
 of guilt and you want to protest your innocence!  You fear retribution and feel
 yourself exposed, just like the trees in Autumn.    
 ~
-288 8 0 0 0 0
+288 8 0 0 0 1
 D2
 ~
 ~
@@ -712,7 +712,7 @@ In the Dry Desert~
    You are confused by the shifting sands around you.  Through the shimmering
 heat you see the hazy outline of a giant scorpion ...  Is this a mirage?    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 2
 D1
 ~
 ~
@@ -727,7 +727,7 @@ In the Woods~
    You find yourself in the center of a Centaurion hunting party.  You'd better
 hide yourself before you become the 'center attraction'!    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 3
 D1
 ~
 ~
@@ -793,7 +793,7 @@ On the Draco~
    You realize you are standing on scaly ground.  As you wonder what the ground
 is made of, you feel the ground move.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D0
 ~
 ~
@@ -809,7 +809,7 @@ Tail of the Draco~
 Draco, the guardian of the inner galaxy.  You realize that the Draco is
 actually flying now!    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D0
 ~
 ~
@@ -824,7 +824,7 @@ Path of the Draco~
    As you struggle along this scaly creature you realize that the only way you
 can reach to the inner galaxy is by going all the way to the head.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D0
 ~
 ~
@@ -840,7 +840,7 @@ Near the Legs of Draco~
 that the surrounding is all dark except for some faint lights from the distant
 stars.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D0
 ~
 ~
@@ -855,7 +855,7 @@ On the Back of Draco~
    At last you are half way through this long, weary journey.  You can see the
 wings are to the east but it seems that another forcefield is in the way.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D1
 You see the forcefield of Autumn.
 ~
@@ -871,7 +871,7 @@ Between the Wings of Draco~
    You hear some giant flapping sounds nearby.  You desperately try to get hold
 of something as the forceful gusts sweep you away.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D1
 ~
 ~
@@ -886,7 +886,7 @@ Near the Arms of Draco~
    From above you can faintly make out the gigantic arms which extend far
 beyond into the darkness.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D2
 ~
 ~
@@ -901,7 +901,7 @@ On the Neck of Draco~
    Your journey is now approaching the end.  However, this neck seems to be
 endless.    
 ~
-288 1 0 0 0 0
+288 1 0 0 0 4
 D0
 ~
 ~
@@ -917,7 +917,7 @@ Approaching the Head of Draco~
 forcefield to the south, some distance away, beyond reach.  If only the head
 were here ...    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 4
 D1
 ~
 ~
@@ -934,7 +934,7 @@ At the Entrance of the Great Dipper~
 now is the path of the Great Dipper or the Plough.  You notice that there are
 seven rooms in this zone, representing the seven stars of the Dipper.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 You see the forcefield of Winter.~
 forcefield~
@@ -953,7 +953,7 @@ Cassiopeia's Throne~
    This is the Throne room of the Queen of the Universe.  From here you can see
 every star and constellation in the Universe.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -968,7 +968,7 @@ Along the Path of the Dipper~
    You can see bright stars shining all around you but nothing of special
 interest.
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D1
 ~
 ~
@@ -983,7 +983,7 @@ Cepheus' Throne~
    This is the Throne room of the King of the Universe.  From here you can see
 every star and constellation in the Universe.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -1002,7 +1002,7 @@ Along the path of the Dipper~
    You can see bright stars shining all around you but nothing of special
 interest.
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -1017,7 +1017,7 @@ Along the path of the Dipper~
    You can see bright stars shining all around you but nothing of special
 interest.
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D1
 ~
 ~
@@ -1033,7 +1033,7 @@ End of the Dipper~
 is a set of claw-marks.  You also notice a room to the south; it looks as if
 Polaris could lie here.    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~
@@ -1050,7 +1050,7 @@ significance.  You can see a powerful telescope pointing down towards the
 Universe (SNOOPING!  ).  It is from here that Polaris commands the Universe.  
 You feel you have come to end of your search in this galaxy ...    
 ~
-288 0 0 0 0 0
+288 0 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/289.wld
+++ b/lib/world/wld/289.wld
@@ -7,7 +7,7 @@ of you, and small paths lead east and west around the building.  Eastward is
 another smaller building; obviously a stable.  Northward is the main road,
 providing all the traffic and customers for this establishment.    
 ~
-289 4 0 0 0 0
+289 4 0 0 0 2
 D0
 ~
 ~
@@ -80,7 +80,7 @@ voices coming from inside are clearly audible, and by listening hard you can
 almost make out the words.  The path around the building continues to the west
 and south.    
 ~
-289 0 0 0 0 0
+289 0 0 0 0 2
 D1
 ~
 ~
@@ -97,7 +97,7 @@ window spills light onto the trees that block out all available light overhead.
 You hear general merryment and alcoholism from inside, and wonder if being
 inside would be more fun than walking around outside...    
 ~
-289 0 0 0 0 0
+289 0 0 0 0 2
 D0
 ~
 ~
@@ -114,7 +114,7 @@ barrel catches run-off from the roof eaves by the corner of the building, and
 you spy a small white fence cordoning off an herb garden nearby.  The path
 around the building leads to the north and east.    
 ~
-289 0 0 0 0 0
+289 0 0 0 0 2
 D0
 ~
 ~
@@ -132,7 +132,7 @@ unmistakeably an outhouse.  You hear the unmistakeable sound of clanging pots
 and pans from the inside, the warning of an upcoming meal.  The path around the
 building here runs east, and west.    
 ~
-289 4 0 0 0 0
+289 4 0 0 0 2
 D0
 ~
 ~
@@ -154,7 +154,7 @@ alley to the north, with the path leading right in-between.  Westwards is the
 kitchen entrance to the Wayhouse, kept wide open to let the heat inside escape.
   
 ~
-289 0 0 0 0 0
+289 0 0 0 0 2
 D0
 ~
 ~
@@ -174,7 +174,7 @@ Near a Large Building~
 the west, and the wooden planked walls of the stable to the east.  The path
 around the building leads north and south of here.    
 ~
-289 0 0 0 0 0
+289 0 0 0 0 2
 D0
 ~
 ~
@@ -190,7 +190,7 @@ Near a Large Building~
 to the west, and the stables to the east.  Another path breaks off to the
 south, between the two buildings, towards what appears to be an outhouse.    
 ~
-289 0 0 0 0 0
+289 0 0 0 0 2
 D1
 ~
 ~
@@ -211,7 +211,7 @@ open and inviting.  Inside you can hear the snorting of horses, and the
 occasional hoof scraping against the ground.  The path leads to the west,
 towards the Wayhouse.    
 ~
-289 4 0 0 0 0
+289 4 0 0 0 2
 D2
 ~
 ~
@@ -228,7 +228,7 @@ aisle, some with horses, some empty.  A pail filled with water and a stack of
 grain are heaped up against the interior wall, dimly illuminated by a lantern
 hanging from a rafter.  Seems rather quiet in here...    
 ~
-289 8 0 0 0 0
+289 8 0 0 0 2
 D0
 ~
 ~
@@ -249,7 +249,7 @@ aisle, some with horses, some empty.  A pail filled with water and a stack of
 grain are heaped up against the interior wall, dimly illuminated by a lantern
 hanging from a rafter.  Seems rather quiet in here...    
 ~
-289 8 0 0 0 0
+289 8 0 0 0 1
 D0
 ~
 ~
@@ -266,7 +266,7 @@ aisle, some with horses, some empty.  A pail filled with water and a stack of
 grain are heaped up against the interior wall, dimly illuminated by a lantern
 hanging from a rafter.  Seems rather quiet in here...    
 ~
-289 8 0 0 0 0
+289 8 0 0 0 1
 D0
 ~
 ~
@@ -283,7 +283,7 @@ aisle, some with horses, some empty.  A pail filled with water and a stack of
 grain are heaped up against the interior wall, dimly illuminated by a lantern
 hanging from a rafter.  Seems rather quiet in here...    
 ~
-289 8 0 0 0 0
+289 8 0 0 0 1
 D2
 ~
 ~

--- a/lib/world/wld/290.wld
+++ b/lib/world/wld/290.wld
@@ -7,7 +7,7 @@ the Golden treasure in the depths of the lair of the lizardmen.  If you wish to
 test your luck, you can push your way through the exit to the south...  If not,
 you can leave the Safari Park to the east.  There is a large sign here.    
 ~
-290 12 0 0 0 0
+290 12 0 0 0 4
 D1
 The Real World is to the east.
 ~
@@ -398,7 +398,7 @@ Mr. Hooper's store~
    This is your friendly neighbourhood convenience store and restaurant.  
 There are many interesting things that you can buy here.    
 ~
-290 12 0 0 0 0
+290 12 0 0 0 1
 D2
 The conjuring chamber is still to the south.
 ~

--- a/lib/world/wld/291.wld
+++ b/lib/world/wld/291.wld
@@ -6,7 +6,7 @@ In the middle of the forest, popping out over the trees is the tall spire of
 the Citadel. The symbol of the triangled wheel on the tower's side is there
 for all to see. A trail leads eastward down the hill towards the woods.
 ~
-291 4 0 0 0 0
+291 4 0 0 0 4
 D1
 ~
 ~
@@ -25,7 +25,7 @@ near the outermost trees on a rapidly dwindling trail that winds into the dark
 heart of the woods.  Your know your imagination can only scratch the surface of
 the unholy terrors that lie within.  You have been warned.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 4
 D1
 ~
 ~
@@ -44,7 +44,7 @@ diabolical laugh drifts to your ears.  It drives shivers down your spine.  You
 can make out a trail to the south and east.  To the north there is a cabin.  
 Or you could flee the woods.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -84,7 +84,7 @@ around, a fresh bout of evil laughter comes to your ear.  It echos off the
 trees, refusing to die.  You feel a bead of sweat form on the back of your
 neck.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -98,7 +98,7 @@ S
 The Black Forest~
    You are in the Black Forest.  Have a Nice Day.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -131,7 +131,7 @@ bark is rough and blood stained.  At the roots lie a fallen hero.  His body
 well along in decomposition, but the cause of death is obvious.  This foolish
 hero has been decapitated.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -151,7 +151,7 @@ The dense woods~
 much further.  Every so often one of the trees carries an aged blood stain
 marring one of the trees.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -172,7 +172,7 @@ nearby trees prevent you from exploring the wall.  It is an imposing mass of
 cold, smooth, black granite.  So near the vile citadel, you know in your soul
 this is not a place you want to be caught dead at.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D2
 ~
 ~
@@ -208,7 +208,7 @@ gravely slopes makes for difficult going.  You can surmise that this place
 would fill up rapidly in a heavy rain.  You just hope that dosen't happen while
 you are here.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 5
 D2
 ~
 ~
@@ -223,7 +223,7 @@ Deeper into the Black Forest~
    The deeper into the forest you press, the more you doubt the sanity of your
 choice.  But you know that with great risks come great rewards.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D1
 ~
 ~
@@ -282,7 +282,7 @@ horse.  Around the hoofmarks the earth is scorched as if by a hot flame.
 Looking around there are the signs of a strugle.  Somebody placed his bets
 against whatever made the hoofmarks, and lost.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -303,7 +303,7 @@ quiet around the area.  You look at the clearing you are standing near and you
 recognize it for what it is.  A killing field.  Your boot crunches on the
 headless skeleton of some small woodland creature.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -363,7 +363,7 @@ away your nervousness and trepidation too.  From here you can push on eastward
 or you can flee west to the safety of the bridge.  Your other option is to
 follow the river to its end.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D1
 ~
 ~
@@ -381,7 +381,7 @@ S
 Hopelessly Lost~
    You are Hopelessly Lost!    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D1
 ~
 ~
@@ -395,7 +395,7 @@ S
 Hopelessly Lost~
    You are Hopelessly Lost!    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D2
 ~
 ~
@@ -409,7 +409,7 @@ S
 Hopelessly Lost~
    You are Hopelessly Lost!    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -423,7 +423,7 @@ S
 Hopelessly Lost~
    You are Hopelessly Lost!    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -437,7 +437,7 @@ S
 Hopelessly Lost~
    You are Hopelessly Lost!    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D1
 ~
 ~
@@ -451,7 +451,7 @@ S
 Hopelessly Lost~
    You are Hopelessly Lost!    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D2
 ~
 ~
@@ -468,7 +468,7 @@ eyes off the citadel, but you manage.  To the west lies a small stream.  To the
 north is a clearing, and south of you is a trail that leads to a small keep in
 ruins.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -493,7 +493,7 @@ making a path around part of the keep belonging to the mistress of the Void Far
 to the south you can see what seems to be the main gate.  To the north the wall
 disappears into the darkness of the Black Forest.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -514,7 +514,7 @@ making a path around part of the keep belonging to the mistress of the Void Far
 to the south you can see what seems to be the main gate.  To the north the wall
 disappears into the darkness of the Black Forest.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -535,7 +535,7 @@ are smooth to the touch.  The gate is a huge, cast iron affair, emblazoned with
 the symbol of the triangled wheel.  Only the bravest of souls would consider
 entering this dreadful place.  There is a gate to the east.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -557,7 +557,7 @@ making a path around part of the keep belonging to the mistress of the Void Far
 to the south you can see what seems to be the main gate.  To the north the wall
 disappears into the darkness of the Black Forest.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -578,7 +578,7 @@ making a path around part of the keep belonging to the mistress of the Void Far
 to the south you can see what seems to be the main gate.  To the north the wall
 disappears into the darkness of the Black Forest.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -622,7 +622,7 @@ strain your eyesight you can barely makeout the remains of a ruined keep.  The
 few remaining walls, once a gleeming white are now a dull grey.  Evidently this
 keep was laid waste by the forces of the citadel.  Pity.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -643,7 +643,7 @@ scattered bits of shattered walls remain as testiment to what once was, now
 they are merely waiting for the forest to reclaim them.  At least the ruins
 provide some measure of shelter from the incessent, madening wind.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -670,7 +670,7 @@ when Ilian's black citadel was erected, those protecting beings withdrew their
 protection to flee to safety, or maybe they made their stand with the occupants
 of the castle, and shared their fate.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -690,7 +690,7 @@ fresh hay on the floor.  Although you take note that some of it has been
 scorched by fire of some sort.  There is still water in the trough.  All this
 leads you to believe that someone or something still makes use of this place
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D3
 ~
 ~
@@ -707,7 +707,7 @@ shattered into a million shards of rainbow hued glass strewn over the ground.
 The east wall still seems soundly built, but you have trepidations about the
 south wall It seems like it could come crashing down at any moment.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -789,7 +789,7 @@ More of the black forest~
    The Black forest extends as far as the eye can see.  Granted that's not too
 far, given how dense the forest is.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -839,7 +839,7 @@ pond scum floats in a fine skin over the surface.  This place approaces a swamp
 more than it does a pond.  This place is a prime breeding ground for mosquitoes
 and other stinging insects that buzz about your face.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 3
 D0
 ~
 ~
@@ -856,7 +856,7 @@ mire.  It is little more than a patch of rock that is covered with poison ivy.
 There is little soil, but somehow the vines mamage to find enough food to
 survive.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -867,7 +867,7 @@ Still More of the forest~
    You know the drill.  Can you tell that I was running low on my creative
 inspiration when I made this room?    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -884,7 +884,7 @@ seemingly endless cadre of oak trees that stand as omnious guardians to this
 dark place.  Press much further and you do not know if you will be able to find
 your way back.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~
@@ -1706,7 +1706,7 @@ the western hills where you began this nightmare to the sea which lies FAR to
 the south.  The balcony extends to the south a bit, but be careful There is no
 guardrail, and that first step is a doozy.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 1
 D2
 ~
 ~
@@ -1723,7 +1723,7 @@ clifflike drop at the edge.  An unexpected gust of wind nearly makes you loose
 your footing, but you manage to hang on.  As nervous as you are, this place has
 an unusual serenity to it.    
 ~
-291 0 0 0 0 0
+291 0 0 0 0 1
 D0
 ~
 ~
@@ -1785,7 +1785,7 @@ seemingly endless cadre of oak trees that stand as omnious guardians to this
 dark place.  Press much further and you do not know if you will be able to find
 your way back.    
 ~
-291 1 0 0 0 0
+291 1 0 0 0 3
 D0
 ~
 ~

--- a/lib/world/wld/292.wld
+++ b/lib/world/wld/292.wld
@@ -94,7 +94,7 @@ white temple to your north.  To the south is a smaller blue temple,
 its doors locked by great bands of magic.  Several people glare at
 you, wondering if you're going to cut through the line.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -141,7 +141,7 @@ citizens of Kerofk are here, bustling and jostling each other in an
 attempt to get all they have to do done as fast as possible.  Bump Oof
 Excuse Me!  There is a Mage's Guild to the north.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -163,7 +163,7 @@ clue how to get across...  Wait, there's an opening!  Sprint, Turn,
 Jab!  Run, Run, Run...  you're across! You look up at the never-ending
 twilight and wonder how so many people could bear to live here.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -188,7 +188,7 @@ Road, and for a moment you forget what kind of strange place you're
 in.  A flowerbox filled with wilted flowers brings you back to
 reality; this city hasn't seen the sun for decades...
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -223,7 +223,7 @@ it would be a good idea to step off, but you've already guessed that,
 haven't you?
    Cliffside Road runs north and south from here.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -251,7 +251,7 @@ the citzenry of Kerofk walk up and down the street, almost oblivious to
 the incredible drop mere feet away.
    Cliffside Road continues North and South.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -278,7 +278,7 @@ further east.  Northwards is Cliffside Road, to the west is Moon Gate
 Road, and to the east a vast expanse of stars shine over the dark
 ocean below.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -300,7 +300,7 @@ picture of a trout in full plate hanging out front.  'Bob's Armoury
 and Tackle' it proclaims.  Armoury? Tackle Shop?!?  How curious!
    Moon Gate Road continues to the east and west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -321,7 +321,7 @@ walk about under the starlight here, in a hurry to get to shops, their
 homes, to work, et cetera.  Citizen's Road is to the north, Moon Gate
 Road continues east and west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -342,7 +342,7 @@ district. It suddenly strikes you how orderly this city is planned...
 done that way on purpose?  Well, it doesn't look like there's anything
 interesting here, but the road continues north and south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -360,7 +360,7 @@ the cliff's edge.  That cliff looks kind of dangerous actually.  The
 Cliffhanger looks good, though.
    Cliff Side Road continues to the north and south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -386,7 +386,7 @@ foot drop off just to your east with the ocean below.  Hmm...something
 tells you not to go east...must be that brain thing, eh?
    Cliffside road leads south, Star Gate Road leads west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -407,7 +407,7 @@ shine down as you look around for the source of the silence.  Ah,
 there's a bookstore/library to your north!  Moon Gate Road continues
 to the east and west as well.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -428,7 +428,7 @@ around and do their business.  Looks like there's some private homes
 on Citizen's Road to your south, and Star Gate Road continues to the
 east and west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -450,7 +450,7 @@ sagging demeanor seem to eminate an air of death and decay and
 cliche's.  Could anyone possibly live in there?
    Citizen's Road continues north and south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -472,7 +472,7 @@ Card'.  The smell wafting out its doors is enough to make a dead man
 turn away in disgust...how about you?
    Star Gate Road continues to the east and west
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -492,7 +492,7 @@ Star Gate Road~
 but not by much.  To the north is a large farmer's stand where a lot
 of the citizenry seem to be going in and out of.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -515,7 +515,7 @@ laughing inside; it's obviously a tavern or an inn, and popular to
 boot.
    Star Gate Road continues east and west
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -536,7 +536,7 @@ street to your south while Star Gate Road continues on its way east
 and west.
    There is an odd feeling of power to your north.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -562,7 +562,7 @@ arrayed outside its doors under heavy lamplight, and a sign proclaims
 assorted types of herbs on special today.
    Business Road continues north and south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -585,7 +585,7 @@ over.  Your reflexes save you, but you feel you better get out of this
 intersection soon.
    Center Road is east-west, Business road is north-south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -612,7 +612,7 @@ chambers, not to mention Mayor Kell's office.  To the east you see a
 huge white temple with a line outside, and a smaller blue temple.
    Center Road continues east and west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -634,7 +634,7 @@ front.  The keep looks like it was built to withstand floods,
 earthquakes, and even acts of God!
    Moon Gate Road continues east and west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -655,7 +655,7 @@ vacant lot to your south.  Also, Moon Gate Road continues east-west.
 The air seems to crackle with energy here, but you can find no source
 for such power.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -677,7 +677,7 @@ on.  There's a few shops along this road, but they don't look terribly
 interesting under this aspect.  Looking around, you notice the
 entrance to the city graveyard to the south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -698,7 +698,7 @@ area as people go about their business.  Along Business Road to the
 north you see many types of different shops lining the street, and
 Moon Gate Road continues east-west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -719,7 +719,7 @@ see the intersection of of Center Road and Business Road, and
 southwards is another intersection--Business Road and Moon Gate Road.
    There is a shop to the west, a dirty sign proclaiming it 'OPEN'.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -741,7 +741,7 @@ be some sort of 'catch-all' general store.  Also, Moon Gate Road
 continues east towards the cliff, and west towards the actual Moon
 Gate.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -763,7 +763,7 @@ has some bustle to it...must be all that night life!  Feeling pleased
 at your prospects, you look around for something to do...
    Wall Side Road leads north, Moon Gate Road leads east.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -784,7 +784,7 @@ raid or war it seems.  There are some signs of construction about, but
 it seems that there is no great need for more buildings right now.
    Wall Side Road continues north and south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -804,7 +804,7 @@ architecture, and the majesty of the starry skies above, you know this
 is a sight you'll never forget.
    Center Road leads east, Wall Side Road continues north-south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -824,7 +824,7 @@ Wall Side Road, North~
 city's wall.  To your east is a recruiting office for the city militia
 of Kerofk.  Wall Side Road continues north and south.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D0
 ~
 ~
@@ -847,7 +847,7 @@ in a world of eternal twilight.  A street sign informs you that this
 is Wall Side Road running south from here, and Star Gate Road leads
 away to the east.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -868,7 +868,7 @@ this busy street between and through them.  It seems that they're used
 to adventurers, or just don't care. Star Gate Road continues east and
 west, intersecting Business Road and Wall Side Road respectively.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -886,7 +886,7 @@ for a temple, this building is big!  Perhaps it would be worth a look
 around?
    Center Road continues to the east and west.
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 D1
 ~
 ~
@@ -1531,9 +1531,9 @@ gave them to Builder_5, smiled, and said,
 these files into a version more suitable for a public release.  This
 is what you have now.
    Both of us hope you enjoy this area, over a year in the making...
-	Amanda Eterniale			Builder_5
+@Amanda Eterniale		@Builder_5
 ~
-292 8 0 0 0 0
+292 8 0 0 0 1
 S
 #29275
 Shrine to the Emperor~

--- a/lib/world/wld/293.wld
+++ b/lib/world/wld/293.wld
@@ -501,7 +501,7 @@ along the edge of a cliff.  Beyond the cliff you see a dark ocean,
 reflecting the starlight above very feebly.  The road continues west
 down the rise, and east, towards the city on the edge.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D1
 ~
 ~
@@ -519,7 +519,7 @@ surrounding the city seem impassable, but several scorch marks along
 its length tells a different stories about war and raids.  To your
 west is a rise where you may get a better vantage point of the city.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D1
 ~
 ~
@@ -536,7 +536,7 @@ To the north you see some cultivated fields, and to the south a fork
 in the road.  The sky above seems eerie, especially to the west where
 the glow of the normal sky brightens the horizon...
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D0
 ~
 ~
@@ -555,7 +555,7 @@ you've never seen the likes of before.  From several burned out shells of
 houses you guess the farmers just try to grow what they can before the
 city is put under siege again.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D1
 ~
 ~
@@ -572,7 +572,7 @@ walled, the other half sprawled directly on the edge of a great cliff
 which drops down into a dark ocean below.  To the east you see a small 
 gate in the city, which farmers are going into and out of sporadically.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D1
 ~
 ~
@@ -588,7 +588,7 @@ Fields near a City~
 From the smell of charred wood and the sounds of fresh construction,
 you guess that the last raze didn't happen long ago...
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D1
 ~
 ~
@@ -604,7 +604,7 @@ Near a City~
 out of the city with their produce.  The walls seem indestructible,
 but scorch marks along its length tell a different story...
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D1
 ~
 ~
@@ -621,7 +621,7 @@ the north out of sight in the starlit sky, one leading up a hill to
 the east, and towards the mountains to the west.
    It seems very quiet and peaceful here.  A breeze caresses your face.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D0
 ~
 ~
@@ -642,7 +642,7 @@ brightness seeping over and between the mountains.  Eastwards the
 strange, unnatural night sky spreads over anything, its permanent
 stars lighting the landscape with an eerie glow.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 2
 D1
 ~
 ~
@@ -659,7 +659,7 @@ leads away under the starry sky to the east, and a mountain pass
 heads up and through to the north.  The scenery on this side of the
 mountains seems bleak and lifeless, probably due to the lack of sun.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 4
 D0
 ~
 ~
@@ -677,7 +677,7 @@ an eerie glow over the stones and shrubberies around.  You can see a
 large dark plain to the east that the sun never seems to have shone
 upon, making it appear to be otherworldly somehow...
 ~
-293 8 0 0 0 0
+293 8 0 0 0 4
 D2
 ~
 ~
@@ -695,7 +695,7 @@ of the night is clearly delineated above you...a sharp edge separating
 night from normal, as it were.  Very odd...you wonder what could be
 causing this unnatural darkness.
 ~
-293 0 0 0 0 0
+293 0 0 0 0 4
 D1
 ~
 ~
@@ -712,7 +712,7 @@ its way up to the north.  The sky seems dark above the mountains,
 as if the mountains were a dividing line keeping back the night.
 The pass also leads back down to the
 ~
-293 0 0 0 0 0
+293 0 0 0 0 4
 D0
 ~
 ~
@@ -740,7 +740,7 @@ the gloom of night and the twinkling stars above, the tombstones seem
 to take a life of their own in a storybook way.  You don't think it
 would be the kind of storybook you would be interested in...
 ~
-293 12 0 0 0 0
+293 12 0 0 0 1
 D0
 ~
 ~
@@ -762,7 +762,7 @@ dug up.  The bones of a dead dwarf lie exposed at the bottom of the
 grave, its hands seemingly to clutch at the sky.  The tombstone at
 the head of the grave is completely unreadable.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 1
 D2
 ~
 ~
@@ -780,7 +780,7 @@ Some grass grows sparsely around the rocks, paled by the lack of sun.
 In this area, you feel the peace of death, instead of the decay usually
 associated with graveyards.
 ~
-293 8 0 0 0 0
+293 8 0 0 0 1
 D0
 ~
 ~
@@ -798,7 +798,7 @@ meeting their ends with dignity and aplomb.  Two pits are dug
 near the wall for a burial yet to take place.  You feel strangely
 chilled by the night air...
 ~
-293 8 0 0 0 0
+293 8 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/294.wld
+++ b/lib/world/wld/294.wld
@@ -113,7 +113,7 @@ and the road continues to the east.  Two shops stand across from each other
 here, the north seeming more busy, the south seeming to attract a better
 quality of customer.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 There's a small shop there with a sign above it.  The sign 
 has the form of a cow in silohuette on it.
@@ -155,7 +155,7 @@ identifies it as 'Clay Street'.  A cursory look north and south reveals a shop
 or two, but not much else of interest.  Looking west, you spy a gate in the
 city wall, and Trade Road continues to the east.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -186,7 +186,7 @@ rubbish.  The alley opens up between two buildings on Trade Road southwards,
 and to the north the alley continues.  There is a slight smell of decay that
 teases your nose, making you feel as if it were time to move on...    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -207,7 +207,7 @@ Alley~
 and rubbish grime up your footwear as you tread lightly through the alleyway;
 obviously this is not one of the highlight attractions of XXXX.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -228,7 +228,7 @@ Clay Street~
 the south.  The wall doesn't look too safe, however; what with all those guards
 on top.  The shop to the south looks like a considerably nicer place to go.  
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -267,7 +267,7 @@ from which you hear a lot of laughing and general merryment.  The building
 seems tall and imposing, making the evident good times inside that much more
 out of place...    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 There's a larger building to the north, looking to be some 
 sort of factory.  You smell a faint tinge of alcohol in the 
@@ -303,7 +303,7 @@ marks the rubble of an ancient church.  A sad feeling akin to gloom presses
 down upon your shoulders, making your own load feel that much more heavier to
 bear here.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -332,7 +332,7 @@ guardian or omen.  None of the pedestrians on Trade Road to the north even
 glance in this direction as they pass on by.  The alley continues on to the
 south.  A strong smell of old blood and rot wafts through the area...    
 ~
-294 4 0 0 0 0
+294 4 0 0 0 1
 D0
 You see Trade Road to the north.
 ~
@@ -355,7 +355,7 @@ their relative decay giving their age to be about two weeks dead.  You shift
 your weight uneasily, startling two rats sniffing around the taller corpse.  
 The alley leads north and east from here.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -384,7 +384,7 @@ on the walls, drawn with an unsteady hand and a large supply of fecal material.
 A more sinister smell teases you just below the stench here just before a
 breeze from the east blows it away from you.    
 ~
-294 4 0 0 0 0
+294 4 0 0 0 1
 D1
 ~
 ~
@@ -410,7 +410,7 @@ is back north towards Trade Road.  A small breeze teases you with an awful
 smell, and whisks it away just as quickly.  Something is making you feel rather
 uneasy about this area, but its probably just your imagination.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -432,7 +432,7 @@ here.  To the south, Clay Road continues towards the southern city wall, not
 far away.  A nicely built building with an exquisite architecture is to the
 east, while the distinctive smell of tannin comes from a shop from the west.  
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -474,7 +474,7 @@ east.  Westwards, you see the intersection of Trade Road and Clay Street, which
 runs north-south.  A large open-air building is to the north, and southwards is
 a large open lot; a fairgrounds, closed for the time being.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 A large building with many tethering posts outside is to 
 the north.
@@ -507,7 +507,7 @@ marking the boundries of Trade Road, and this neighborhood.  To the south is a
 large fairgrounds area, closed for the time being.  A building to the north
 seems to be locked up tight, with a large, 'FOR RENT' sign out front...    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -545,7 +545,7 @@ west from here, and there is a largish gatheouse not far to the east.  A
 north-south running road labeled 'Staid Avenue' intersects here, taking much of
 the traffic away from the main road to the south.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -576,7 +576,7 @@ can see farmlands.  The gate looks to be a good defensible point in the city
 wall, an architectural artifact of more dangerous times in these realms.  
 Westwards a large road leads through XXXX.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D3
 ~
 ~
@@ -600,7 +600,7 @@ Most of the buildings seem to be low cost housing for the common populace of
 XXXX; making you guess there is a very high population density in this area.
   
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -617,7 +617,7 @@ another intersection of roads.  There seems to be many buildings used as
 domiciles in this area.  You wouldn't exactly call this neighborhood a 'bad'
 neighborhood yet, but the potential is certainly there.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -639,7 +639,7 @@ residential district.  Harple Road seems to run along part of the length of the
 wall here, lined with apartment buildings and a few duplexed houses.  To the
 north is one particularly bad looking boarding house.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 There is a boarding house to the north.
 ~
@@ -674,7 +674,7 @@ amazing lack of the graffiti typical of other large, heavily populated towns in
 this neighborhood.  Seems as if the average populace in XXXX is considerably
 more well-behaved than most other places.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 An ordinary house is to the north.
 ~
@@ -700,7 +700,7 @@ crooked and warped by the uneven ground.  Just to the west Staid Avenue runs
 south from Harple, towards Trade Road.  The neighborhood seems quiet, pensive
 even.  Strange...    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 A normal-looking house is to the north.
 ~
@@ -722,7 +722,7 @@ Harple Road~
 Avenue leads south from Harple not far from here.  There doesn't seem to be
 much going on around here at all...  A very calm neighborhood.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 A private home is to the east.
 ~
@@ -748,7 +748,7 @@ by much.  The buildings to either side of you rise high up, cutting off most of
 the light available from the sky.  The stench and darkness raises your hackles,
 and you shiver involuntarily.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 Harple Road runs to the east.
 ~
@@ -774,7 +774,7 @@ west.  An ill wind ruffles your hair from the north, carrying a smell of
 sewage, of rot, sickness and decomposition.  Your stomach squirms like a live
 animal in your gut, making you feel distinctly uneasy.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -791,7 +791,7 @@ Staid Avenue~
 the shops and buildings in this area are getting noticeably worse now, and the
 litter in the street is getting thicker the farther south you go.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -825,7 +825,7 @@ Boulevard near the river.  The neighborhood seems to be getting worse and worse
 the closer to the river you actually get.  Westwards is an open shop with a
 monstrous anchor out in front being used for a tethering post.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -858,7 +858,7 @@ north side of Klelk in both directions you see some of the typical dives you
 would expect close to the waterfront.  North from here Staid Avenue heads
 towards Trade Road and the central areas of the city.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -895,7 +895,7 @@ seems to be.  You would guess that the sailors of the river bring money to this
 section of town; hence all the low-grade shops and wayhouses, not to mention
 what might be called a 'tavern' to the north.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 A horrible, disgusting tavern is to the north.  It's open 
 though.
@@ -927,7 +927,7 @@ is especially high here, perhaps to protect the guards above from the rabble
 below.  The wall is stained with trash and refuse, obviously missed shots at
 the guards patrolling on the top...    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 There seems to be an alley to the north...
 ~
@@ -949,7 +949,7 @@ Alley~
 through, in all directions.  The alley continues to the west, and south you see
 Klelk Boulevard.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D2
 You spot Klelk Boulevard to the south.
 ~
@@ -967,7 +967,7 @@ junk lie about, unwanted and thrown away.  This alley seems not to be travelled
 at all, or used for trash and refuse.  The path between buildings continues to
 the east, and west is an opening up onto Clay Street.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -991,7 +991,7 @@ the south are the city docks, extending into the swiftly flowing river.  A lone
 ship sails past, travelling eastward and sporting a merchant's flag.  A ruined
 building nearly stands to the north.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 What appears to have once been a shop is to the north.
 ~
@@ -1099,7 +1099,7 @@ customer describe what they want, whereupon the merchant brings something
 similar from the back through a large metal door.  This strikes you as a fairly
 inefficient method of shop-keeping, but very secure.    
 ~
-294 8 0 0 0 0
+294 8 0 0 0 1
 D0
 Trade Road runs right outside.
 ~
@@ -1146,7 +1146,7 @@ around you...  Images quickly shattered by the rustle of your clothing in the
 wind and a distant sound of someone talking on the street.  A sense of sadness
 consumes you as you stand here, and then you turn to go.    
 ~
-294 4 0 0 0 0
+294 4 0 0 0 4
 D1
 ~
 ~
@@ -1568,7 +1568,7 @@ how to protect themselves.  These strange portals that appear sometimes bring
 with them strange monsters.  Things from the past and even some never thing
 never before even imagined.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1585,7 +1585,7 @@ in ruins.  One of those strange happening took place here.  Some type of portal
 opened in the midst of this building, the strange forces within it brought the
 walls down upon itself.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1602,7 +1602,7 @@ that these people dare sleep at night.  Many casualties occur regularly in this
 area.  By the looks of the people they have come to accept their fate.  The
 street continues to the north and south.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -1619,7 +1619,7 @@ down and in need of some serious repair.  The residential district is not only
 outside the protective dome of XXXX, but also outside of it's rule.  No one
 even attempts to take care of this area or it's people.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1636,7 +1636,7 @@ the now unstable world these people live in.  Safety only lies within the walls
 of XXXX.  The main trade road to the south intersects the avenue you are
 currently on.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D0
 ~
 ~
@@ -1654,7 +1654,7 @@ city.  The road is in decent shape, good enough for the wagons and caravans to
 make good time on.  The road and everything around it is layered in a thick
 dust.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1671,7 +1671,7 @@ citizenry here seem depressed and resigned to some awful fate that only they
 seem to understand or know.  The road continues to the east towards XXXX or
 west out towards the farmlands.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1688,7 +1688,7 @@ stale air.  The wagon passes by quickly, the driver seeming to try to mind his
 own business.  The creak and groan of the wagon wheels reveals it must be
 carrying a heavy load.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 S
 #29463
 Trade Road~
@@ -1697,7 +1697,7 @@ Without them the city would surely starve.  The farmers are well taken care of
 for their sacrifice of living outside of XXXX in harms way just to bring
 food to the city.  The Trade Road stretches to the east and west.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 S
 #29464
 Trade Road~
@@ -1706,7 +1706,7 @@ the residential district.  A few people are about, but not the amount you would
 expect.  Bulidings line the Trade Road to the north and south, but they all
 seem to be empty.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 S
 #29465
 Trade Road~
@@ -1715,7 +1715,7 @@ Many people continue to live here out of stubbornness and tradition.  A few
 moved within the city after the strange happenings began, but many people just
 can't leave where they were born and raised.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1732,7 +1732,7 @@ wagons delivering goods for trade between XXXX, the farmlands, and the lands
 beyond.  With the appearance of portals throughout the realm the possibilities
 for trade are now boundless.  If you dare take the risk of exploring.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1750,7 +1750,7 @@ buildings falling apart and decrepit, but so are the people.  People have now
 seen things that should never be forced upon the mortal eye.  Many of them are
 forever changed from that moment on.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1768,7 +1768,7 @@ Recent studies by the Magi of XXXX have concluded that the number of
 the damage done by Drakkar is far more elaborate than just the tearing of time
 and space.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~
@@ -1785,7 +1785,7 @@ stark relief from the rest of this place.  The road is potted, rutted, and a
 slimy mess.  The buildings are about the same, a wonder they still stand.  The
 boulevard continues east and west.    
 ~
-294 0 0 0 0 0
+294 0 0 0 0 1
 D1
 ~
 ~

--- a/lib/world/wld/295.wld
+++ b/lib/world/wld/295.wld
@@ -3,7 +3,7 @@ The start of the jungle~
    Going by the trees, you appear to have left the forest and entered a jungle!
 There are exotic trees and plants that you have never seen anywhere before.  
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D2
 ~
 ~
@@ -34,7 +34,7 @@ Deeper into the jungle~
 comming from all around you, and someone somewhere is beating some drums.  
 Hope the natives are friendly!    
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D0
 ~
 ~
@@ -50,7 +50,7 @@ Deeper in to the jungle~
 jungle, east appears to lead down a small trail from which the sound of drums
 can be heard, west heads in to some thicker trees 
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D0
 ~
 ~
@@ -70,7 +70,7 @@ On a small trail~
 To the east the sound of drums are getting very loud. Maybe you should turn
 back and go and get some help before you go any further!
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D1
 ~
 ~
@@ -86,7 +86,7 @@ The gate to the camp~
 to rest for a while, but the skulls that are stuck on the end of spears tell
 you different!    
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D1
 ~
 gate~
@@ -103,7 +103,7 @@ all over the place, some of them are obviously human!  It looks like you just
 missed a big feast. Maybe you should leave before they make you the guest of
 honour at the next one!
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D0
 ~
 ~
@@ -162,7 +162,7 @@ To the monkeys!~
 There are vines hanging down from some of the trees that look like you could
 climb up.
 ~
-295 4 0 0 0 0
+295 4 0 0 0 3
 D1
 ~
 ~
@@ -181,7 +181,7 @@ In the trees~
    Wow, these trees are high!  You think you can almost see Midgaard from up
 here! Wonder if there are any animals living up here?
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D0
 ~
 ~
@@ -198,7 +198,7 @@ stable in the trees around you, maybe you should go back down.  You also notice
 what looks like a bit of snake skin hanging from a branch. Wonder where its
 owner is?
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D0
 ~
 ~
@@ -213,7 +213,7 @@ In the trees~
    It looks like you have just walked in to a nest of greater climbing tree
 snakes! Watch out, they could be poison in them there fangs!
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D2
 ~
 ~
@@ -225,7 +225,7 @@ Close to the monkeys~
 sounds like all the apes from the jungle are having some sort of a meeting!
 This has got to be worth a look at.
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D1
 ~
 ~
@@ -241,7 +241,7 @@ The meeting room~
 they have one hell of a party at these meetings, judging from all the junk
 left around.
 ~
-295 0 0 0 0 0
+295 0 0 0 0 3
 D0
 ~
 ~

--- a/lib/world/wld/296.wld
+++ b/lib/world/wld/296.wld
@@ -8,7 +8,7 @@ Ahead is a largish building that seems to block out the sun nearby:
 a big, squat, dark brown building that exudes lifelessness.  You see
 several people going in and out its doors, shoulders slumped in defeat.
 ~
-296 4 0 0 0 0
+296 4 0 0 0 1
 D0
 ~
 ~
@@ -52,7 +52,7 @@ area, where many wagons and carts sit parked.  To the north, you
 see the building, with the logo emblazoned:
               'Froboz's Fun Factory of Doom!'
 ~
-296 0 0 0 0 0
+296 0 0 0 0 1
 D0
 ~
 ~
@@ -73,7 +73,7 @@ wagons and carts parked everywhere, all as close as possible to
 the main building while staying nicely between the little yellow
 lines drawn in the dirt.
 ~
-296 0 0 0 0 0
+296 0 0 0 0 1
 D1
 ~
 ~
@@ -95,7 +95,7 @@ are the more expensive vehicles -- some taking up two parking spaces
 so no one scratches the trim.  Way, way in the back is a huge wagon
 with harness for four animals!  Talk about major horsepower!!!
 ~
-296 0 0 0 0 0
+296 0 0 0 0 1
 D0
 ~
 ~
@@ -113,7 +113,7 @@ lot, and a small access road winds north around the west side
 of the building.  There aren't as many wagons and carts here,
 since the walk to the front entrance is kind of long...
 ~
-296 0 0 0 0 0
+296 0 0 0 0 1
 D0
 ~
 ~
@@ -135,7 +135,7 @@ the entrance of the building.  You do see a couple of old, decrepit
 vehicles around with broken wheels and such, but there just isn't
 much here of interest.
 ~
-296 0 0 0 0 0
+296 0 0 0 0 1
 D0
 ~
 ~
@@ -154,7 +154,7 @@ seemingly impenatrable, and have Froboz's curly-Q sigil worked
 in on the front.  You are not sure if the doors are meant to
 keep intruders out, or workers in...
 ~
-296 0 0 0 0 0
+296 0 0 0 0 1
 D0
 ~
 ~
@@ -820,7 +820,7 @@ still wouldn't want to work there.  Many heavy  carts and
 wagons slowly make their way up and down this road, wearing
 the ruts in the road even deeper into the earth.
 ~
-296 0 0 0 0 0
+296 0 0 0 0 1
 D0
 ~
 ~
@@ -838,7 +838,7 @@ to be loaded or unloaded by the factory workers, and then sent
 on their delivery routes.  As you watch, they all slowly move
 up one cart-length, and then the drivers continue their snoozing.
 ~
-296 4 0 0 0 0
+296 4 0 0 0 1
 D1
 ~
 ~

--- a/lib/world/wld/298.wld
+++ b/lib/world/wld/298.wld
@@ -791,7 +791,7 @@ The Eastern Side of the Moat~
 end of this side of the moat.  Your only choice is to go back from where you
 came.    
 ~
-298 8 0 0 0 0
+298 8 0 0 0 6
 D3
 ~
 The Castle Moat~
@@ -815,7 +815,7 @@ Under Water in the Moat~
 from the muck that surrounds you.  You have a feeling you should go back from
 where you came.  If you go down futher you will surely die!    
 ~
-298 1 0 0 0 0
+298 1 0 0 0 8
 D4
 ~
 The Castle Moat~
@@ -830,7 +830,7 @@ The Deadly Depths of the Moat~
    The pressure is too much for you to handle.  You better go up before you
 drown.    
 ~
-298 0 0 0 0 0
+298 0 0 0 0 8
 D4
 ~
 Under water in the Moat~

--- a/lib/world/wld/299.wld
+++ b/lib/world/wld/299.wld
@@ -10,7 +10,7 @@ and left lying on the ground near the now open doorway.
 can be seen, creaking in the wind.  On the other side of the gate,
 there seems to be an older road leading away from the cathedral.
 ~
-299 0 0 0 0 0
+299 0 0 0 0 2
 D0
 A large fountain of water can be seen inside the open doorway to the
 north.
@@ -1396,7 +1396,7 @@ a large stone wall with an iron wrought gate planted firmly where the
 road would pass through it.  The building to the north appears to be
 an old church or cathedral.
 ~
-299 4 0 0 0 0
+299 4 0 0 0 1
 D0
 An iron wrought gate stands in the middle of the stone wall, and blocks
 the way northwards into the courtyard of the cathedral.

--- a/lib/world/wld/3.wld
+++ b/lib/world/wld/3.wld
@@ -6,7 +6,7 @@ smell.  The Hall is bare, only a few small paintings cover the walls.  Clerics
 have very little need for decorations of any kind.  A small waiting room is to
 the west.    
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -58,7 +58,7 @@ overturned leaving gaping holes.  No wagons travel down this part of the city.
 Everyone knows clerics have no need for anything besides what they can provide
 by themselves.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -75,7 +75,7 @@ packed dirt.  To the north one may enter the inner city towards the Temple of
 Sanctus or go south towards the southern gate.  The southern half of the city
 consists of the magi and clerics' quarters.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -92,7 +92,7 @@ where the inner city wall turns to the west.  This avenue runs deep within the
 Magi's Quarter.  Accidents have been known to happen around here.  People must
 be careful for who knows what an inexperienced student may do.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -109,7 +109,7 @@ sides of the hallway.  Depicted on these drawings are a myriad of creatures
 ranging from ogres, orcs, goblins, and demons to humans, elves, and dwarves.  
 One of the paintings looks oddly familiar.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -131,7 +131,7 @@ large copper tubs filled with hot water.  A large fire with pots of water
 heating over it fills the eastern wall.  These baths are only to be used by the
 magi whom believe cleanliness is next to godliness.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -152,7 +152,7 @@ from wall to wall.  Every rack is made precisely to standard, every sheet a
 pristine white, without even a speck of dust.  The Cleric's of Sanctus lead a
 disciplined life, second to none, not even the soldiers.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -170,7 +170,7 @@ Sanctus consider decorations, desires, or any form of unnecessary wants to be
 blasphemous.  They dedicate their lives to helping others, never themselves, and
 would all sacrifice their lives for that principle.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -191,7 +191,7 @@ on to the east.  A small road follows along the inner city wall just north of
 the Tower of the High Council which seems to glow because of its glaring
 brightness.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -212,7 +212,7 @@ Even those would be vandals, pickpockets, and thugs shy away out of their
 respect of the clerics.  To be a cleric is to be respected second only to that
 of the Master Magi.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -230,7 +230,7 @@ or maybe three times the average man's height.  One can just make out a small
 walkway on the top of the wall, too bad only the guards know where the entrance
 is.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -248,7 +248,7 @@ smaller.  Far up in the tower you can see people walking by windows in white
 flowing robes.  The healers within are known for their miraculous abilities in
 restoring the wounded.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -265,7 +265,7 @@ runs from the south gate directly to the heart of Sanctus inside the temple.  A
 few apprentice healers in flowing robes rush between the Temple and the Clerics'
 Quarters, no doubt on an errand from the Council.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -283,7 +283,7 @@ clerics' quarters lie to the west while the magi quarters are to the east.
 Within their centers rises the Tower of the High Council of Clerics and the
 Tower of the Magi respectively.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -308,7 +308,7 @@ surroundings and the underlying alley.  Within the tower lie many secrets that
 the average citizen is not privileged enough to be told about.  Rumours abound,
 especially about the Orb of Sanctum the gods left in the Master Magi's care.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -325,7 +325,7 @@ coming either from on top of the inner city wall to the north or from an open
 window of the Tower of the Magi south of here.  The voices are too low to be
 discernable.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -342,7 +342,7 @@ battlefields.  In case of an attack by superior numbers the citizens will fall
 back into the inner city as a last measure of defense.  Luckily, the army has
 been very successful in protecting the city and it has never come to that.    
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -359,7 +359,7 @@ it turns north along the Magi Avenue.  The Tower of the Magi still looms heavy
 over the surroundings oppressively.  The sounds of voices echo between the tower
 and the inner city wall, very disturbing.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -376,7 +376,7 @@ the inner city wall.  The Magi Mansion lies just to the east, so extravagant
 that it is almost at the point of becoming an eyesore.  The Tower contains the
 fabled Orb of Sanctum, but few are ever lucky enough to lay their eyes on it.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -398,7 +398,7 @@ in.  In the one infront of you the army of Sanctus stands on the verge of
 defeat, except for the constant bombardment of fireballs, lightning, and meteors
 hurled from the battlements by the Magi.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -419,7 +419,7 @@ as appetizers, and others in fine silver plates and containers.  The kitchen is
 cramped, too many things and too many people in one area.  The cooks look
 overworked and ready to revolt.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -441,7 +441,7 @@ so that one can give thanks for all that has been given in this simple room of
 prayer.  The walls are unadorned, everything looks to be plain and only used for
 its intended purpose.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -462,7 +462,7 @@ entire building.  The only source of light are lanterns spaced widely apart upon
 the walls which leave much of the hall in shadow.  The bare floor and walls show
 the lifestyle the clerics lead.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -484,7 +484,7 @@ inner city wall begins.  Many people come to this quarter to seek aid from the
 clerics, whether it be healing in the tower or to settle disputes within the
 Hall.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -501,7 +501,7 @@ Very few are selected for this great honor, and even fewer ever achieve a
 mastery in the art of restoring health.  Several of the older clerics are here
 bestowing their knowledge and wisdom to their students.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -517,7 +517,7 @@ A Training Room~
 gray-haired man who is drawing something on a board.  He often uses words of a
 different language that are very hard to follow and impossible to understand.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D1
 ~
 ~
@@ -538,7 +538,7 @@ is shivering in fright.  It seems to have broken its foot and the soon to be
 healers are practicing their skills on it.  Better than expirementing with live
 humans.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -560,7 +560,7 @@ boy to instantly fall asleep.  Another cleric takes the boys arm which has been
 badly bruised and possibly broken and begins chanting mysterious words.  The
 bruises fade away without a trace.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D2
 ~
 ~
@@ -577,7 +577,7 @@ and the oppressive Tower of the Magi.  This section of the city has a very
 solemn feeling overshadowing it.  The magic of healing on one side and the magic
 of power and destruction on the other.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -594,7 +594,7 @@ are held within this tower no matter what time of day.  The Magi are searching
 relentlessly for the next Master Magi.  They are short by two and the five
 existing are all old and nearly finished in their lives.    
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D1
 ~
 ~
@@ -611,7 +611,7 @@ Though the army is generally all that is required to handle most battles, the
 Magi are sometimes called upon to prevent heavy casualties or counter any
 magical abilities the attackers may possess.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D1
 ~
 ~
@@ -632,7 +632,7 @@ that upholds the balance within the city.  Mention of the Orb of Sanctus
 whispers around the room, and of how the gods bestowed it upon the Master Magi
 to preserve and protect.  Without the Orb the city would surely fall.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D1
 ~
 ~
@@ -653,7 +653,7 @@ small flickering ball of light.  The Master Magi casts a stern eye over anyone
 watching and motions them away.  No one disagrees with a Master Magi, at least
 no one that wishes to live.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D2
 ~
 ~
@@ -671,7 +671,7 @@ above the other buildings.  The Magi train young students within to take their
 place, but fewer and fewer meet the requirements and actually survive the
 training.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -689,7 +689,7 @@ the windows.  Rugs of the colors of the Magi line the floors.  Everything is
 spotless and well maintained.  Living here would be what many would consider as
 living the good life.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -707,7 +707,7 @@ extravagant life and hold themselves to be very prestigious and elegant.  No one
 would ever dare call them otherwise.  The hall is unkempt and bare of any
 furnishings.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -725,7 +725,7 @@ arranged assortments.  The rest of the room is filled with empty cots and bunks
 which are used to rehabilitate the injured if there are ever more casualties
 than the tower can hold.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -742,7 +742,7 @@ It is here the High Council convenes to help citizens solve minor disputes.
 The building is barren of any luxuries.  That is the way a cleric must live,
 without desires or wants.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -764,7 +764,7 @@ with multi-colored herbs swings in the gentle breeze.  The Tower rises far
 above, its two spires reaching almost as high as the Temple.  In contrast the
 hall looks very mundane.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -789,7 +789,7 @@ west.  The Tower is bathed in bright white light that reflects off every
 surface.  All around, the soft murmur of healers in training or going about
 their daily routine can be heard.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -814,7 +814,7 @@ tower towards the High Council's chambers.  Many famous healers reside within
 this tower's magical walls.  It is said that just by standing in certain rooms
 of the tower one can heal at unnatural rates.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -842,7 +842,7 @@ The Tower of the Clerics~
 around you is impressive in both size and stature.  Large white pillars support
 high domed ceilings of this spotless white room.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -872,7 +872,7 @@ entrance of the revered Tower of the High Council.  High above is where the
 councillors make many important decisions on how to uphold the welfare and
 health of the city.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -897,7 +897,7 @@ part of the road.  To the west the Tower of the High Council of Clerics, to the
 east the Tower of the Magi.  Both impressive structures were built by both
 master architects and the use of magic.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -922,7 +922,7 @@ oppression, as if something or someone is holding something deliberately back.
 A large doorway to the west leads to the Southern Road or it is possible to
 explore deeper into the temple to the east.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -947,7 +947,7 @@ tinge of sulphur hangs in the air, probably a spell that went haywire.
 Students roam the halls in deep thought, oblivious to the normal reality you
 live in.  Training Rooms lie in all directions.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -975,7 +975,7 @@ The Tower of the Magi~
 sounds of people chanting echo off the pitch black walls that almost appear
 depthless.  Most likely a simple trick of the eye, but then again, maybe not.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1005,7 +1005,7 @@ wood causes one to lose themselves as they peer further and further into the
 blackness.  It is impossible to tell if this is caused by magic or just a simple
 trick of the eye.  To the east is the center of the Magi Quarters.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -1029,7 +1029,7 @@ The Magi Quarters~
 found when they are not guarding the orb is to the east.  Also nearby is the
 pure black Tower of the Magi which houses the sacred orb that protects the city.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -1054,7 +1054,7 @@ style and design imaginable.  The Magi believe in a life of service to their
 discipline, but they also believe that they should be able to live in comfort.
 This building is one of the most elaborate within the entire city.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1076,7 +1076,7 @@ those who wish to study the fine art of magic to rest comfortably.  Several
 books lay open upon the tables.  Occasional trickles of smoke waft in from under
 the doorway to the east.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1097,7 +1097,7 @@ herbs required for the mixes and salves the clerics require.  They are rumoured
 to sometimes sell some of their remedies, though this is very rare and at a very
 steep price.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 door~
@@ -1110,7 +1110,7 @@ form of antiseptic stings in the air.  All the beds are empty, must be the
 healers here are well-versed in their craft.  The Temple continues to the north
 and west.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -1127,7 +1127,7 @@ portraying a woman and children playing on a river's edge surround the edge of
 basin.  The water inside the basin is extremely clean and sterily, likely used
 by the the clerics to tend for the wounded.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1148,7 +1148,7 @@ the north, the center of the tower, holds a set of stairs leading higher up into
 the tower.  Small benches line the walls here, allowing people to rest from
 their adentures.  
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1169,7 +1169,7 @@ apprentice does what he can to aid these poor people, but it is obvious that
 many of them need to be attended to shortly by a real healer or else they may
 perish.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1186,7 +1186,7 @@ its polished surfaces reflecting all light down onto the Clerics' Quarters which
 it protects.  To the west the Tower of the Magi does the exact opposite, seeming
 to absorb all light surrounding it.  There must be balance in all things.  
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -1203,7 +1203,7 @@ The smell of dust and musty old papers emanates from them.  Many centuries of
 knowledge lie within these books that were salvaged from the lands beyond.  
 Many more have yet to be found.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -1220,7 +1220,7 @@ set of spiral staircases lead to the second floor.  The Orb of Sanctum is
 protected somewhere within this tower.  The Master Magi have been given the task
 of ensuring its safety.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1241,7 +1241,7 @@ fight in battles any longer.  They have instead devoted their time to training
 future Magi to take their places.  But, good students have become even harder
 to come by these days.    
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -1263,7 +1263,7 @@ with various books.  This must be some sort of study room for the Magi.  The
 black walls seem to absorb the white light coming from strange bulbs hanging
 from the ceiling.    
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D0
 ~
 ~
@@ -1281,7 +1281,7 @@ bookshelves, tables and the floor of this under sized room.  It is here a vast
 amount of the Magi have left thei findings when delving into the depths of
 their magic.    
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 door~
@@ -1293,7 +1293,7 @@ The Southern Gate~
 well protected against an attack.  Lookouts can be heard above chatting idly
 while the sentinel guards stand at attention waiting to be called into action.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~
@@ -1315,7 +1315,7 @@ building with bales of hay stacked everywhere.  The horses can't reach the hay
 though they all seem to still try.  It is possible to buy a horse for a minimal
 fee, but not all of them are well tamed and have been known to become ornery.
 ~
-3 8 0 0 0 0
+3 8 0 0 0 1
 D1
 ~
 ~
@@ -1331,7 +1331,7 @@ will never be used by mortals. Although a pet shopkeeper is not required it is
 recommended. In order to implement a pet shop the actual mud code has to be
 modified. Just ask Rumble to do it for you. 
 ~
-3 1024 0 0 0 0
+3 1024 0 0 0 1
 S
 #365
 On the Window Ledge~
@@ -1340,7 +1340,7 @@ of the city.  A gust of wind howls past threatening to pull anything along with
 it.  The only exit is back into the tower or a deadly jump to the cobblestone
 road below.
 ~
-3 0 0 0 0 0
+3 0 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/30.wld
+++ b/lib/world/wld/30.wld
@@ -131,7 +131,7 @@ temple gate.  The entrance to the Clerics' Guild is to the west, and the old
 Grunting Boar Inn, is to the east.  Just south of here you see the market
 square, the center of Midgaard.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the temple.
 ~
@@ -321,7 +321,7 @@ entrance to the Guild of Magic Users.  The street continues east towards the
 market square.  The magic shop is to the north and to the west is the city
 gate.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the magic shop.
 ~
@@ -349,7 +349,7 @@ Main Street~
 here is the entrance to the Armory, and the bakery is to the north.  East of
 here is the market square.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the bakery.
 ~
@@ -378,7 +378,7 @@ A large, peculiar looking statue is standing in the middle of the square.
 Roads lead in every direction, north to the temple square, south to the
 common square, east and westbound is the main street.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the temple square.
 ~
@@ -410,7 +410,7 @@ Main Street~
 general store, and the main street continues east.  To the west you see and
 hear the market place, to the south a small door leads into the Pet Shop.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the general store.
 ~
@@ -438,7 +438,7 @@ Main Street~
 Guild of Swordsmen.  To the east you leave town and to the west the street
 leads to the market square.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the weapon shop.
 ~
@@ -590,7 +590,7 @@ The Eastern End Of Poor Alley~
    You are at the poor alley.  South of here is the Grubby Inn and to the
 east you see common square.  The alley continues further west.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 You see the common square.
 ~
@@ -613,7 +613,7 @@ The Common Square~
 the poor alley and to the east is the dark alley.  To the north, this square
 is connected to the market square.  From the south you notice a nasty smell.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the market square.
 ~
@@ -640,7 +640,7 @@ The Dark Alley~
    The dark alley, to the west is the common square and to the south is the
 Guild of Thieves.  The alley continues east.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 The alley continues east.
 ~
@@ -726,7 +726,7 @@ The Dump~
 garbage you can see a large junction of pipes, looks like the entrance to the
 sewer system.  North of here you see the common square.
 ~
-30 4 0 0 0 0
+30 4 0 0 0 2
 D0
 You see the common square.
 ~
@@ -795,7 +795,7 @@ Inside The West Gate Of Midgaard~
 connected with a footbridge across the heavy wooden gate.  Main Street leads
 east and Wall Road leads south from here.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 You see Main Street.
 ~
@@ -840,7 +840,7 @@ Inside The East Gate Of Midgaard~
 connected with a footbridge across the heavy wooden gate.  Main Street leads
 west from here.  To the south you see the Water Shop.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 You see the city gate.
 ~
@@ -883,7 +883,7 @@ Wall Road~
    You are walking next to the western city wall.  The road continues further
 south and the city gate is just north of here.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the city gate.
 ~
@@ -906,7 +906,7 @@ Wall Road~
 north and south.  A small, poor alley leads east.
 Some letters have been written on the wall here.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 The road continues further north.
 ~
@@ -937,7 +937,7 @@ Poor Alley~
    You are on Poor Alley, which continues further east.  You see the
 city wall to the west.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 The alley leads east.
 ~
@@ -954,7 +954,7 @@ The Dark Alley At The Levee~
    You are standing in the alley which continues east and west.  South of
 here you see the levee.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 The alley leads east.
 ~
@@ -977,7 +977,7 @@ The Eastern End Of The Alley~
 east, blocking any further movement.  A small warehouse is directly south of
 here.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D2
 You see the warehouse.
 ~
@@ -994,7 +994,7 @@ Wall Road~
    You are standing on the road next to the western city wall, which
 continues north.  South of here is a bridge across the river.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the road.
 ~
@@ -1028,7 +1028,7 @@ The Levee~
    You are at the levee.  South of here you see the river gently flowing west.
 The river bank is very low making it possible to enter the river.
 ~
-30 128 0 0 0 0
+30 128 0 0 0 1
 D0
 You see the alley.
 ~
@@ -1058,7 +1058,7 @@ On The Bridge~
 built out from the western city wall and the river flows west through an
 opening in the wall ten feet below the bridge.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the road.
 ~
@@ -1090,7 +1090,7 @@ Outside The West Gate Of Midgaard~
 connected with a footbridge across the heavy wooden gate.  To the west you
 can see the edge of a big forest.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 The city gate is to the east.
 ~
@@ -1129,7 +1129,7 @@ Outside The East Gate Of Midgaard~
 connected with a footbridge across the heavy wooden gate.  To the east the
 plains stretch out in the distance.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D1
 You see the plains.
 ~
@@ -1213,7 +1213,7 @@ Behind The Temple Altar~
 of here.  To the north, the path continues through the lush contryside of
 Midgaard towards the Dragonhelm Mountains far off to the north.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see the lush, green countryside of Midgaard.
 ~
@@ -1238,7 +1238,7 @@ stay here forever, surrounded by powerful beauty in all directions.
    The path you are on continues north through the field and south back
 to Midgaard.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 1
 D0
 You see more of the path through the Great Field.
 ~
@@ -1263,7 +1263,7 @@ stay here forever, surrounded by powerful beauty in all directions.
    There is a strange structure on the eastern side of the path.  A small
 dirt path splits off of the main path and leads off to the west.
 ~
-30 4 0 0 0 0
+30 4 0 0 0 1
 D0
 The path continues northwards bringing you ever closer to the Dragonhelm
 Mountains.
@@ -1294,7 +1294,7 @@ been pried open by curious customs agents, and are now stacked along the west
 wall, hiding plenty of 'WANTED' posters.
 There is a sign posted on the wall here.
 ~
-30 8 0 0 0 0
+30 8 0 0 0 1
 D2
 You see the entrance to the Grunting Boar Inn and Tavern.
 ~
@@ -1349,7 +1349,7 @@ The Midgaard Donation Room~
 are a couple of small wooden benches here where people occasionally sit
 while they wait for items to appear.  The temple is to the west.
 ~
-30 28 0 0 0 0
+30 28 0 0 0 1
 D3
 The busy temple is back west.
 ~
@@ -1362,7 +1362,7 @@ The Cryogenic Center~
 body-length canisters lined up against the walls.  The Reception is to the
 south.
 ~
-30 8 0 0 0 0
+30 8 0 0 0 1
 D2
 The Reception is to the south.
 ~
@@ -1382,7 +1382,7 @@ stay here forever, surrounded by powerful beauty in all directions.
    The way north appears to be blocked by a large plot device and you cannot
 see any way around it.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 2
 D0
 Unfortunately the way north is blocked by a large plot device and there
 does not seem to be any way around it.
@@ -1415,7 +1415,7 @@ in all directions.
    There is a large rusty gate sitting in a stone archway just to the
 west.
 ~
-30 0 0 0 0 0
+30 0 0 0 0 2
 D1
 The path meets up with a larger path just to the east.
 ~

--- a/lib/world/wld/300.wld
+++ b/lib/world/wld/300.wld
@@ -5,7 +5,7 @@ cover the valley floor.  It would appear that not many have come here
 in ages.  To the west, the land rises to leave the valley.  To the
 east the vegetation clears to give way to a strange uprising of stone.
 ~
-300 4 0 0 0 0
+300 4 0 0 0 4
 D1
 The uprising looks like some huge beast set to pounce.
 ~
@@ -73,7 +73,7 @@ between its limbs and the huge oaks, dwarfed by the dragon itself,
 which have grown there.  A vague evil emanates from the once-alive
 stone that terrorized nations long ago.
 ~
-300 0 0 0 0 0
+300 0 0 0 0 4
 D1
 The huge maw lies frozen in midsnarl.  You could find enough purchase
 to scale the tongue and enter inside, should you want to.
@@ -352,7 +352,7 @@ dripping off stalactites far above.  Pools of acid fill every crevice
 on the craggy cavern floor.  The cavern continues to the south and
 east.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D1
 ~
 ~
@@ -368,7 +368,7 @@ The Acid Forest~
 jester's garb.  Puddles of weak stomach acid are pooled on the floor.
 The cavern stretches in all directions but north.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D1
 ~
 ~
@@ -388,7 +388,7 @@ The Acid Forest~
 dripping off stalactites far above.  Pools of acid fill every crevice
 on the craggy cavern floor.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D2
 ~
 ~
@@ -405,7 +405,7 @@ on the cavern floor is a forest of oddly shaped stalagmites surrounded
 everywhere by puddles of what must be the remnants of the dragons
 stomach acid.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D0
 ~
 ~
@@ -430,7 +430,7 @@ The Acid Forest~
 bridge passes far overhead.  Sharp stalagmites poise here to meet
 those who would drop from it.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D0
 ~
 ~
@@ -454,7 +454,7 @@ The Acid Forest~
 jester's garb.  Puddles of weak stomach acid are pooled on the floor.
 A steep climb up leads to a large plateau at the end of the cavern.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D0
 ~
 ~
@@ -478,7 +478,7 @@ The Acid Forest~
    Mists swirl around strange crystal egg shells here.  The cavern
 continues to the north and to the east.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D0
 ~
 ~
@@ -494,7 +494,7 @@ The Acid Forest~
 dripping off stalactites far above.  Pools of acid fill every crevice
 on the craggy cavern floor.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D0
 ~
 ~
@@ -514,7 +514,7 @@ The Acid Forest~
 jester's garb.  Puddles of weak stomach acid are pooled on the floor.
 The cavern stretches to the north and west.
 ~
-300 8 0 0 0 0
+300 8 0 0 0 4
 D0
 ~
 ~
@@ -821,7 +821,7 @@ faint path to the south, leading back around the dragon-hill.
 A skull-topped signpost flanks an unused road to the north.
 There is a large plot device blocking the way along the road to the north.
 ~
-300 4 0 0 0 0
+300 4 0 0 0 3
 D0
 A large plot device blocks the unused road to the north.
 ~

--- a/lib/world/wld/301.wld
+++ b/lib/world/wld/301.wld
@@ -5,7 +5,7 @@ the university stretches as far as the eye can see.  A sign is neatly posted on
 the left pillar of the gateway.  It is made of nicely polished brass.  Because
 of this, it looks rather important (as all signs go).
 ~
-301 4 0 0 0 5
+301 4 0 0 0 1
 D1
 Campus Crescent continues to the east.
 ~
@@ -67,7 +67,7 @@ Campus Crescent~
 conscientious behaviour of the politically correct students (as they all seem
 to be).  The road continues east and west.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D1
 Campus Crescent continues to the east.
 ~
@@ -90,7 +90,7 @@ conscientious behaviour of the politically correct students (as they all seem
 to be).  The road continues east and west.  To the north and south, you can see
 dormitories.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 To the north you see Victoria Hall.
 ~
@@ -127,7 +127,7 @@ conscientious behaviour of the politically correct students (as they all seem
 to be).  The road continues east and west.  A noxious smell permeates from the
 south.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D1
 Campus Crescent crosses University Avenue to the east.
 ~
@@ -158,7 +158,7 @@ The Crossroads~
 (Thus the name Crossroads.  ) University runs north-south whilst Campus runs
 east-west.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 University Avenue heads off to the north.
 ~
@@ -192,7 +192,7 @@ conscientious behaviour of the politically correct students (as they all seem
 to be).  The road continues east and west.  A large building lies south, off
 the road.  You can see another building to the north.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 To the north, lies the Arts faculty building, Corry-Mack.
 ~
@@ -229,7 +229,7 @@ conscientious behaviour of the politically correct students (as they all seem
 to be).  The road continues east and west.  The bookstore is to the north.  An
 odd, round-shaped building lies to the south.    
 ~
-301 0 0 0 0 5
+301 0 0 0 0 1
 D0
 Well, as I said earlier, the bookstore is to the north!  Try looking at it.
 ~
@@ -269,7 +269,7 @@ Division Road~
    Asphalt pavement lies heinously beneath your feet.  The road continues north
 and south.  A nice cobblestone road leads off to the west.    
 ~
-301 0 0 0 0 5
+301 0 0 0 0 1
 D0
 Division Road continues north.
 ~
@@ -299,7 +299,7 @@ University Avenue~
    This nicely crafted dirt road runs north-south.  It is normally filled with
 students.  An awful fog drifts in from the west.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 University Avenue crosses a cobblestone road to the north.
 ~
@@ -334,7 +334,7 @@ University Avenue~
    This nicely crafted dirt road runs north-south.  But it ends here.  It is
 normally filled with students.  There is a dormitory to west.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 2
 D0
 University Avenue continues to the north.
 ~
@@ -360,7 +360,7 @@ University Avenue~
    This nicely crafted dirt road runs north-south.  It is normally filled with
 students.  Buildings lie on either side of the street.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 University Avenue continues to the north.
 ~
@@ -400,7 +400,7 @@ University Avenue~
    This nicely crafted dirt road runs north-south.  It is normally filled with
 students.  Buildings lie on either side of the street.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 University Avenue continues to the north.
 ~
@@ -436,7 +436,7 @@ University Avenue~
    This nicely crafted dirt road runs north-south.  It is normally filled with
 students.  A road branches off to the east.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 University Avenue continues to the north.
 ~
@@ -464,7 +464,7 @@ University Avenue~
 students.  To the north you can see several menacing figures.  There is a sign
 here.  Reading it would be beneficial to your health and general well-being.  
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 Low-income student housing lies to the north.  BEWARE!
 ~
@@ -505,7 +505,7 @@ Union Street~
    This non-descript road segment runs east-west between University Avenue and
 Division Road.  To the north is the student centre.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 The student centre, known as the "J" Dock, stands to the north.
 ~
@@ -535,7 +535,7 @@ Union Street~
    This non-descript road segment runs east-west between University Avenue and
 Division Road.  There are buildings on either side of the street.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 The main entrance to the Jock Hardy Gym lies to the north.
 ~
@@ -571,7 +571,7 @@ Division Road~
 south.  A non-descript road leads off to the west.  A building lies to the
 north.    
 ~
-301 0 0 0 0 5
+301 0 0 0 0 1
 D0
 The Jock Hardy Arena is to the north.
 ~
@@ -601,7 +601,7 @@ Division Road~
    Asphalt pavement lies heinously beneath your feet.  The road continues north
 and south.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 Division Road continues north.
 ~
@@ -626,7 +626,7 @@ Division Road~
    Asphalt pavement lies heinously beneath your feet.  The road continues north
 and south.  A building is off to the west.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 1
 D0
 Division Road continues north.
 ~
@@ -657,7 +657,7 @@ Division Road~
    Asphalt pavement lies heinously beneath your feet.  The road continues north
 and south.    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 3
 D0
 Division Road continues north.
 ~
@@ -709,7 +709,7 @@ Division Road~
 north.  A dormitory sits to the east.  Strange that it's so far from everything
 else...    
 ~
-301 0 0 0 0 0
+301 0 0 0 0 3
 D0
 Division Road continues north.
 ~
@@ -740,7 +740,7 @@ the left pillar of the gateway.  It is made of nicely polished brass.  Because
 of this, it looks rather important (as all signs go).  The road continues north
 and south from your present location.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 1
 D2
 The Student GHETTO...  Beware!
 ~
@@ -767,7 +767,7 @@ The Ghetto~
 run down, almost into the ground in fact.  You can see many furtive shapes
 moving through the darkness.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 4
 D0
 The gateway lies to the north.
 ~
@@ -785,7 +785,7 @@ The Ghetto~
 run down, almost into the ground in fact.  You can see many furtive shapes
 moving through the darkness.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 4
 D0
 This is the ghetto, do you really need to know what is north of you?
 ~
@@ -817,7 +817,7 @@ Campus Crescent.  To both the east and west you can see locked doors.  The
 floor is decorated with rather ugly, puce tiles.  Beside the east door you can
 see an enormous amount of mailboxes.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D0
 The cobblestoned Campus Crescent lies to the north.
 ~
@@ -937,7 +937,7 @@ Supposedly, if you walk in one direction long enough, you will get to where you
 want to be.  Exits lead in all cardinal directions.  A footnote has been
 attached to this description.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D0
 Campus Crescent can be seen through the glass doors.
 ~
@@ -1002,7 +1002,7 @@ engineering events (like the construction of this area) that have taken place
 in XXX's history.  There are two exits, east to the street and west further
 inside the building.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D1
 University Avenue lies to the east.
 ~
@@ -1104,7 +1104,7 @@ the building you noticed how old this building seemed quite a long time ago.
 There are two exits.  One to the road, which happens to lie to the west and the
 exit to the east leads to a long hallway.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 2
 D1
 A long hallway leads off in this direction.
 ~
@@ -1124,7 +1124,7 @@ Shoppe.  North of you is the back hall with its bank machines, and south is the
 exit to Union Street.  This area is usually rather busy with students as this
 is the University Student Centre.    
 ~
-301 8 0 0 0 5
+301 8 0 0 0 1
 D0
 To the north you can see the back hall, complete with numerous bank
 machines, but of course you already knew that, didn't you?
@@ -1157,7 +1157,7 @@ The Back Hall~
 the north, and a games room to the east.  The Central Annex is located to the
 south whilst the street is located directly to your west.    
 ~
-301 8 0 0 0 5
+301 8 0 0 0 0
 D0
 You can distinctly see a post office here, it might have a message in it, but
 you are not quite sure.
@@ -1186,7 +1186,7 @@ Jock Hardy Lobby~
 achievements of the students and alumni.  Exits branch off in many directions.
 There is a sign here.    
 ~
-301 8 0 0 0 5
+301 8 0 0 0 1
 D0
 There is a stairway to the north.
 ~
@@ -1272,7 +1272,7 @@ Campus, miles away from everything else.  There are three exits from here, west
 to the street and main campus, east to explore the depths of Wally World, and
 north to visit the front office and reception desk.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 3
 D0
 This way leads to the reception desk.
 ~
@@ -1296,7 +1296,7 @@ The food here is mass-produced and cheaply made.  After watching how they cook
 this food you are glad you do not normally eat at the cafeteria.  There is a
 door to the east.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D1
 The doorway leads back out of the kitchen.
 ~
@@ -1322,7 +1322,7 @@ The Kitchen~
 The food here is mass-produced and cheaply made.  After watching how they cook
 this food you are glad you do not normally eat at the cafeteria.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D0
 The kitchen continues north.
 ~
@@ -1340,7 +1340,7 @@ eat this food to subsist.  You feel pity upon them as you watch them fill their
 stomachs with this sorry excuse for food.  The dining hall continues east and
 south.  The exit is to the north.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 4
 D0
 An unknown force draws you north.
 ~
@@ -1372,7 +1372,7 @@ eat this food to subsist.  You feel pity upon them as you watch them fill their
 stomachs with this sorry excuse for food.  The dining hall continues west and
 south.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 4
 D2
 The dining hall continues south.
 ~
@@ -1399,7 +1399,7 @@ eat this food to subsist.  You feel pity upon them as you watch them fill their
 stomachs with this sorry excuse for food.  The dining hall continues north and
 east.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 4
 D0
 The dining hall continues north.
 ~
@@ -1426,7 +1426,7 @@ eat this food to subsist.  You feel pity upon them as you watch them fill their
 stomachs with this sorry excuse for food.  The dining hall continues north and
 west.  The exit is to the east.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 4
 D0
 The dining hall continues north.
 ~
@@ -1458,7 +1458,7 @@ The food here is mass-produced and cheaply made.  After watching how they cook
 this food you are glad you do not normally eat at the cafeteria.  There is a
 door here.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D1
 The kitchen continues east.
 ~
@@ -1484,7 +1484,7 @@ A Storeroom~
 spam and other uninteresting stuff.  But wait!  They keep edible food here too!
 So that's what the staff eats!    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D0
 These stairs lead back to the door to the kitchen.
 ~
@@ -1510,7 +1510,7 @@ The food here is mass-produced and cheaply made.  After watching how they cook
 this food you are glad you do not normally eat at the cafeteria.  There is a
 door to the north.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D0
 The doorway leads back out of the kitchen.
 ~
@@ -1534,7 +1534,7 @@ S
 Stairway~
    As the title implies, there is a set of stairs here which lead up.    
 ~
-301 8 0 0 0 5
+301 8 0 0 0 2
 D2
 The main lobby is to the south.
 ~
@@ -1568,7 +1568,7 @@ Equipment Room~
    The equipment room houses various items used to work out and for sports.  
 There is a set of stairs here which lead down.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 2
 D3
 The Gym is to the west.
 ~
@@ -1585,7 +1585,7 @@ Locker Room~
    The fresh smell of sweat lingers in the locker rooms.  There is a set of
 stairs nearby.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 3
 D1
 A hallway branches off to the east.
 ~
@@ -1793,7 +1793,7 @@ boots trampling up and down it all day (and night).  The exit to the north is
 much less worn but the path to the south has been worn right down.  There is a
 small sign partway up the stairwell.    
 ~
-301 8 0 0 0 0
+301 8 0 0 0 1
 D0
 The Campus Bookstore is located to the north.
 ~
@@ -1964,7 +1964,7 @@ smells pretty bad, it wouldn't be a bad idea to remember where this is so that
 you can rest here later.  You find it rather difficult to manoeuvre in here
 because of the large number of drunks on the floor.  The only exit is north.  
 ~
-301 12 0 0 0 0
+301 12 0 0 0 4
 D0
 Back to the entrance...  out of the bad smells here...
 ~
@@ -1979,7 +1979,7 @@ towards the street whilst the north and west exits are too dark to see the ends
 of.  The stairs on the south side of the room lead up to the second floor and
 whatever might be up there...    
 ~
-301 9 0 0 0 0
+301 9 0 0 0 1
 D0
 You can't tell, it's too dark.
 ~
@@ -2017,7 +2017,7 @@ Hallway~
    This hallway is non-descript and has two exits.  The eastern exit seems to
 lead into a large room while the southern exit leads, well, south.    
 ~
-301 9 0 0 0 0
+301 9 0 0 0 1
 D1
 There seems to be a large room to the east.
 ~
@@ -2040,7 +2040,7 @@ Auditorium~
 only exit (west).  There are numerous seats arranged like a theatre would be.
 There is a large stage at the east end of the room.    
 ~
-301 9 0 0 0 0
+301 9 0 0 0 3
 D3
 The hallway you probably entered from is handily located to the west.
 ~
@@ -2071,7 +2071,7 @@ Hallway~
 Unfortunately, you can't see what the exits lead to.  Just before you finish
 looking, you notice a door to the north.    
 ~
-301 9 0 0 0 0
+301 9 0 0 0 1
 D0
 This seems to lead to a library.
 ~
@@ -2098,7 +2098,7 @@ The Back Exit~
 way to the west.  If you were to go east, though, you would not have a problem
 as the corridor seems to continue that way.    
 ~
-301 9 0 0 0 0
+301 9 0 0 0 1
 D1
 The hallway looks to continue in this direction.
 ~
@@ -2135,7 +2135,7 @@ Upper Lobby~
 south which leads down.  You can't see where the stairwell leads.  For that
 matter you can't see where any of the exits lead.    
 ~
-301 9 0 0 0 0
+301 9 0 0 0 1
 D0
 It's too dark to see.
 ~
@@ -2163,7 +2163,7 @@ A Classroom~
 tables, no nothing...  Wait, that would mean something is here, wouldn't it?  
 Alright, there is something, there is an exit to the west.    
 ~
-301 13 0 0 0 0
+301 13 0 0 0 1
 D3
 This leads back to the upper lobby.
 ~
@@ -2176,7 +2176,7 @@ A Classroom~
 tables, no nothing...  Ok, you caught me again, there is an exit to the east.
   
 ~
-301 13 0 0 0 0
+301 13 0 0 0 1
 D1
 This leads back to the upper lobby.
 ~
@@ -2188,7 +2188,7 @@ Hallway~
    This hallway has three conventional exits and a door.  East, south and west
 are conventional whilst the north wall holds a door.    
 ~
-301 9 0 0 0 5
+301 9 0 0 0 1
 D0
 This seems to be an office.
 ~
@@ -2215,7 +2215,7 @@ A Classroom~
    This classroom is completely deserted.  There are no desks, no chairs, no
 tables, no nothing...  Except the typical exit to the west of course.    
 ~
-301 13 0 0 0 0
+301 13 0 0 0 1
 D3
 This leads back to the hallway.
 ~
@@ -2228,7 +2228,7 @@ A Classroom~
 tables, no nothing...  Not even an exit to the north, good thing since the
 actual exit is to the east.    
 ~
-301 13 0 0 0 0
+301 13 0 0 0 1
 D1
 This leads back to the hallway.
 ~
@@ -2241,7 +2241,7 @@ Faculty Office~
 student trying to break in.  A huge desk has been toppled over and now rests
 against a wall.    
 ~
-301 9 0 0 0 0
+301 9 0 0 0 1
 D2
 This door leads to the hall.
 ~
@@ -2258,7 +2258,7 @@ Back Path~
 could be at the end of it.  To the north the path continues, to the east, a
 door graces the building next to you.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 4
 D0
 The pathway continues.
 ~
@@ -2282,7 +2282,7 @@ S
 A Pathway~
    The path continues north-south.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 4
 D0
 The path continues.
 ~
@@ -2303,7 +2303,7 @@ A Pathway~
    The pathway continues north-south.  To the north you can see a tall, thin
 structure sticking up from the ground.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 4
 D0
 The pathway continues.
 ~
@@ -2320,7 +2320,7 @@ Approach To The Greasepole~
    The path seems to be taking a direct route to the needle-like structure just
 to the north.  To the south the path continues.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 4
 D0
 The path begins to lead to a large pit.
 ~
@@ -2337,7 +2337,7 @@ The Greasepit~
    The tall, needle-like structure stands right in front of you.  There are two
 ways you can go: to the south on the path, or up the greasepole.    
 ~
-301 4 0 0 0 0
+301 4 0 0 0 4
 D2
 The path leads off to the south.
 ~

--- a/lib/world/wld/302.wld
+++ b/lib/world/wld/302.wld
@@ -2,7 +2,7 @@
 The Top Of The Greasepole~
    You've made it to the top!  All you have to do now is get down...    
 ~
-302 4 0 0 0 0
+302 4 0 0 0 5
 D5
 It's a long slide down.
 ~
@@ -61,7 +61,7 @@ Reception Desk~
 to see the incoming mail behind the desk as well as hooks for keys to hang
 upon.  To the east there is a door and just south of you is the lobby.    
 ~
-302 136 0 0 0 0
+302 136 0 0 0 1
 D1
 ~
 door~
@@ -85,7 +85,7 @@ Main Office~
 a desk, chair and filing cabinet in the room.  There is only one exit from the
 room, west.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D3
 This way leads back to the reception desk.
 ~
@@ -114,7 +114,7 @@ Lobby~
 that you can find it again.  Just to make it easy to rediscover, exits have
 been handily located to both the east and west.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 4
 D1
 This leads to a handy stairwell.
 ~
@@ -130,7 +130,7 @@ S
 Stairwell~
    This is, as it says, a stairwell.  The exits are west and up.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 4
 D3
 This leads to the lobby.
 ~
@@ -146,7 +146,7 @@ S
 Stairwell~
    This is another stairwell.  The exits are west, up, and down.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 4
 D3
 You can't tell where this leads.
 ~
@@ -168,7 +168,7 @@ Landing~
    This is a landing with halls heading off in all the cardinal directions.  
 The only problem is that, the hall to the west is blocked by a door.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 You can't tell where this leads.
 ~
@@ -196,7 +196,7 @@ Broom Closet~
 nothing, not even brooms.  And there is no other exit to boot, just the one you
 came in!    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 You can't tell where this leads.
 ~
@@ -208,7 +208,7 @@ Hallway~
    The hall continues north-south and there is a doorway on either side of the
 hall.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 You can't tell where this leads.
 ~
@@ -245,7 +245,7 @@ Private Room 205~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D3
 This leads back to the hall.
 ~
@@ -262,7 +262,7 @@ Private Room 206~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 This leads back to the hall.
 ~
@@ -278,7 +278,7 @@ Hallway~
    The hall leads to the south and there is a doorway on either side of the
 hall as well as one to the north.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 You can't tell where this leads.
 ~
@@ -316,7 +316,7 @@ Private Room 203~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D3
 This leads back to the hall.
 ~
@@ -333,7 +333,7 @@ Private Room 204~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 This leads back to the hall.
 ~
@@ -350,7 +350,7 @@ Private Room 201~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D2
 This leads back to the hall.
 ~
@@ -366,7 +366,7 @@ Hallway~
    The hall continues north-south and there is a doorway on either side of the
 hall.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 You can't tell where this leads.
 ~
@@ -403,7 +403,7 @@ Private Room 207~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D3
 This leads back to the hall.
 ~
@@ -420,7 +420,7 @@ Private Room 208~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 This leads back to the hall.
 ~
@@ -436,7 +436,7 @@ Hallway~
    The hall leads to the north and there is a doorway on either side of the
 hall as well as one to the south.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 You can't tell where this leads.
 ~
@@ -474,7 +474,7 @@ Private Room 209~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D3
 This leads back to the hall.
 ~
@@ -491,7 +491,7 @@ Private Room 210~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 This leads back to the hall.
 ~
@@ -508,7 +508,7 @@ Private Room 202~
 The floor is tiled, while the hallways are carpeted.  I wonder why?  There is
 only one exit...  The one you came in...    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 This leads back to the hall.
 ~
@@ -523,7 +523,7 @@ S
 Stairwell~
    This is another stairwell.  The exits are west, up, and down.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 4
 D3
 You can't tell where this leads.
 ~
@@ -545,7 +545,7 @@ Landing~
    This is a landing with halls heading off in all the cardinal directions.  
 The only problem is that, the hall to the west is blocked by a door.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 You can't tell where this leads.
 ~
@@ -573,7 +573,7 @@ Broom Closet~
 nothing, not even brooms.  And to boot there is no other exit, just the one you
 came in!    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 You can't tell where this leads.
 ~
@@ -586,7 +586,7 @@ Hallway~
 to the north.  Coincidentally, there are also doors to the east and west.  The
 only exit without a door in fact is to the south!    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 The door is locked, so therefore you cannot see through it.
 ~
@@ -617,7 +617,7 @@ Private Room 301~
    This room is quite well furnished and could probably comfortably house two
 people.  It is much larger than the rooms downstairs.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D3
 The door leads back into the hallway.
 ~
@@ -629,7 +629,7 @@ Private Room 302~
    This room is quite well furnished and could probably comfortably house two
 people.  It is much larger than the rooms downstairs.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 The door leads back into the hallway.
 ~
@@ -642,7 +642,7 @@ Main Residence Office~
 North XXX.  There is a large desk here as well as two plush chairs.  In the
 north-west corner of the room there is a trapdoor in the ceiling.    
 ~
-302 13 0 0 0 0
+302 13 0 0 0 2
 D2
 The door leads to the hallway.
 ~
@@ -669,7 +669,7 @@ Hallway~
 to the south.  Coincidentally, there are also doors to the east and west.  The
 only exit without a door in fact is to the north!    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 The hallway continues to the north.
 ~
@@ -700,7 +700,7 @@ Private Room 304~
    This room is quite well furnished and could probably comfortably house two
 people.  It is much larger than the rooms downstairs.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 The door leads back into the hallway.
 ~
@@ -712,7 +712,7 @@ Private Room 303~
    This room is quite well furnished and could probably comfortably house two
 people.  It is much larger than the rooms downstairs.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D3
 The door leads back into the hallway.
 ~
@@ -724,7 +724,7 @@ Private Room 300~
    This room is quite well furnished and could probably comfortably house two
 people.  It is much larger than the rooms downstairs.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 The door leads back into the hallway.
 ~
@@ -736,7 +736,7 @@ Attic~
    This attic is carefully hidden away from sight as it is used as a secret
 storeroom.  The only exit is down.    
 ~
-302 13 0 0 0 0
+302 13 0 0 0 4
 D2
 You see nothing special.
 ~
@@ -758,7 +758,7 @@ Small Storage Room~
 exits from it.  The main exit is through the grate to the north but there is a
 chute down to the first floor located in the floor.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 3
 D0
 The attic is just north of here.
 ~
@@ -799,7 +799,7 @@ The Ghetto~
 small obstacle...  An overturned policemobile.  There are houses on either side
 of the road.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 4
 D0
 To escape the ghetto, you can head this way.
 ~
@@ -824,7 +824,7 @@ S
 Ghetto House~
    It's a mess.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 5
 D3
 An exit from this hellhole.
 ~
@@ -839,7 +839,7 @@ S
 Frec House~
    You feel a little apprehensive as you enter this house...  It's a mess.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 5
 D1
 An exit from this hellhole.
 ~
@@ -859,7 +859,7 @@ S
 Ghetto House~
    It looks like a hellhole...  It's a mess.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 5
 D0
 An exit from this hellhole to yet another hellhole.
 ~
@@ -885,7 +885,7 @@ The Ghetto~
 small obstacle...  An overturned policemobile.  There is a house to the west.
   
 ~
-302 1 0 0 0 0
+302 1 0 0 0 4
 D2
 The ghetto continues south.
 ~
@@ -910,7 +910,7 @@ The Ghetto Intersection~
    This intersection is the joining point of what's left of University Avenue
 and Earl Road which heads off to the east.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 4
 D0
 The ghetto continues north.
 ~
@@ -941,7 +941,7 @@ The Ghetto~
    This part of the ghetto has survived in a better condition than the rest of
 the ghetto.  A house lies to the north.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 3
 D0
 A fairly well-kept house is north.
 ~
@@ -967,7 +967,7 @@ The Ghetto~
    Earl Road ends abruptly as there is a house built immediately to the east.
 Another stands to the south.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 3
 D1
 A very well-kept house is east.
 ~
@@ -992,7 +992,7 @@ S
 Gael House~
    This house reminds you of home, your parent's home.  It's mind-boggling.  
 ~
-302 8 0 0 0 0
+302 8 0 0 0 3
 D3
 You may exit to the west.
 ~
@@ -1003,7 +1003,7 @@ S
 Gael House~
    This house reminds you of home, your aunt's home.  Now, that's absurd.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 3
 D0
 You may exit to the north.
 ~
@@ -1015,7 +1015,7 @@ Boss House~
    Papers and calculators litter the room, making an otherwise neat house,
 messy.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 4
 D2
 You may exit to the south.
 ~
@@ -1032,7 +1032,7 @@ The Ghetto~
    This part of the ghetto seems to have survived.  To the west, you can see,
 behind the rubble, the vague outlines of a house.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 3
 D0
 The ghetto continues north.
 ~
@@ -1053,7 +1053,7 @@ The Ghetto~
    This part of the ghetto seems to have survived.  To the east, you can see
 the A & Z Supermarket.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 3
 D0
 The ghetto continues north.
 ~
@@ -1079,7 +1079,7 @@ The Ghetto~
    This part of the ghetto seems to have survived.  There are houses on either
 side of the road.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 3
 D0
 The ghetto continues north.
 ~
@@ -1110,7 +1110,7 @@ The Ghetto~
    This part of the ghetto seems to have survived.  There is a house to the
 east.  South of you, you can see the end of the ghetto.    
 ~
-302 1 0 0 0 0
+302 1 0 0 0 4
 D0
 The ghetto continues north.
 ~
@@ -1136,7 +1136,7 @@ The A & Z Supermarket~
    Aisles and aisles of foodstuffs are waiting to be bought by unknowing
 customers.    
 ~
-302 140 0 0 0 0
+302 140 0 0 0 2
 D3
 The automatic doors hide the ghetto.
 ~
@@ -1152,7 +1152,7 @@ Frec House~
    This house reminds you of your room, only worse.  It seems to be a
 post-holocaust version of it.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 5
 D3
 You will exit to the west.
 ~
@@ -1164,7 +1164,7 @@ Boss House~
    Papers and calculators litter the room, making an otherwise neat house,
 messy.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 4
 D1
 You may exit to the east.
 ~
@@ -1180,7 +1180,7 @@ S
 Gael House~
    This house reminds you of home, your grandma's home.  It's insane.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 3
 D3
 You may exit to the west.
 ~
@@ -1192,7 +1192,7 @@ Boss House~
    Papers and calculators litter the room, making an otherwise neat house,
 messy.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 4
 D1
 You may exit to the east.
 ~
@@ -1214,7 +1214,7 @@ Frec House~
    This house reminds you of your room, only worse.  It seems to be a
 post-holocaust version of it.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 5
 D0
 You will exit to the north.  Even if it is to another ghetto house.
 ~
@@ -1226,7 +1226,7 @@ Stairwell~
    A spiralling stairwell leads both up and down.  To the east, there is an
 exit to the auditorium.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 2
 D1
 As I said, there is an exit to the auditorium.
 ~
@@ -1337,7 +1337,7 @@ painstaking writing of descriptions, if they aren't going to be read?  You
 probably aren't even reading this!  [Editorial :)] Well, anyways, the only exit
 is to the north.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D0
 The auditorium is to the north.
 ~
@@ -1361,7 +1361,7 @@ Upper Stairwell~
    The stairwell spirals upwards and downwards.  The balcony lies to the east.
   
 ~
-302 8 0 0 0 0
+302 8 0 0 0 2
 D1
 As I said, the balcony lies to the east.
 ~
@@ -1418,7 +1418,7 @@ of the Grant Hall clock tower.  You can see lots of little gears connected to
 lots of big gears.  There is absolutely no view seeing that the clock faces are
 opaque.  But, there is an exit that you can use by going down.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 3
 D5
 This leads back into the stairwell.
 ~
@@ -1431,7 +1431,7 @@ Hallway~
 Unfortunately, the building seems to be living up to its name.  The hallway
 leads east-west with a room to the north and a door to the south.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D0
 There is a fairly large room to the north.
 ~
@@ -1462,7 +1462,7 @@ Hallway~
    The hallway continues along here.  In fact it continues both east and west.
 There is however a door to the south.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D1
 The hallway continues.
 ~
@@ -1491,7 +1491,7 @@ Hallway~
 door to the north and stairs leading down, but otherwise this section of the
 hall is no different than the rest.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D0
 A door with the word "OFFICE" emblazoned on it stands to your north.
 ~
@@ -1523,7 +1523,7 @@ that I have to actually get up early after a nice relaxing weekend, but you are
 probably in situation like this, and if you aren't, boy do I ever envy you.  
 Anyways, there is a door to the north.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 2
 D0
 A large, steel door stands to the north.
 ~
@@ -1544,7 +1544,7 @@ technological marvels.  This lab is devoid of personnel but all of the machines
 are making scary humming noises.  You should probably make a beeline out the
 door to the north.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 2
 D0
 A door stands to the north.  This door is made of steel and is fairly
 large.
@@ -1564,7 +1564,7 @@ row coming from below and if you don't mind breezes coming through the large
 gaps in the wall.  Other than that, it does look alright.  There is one exit,
 the one to the south, which just happens to be blocked by a door.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D2
 The door blocking your way is well made.  It seems to be made of Oak with a
 well designed brass doorknob.
@@ -1585,7 +1585,7 @@ however, you have passed through one or two labs on the way, the reason is even
 more obvious, as this room contains all sorts of nice computer equipment.  
 There is a staircase leading up is one corner of the room.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D4
 The staircase in the north-east corner leads up towards the main floor
 of the building.
@@ -1600,7 +1600,7 @@ Of course, you don't expect anything less, this being a university, but I
 presume that you agree with me that enough is enough.  There is a hallway to
 the south.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 1
 D2
 The hallway lies to the south.
 ~
@@ -1611,7 +1611,7 @@ S
 A Hallway~
    This hallway leads through the building in all cardinal directions.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 It is too dark to tell.
 ~
@@ -1642,7 +1642,7 @@ S
 A Hallway~
    This hallway leads through the building in most directions.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 It is too dark to tell.
 ~
@@ -1663,7 +1663,7 @@ S
 A Hallway~
    This hallway leads through the building in most directions.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 It is too dark to tell.
 ~
@@ -1689,7 +1689,7 @@ S
 A Hallway~
    This hallway leads through the building in most directions.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 It is too dark to tell.
 ~
@@ -1715,7 +1715,7 @@ S
 A Hallway~
    This hallway leads through the building in most directions.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 It is too dark to tell.
 ~
@@ -1741,7 +1741,7 @@ S
 A Hallway~
    This hallway leads through the building in most directions.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 It is too dark to tell.
 ~
@@ -1768,7 +1768,7 @@ A Classroom~
    This room suddenly dispels the monotony of the halls you were just passing
 through.  
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D0
 It is too dark to tell.
 ~
@@ -1811,7 +1811,7 @@ A Classroom~
    This room suddenly dispels the monotony of the halls you were just passing
 through.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D1
 It is too dark to tell.
 ~
@@ -1838,7 +1838,7 @@ A Hallway~
 two exits.  One exits to the east towards light, while the other heads west
 back into the darkness.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D1
 This way draws you towards it...probably because you are suffering from
 light withdrawl.
@@ -1863,7 +1863,7 @@ S
 The Exit~
    This long corridor leads out onto the street.    
 ~
-302 8 0 0 0 0
+302 8 0 0 0 5
 D1
 The light beckons you.
 ~
@@ -2165,7 +2165,7 @@ reminds you of movie theatres of old (like when they sat more than 10).  Its
 main purpose seems to exist and collect dust.  Maybe someone is doing some kind
 of study here.  There is a sign on the east wall near the front of the room.  
 ~
-302 9 0 0 0 0
+302 9 0 0 0 3
 D1
 This leads towards the street.
 ~
@@ -2182,7 +2182,7 @@ A Completely Empty Hallway~
    This hallway is not completely empty but looks like it is.  Must be
 something related to the Infinite Improbability Principle.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 3
 D0
 There is a classroom to the north.
 ~
@@ -2204,7 +2204,7 @@ Classroom~
 looked larger on the outside.  Obviously some sort of principle related to the
 TARDIS principle on Doctor Who....    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D2
 A hallway leads off to the south.
 ~
@@ -2220,7 +2220,7 @@ S
 East Stairwell~
    This stairwell leads up into the heights of Leonard Hall.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 3
 D3
 This leads back to the lobby.
 ~
@@ -2236,7 +2236,7 @@ S
 West Stairwell~
    This leads up into the heights of Leonard Hall.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 3
 D1
 This leads back to the lobby.
 ~
@@ -2253,7 +2253,7 @@ Junction~
    This hallway leads north and south and there is a stairwell leading down in
 the place where the western wall should be found.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 The hallway continues north.
 ~
@@ -2274,7 +2274,7 @@ S
 Hallway~
    The hallway turns east-south here and there is an opening to the north.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 There is a room of sorts to the north.
 ~
@@ -2297,7 +2297,7 @@ Dorm Room~
 consists of a bed, and a desk.  Nothing else.  Just a bed and a desk.  But
 there is an exit to the south.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 1
 D2
 The hallway is south of here.
 ~
@@ -2313,7 +2313,7 @@ Hallway~
    This hallway comes to an abrupt end here.  However, there are exits in all
 cardinal directions except up and down.    
 ~
-302 9 0 0 0 0
+302 9 0 0 0 2
 D0
 There seems to be a room to the north.
 ~

--- a/lib/world/wld/303.wld
+++ b/lib/world/wld/303.wld
@@ -4,7 +4,7 @@ Dorm Room~
 in this room as any other dorm room, a desk, bed, and exit...  This time to the
 south.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D2
 The hallway lies to the south.
 ~
@@ -37,7 +37,7 @@ water bottle structure similar to the ones used in modern day hamster and
 gerbil cages.  The only exit is to the west.  Just as you finish looking
 around, your eye spots a SEP.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 4
 D3
 Thank Bob, the hallway is still to the west of here.
 ~
@@ -62,7 +62,7 @@ Hallway~
 there is a room to the south and a door to the east.  The hallway grinds to a
 start when you move northwards though.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D0
 The hallway starts here and runs northwards.  You'd better catch it before
 it gets away.  *Groan*
@@ -100,7 +100,7 @@ would say that they don't have that item.  The logistics just don't work on
 these magnitudes, with more rooms maybe, but definitely not one room.  There is
 an exit to the north.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D0
 This leads back to the hallway out of this stupidity.
 ~
@@ -119,7 +119,7 @@ below you though...  About 60 feet below you that is.  If you go north, you can
 escape back to the real world (the balcony at least, just type exit to see
 where you end up if you go down).    
 ~
-303 0 0 0 0 0
+303 0 0 0 0 4
 D0
 The salvation of the balcony is directly to the north.  All it needs is for
 you to press N and then RETURN.
@@ -155,7 +155,7 @@ Really Narrow Stairwell, Part I~
    This stairwell is just wide enough for one person at a time.  A door lies to
 the west.
 ~
-303 13 0 0 0 0
+303 13 0 0 0 5
 D3
 This is blocked by a door.  Unless you opened it already, which is pretty
 likely.
@@ -173,7 +173,7 @@ S
 Really Narrow Stairwell, Part II~
    The Stairwell's Revenge.  Now there is an exit to the west and one down.  
 ~
-303 13 0 0 0 0
+303 13 0 0 0 5
 D3
 This leads to a nice entrance hall.
 ~
@@ -195,7 +195,7 @@ Entry Hall~
 mudroom.  That is, you remove the mud from your footwear here.  The hall
 continues to the west into a nice, clean room and to the east to a stairwell.
 ~
-303 9 0 0 0 0
+303 9 0 0 0 3
 D1
 The dreaded stairwell is here.
 ~
@@ -219,7 +219,7 @@ furnishing the room, such as a rocking chair, a coffee table, and a couch.
 All of the furnishings are decorated in a somewhat flowery style.  You can
 leave this room by going east to the entrance hall or south to the bedroom.  
 ~
-303 8 0 0 0 0
+303 8 0 0 0 2
 D1
 The entrance hall is directly to the east.
 ~
@@ -248,7 +248,7 @@ Bedroom~
 bedroom furnishings here, a bed (obviously), a night-table, and a dresser.  
 There are exits to the north and to the balcony to the east.    
 ~
-303 8 0 0 0 0
+303 8 0 0 0 2
 D0
 The living room is to the north.
 ~
@@ -283,7 +283,7 @@ does not resemble the real countryside, so you aren't sure what you are seeing
 exactly.  Must be an illusion.  Anyways, there is an exit back to the bedroom
 in the west wall.    
 ~
-303 4 0 0 0 0
+303 4 0 0 0 2
 D2
 This leads to a thin ledge.
 ~
@@ -316,7 +316,7 @@ Hallway Junction~
    This hallway leads north and south and there is a stairwell in the east
 wall.  There is a sign on the wall.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D0
 The hallway continues north.
 ~
@@ -344,7 +344,7 @@ S
 Hallway~
    The hallway turns west-south here and there is an opening to the north.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D0
 There is a room to the north.
 ~
@@ -369,7 +369,7 @@ room, you can see a large collection of CDs and Cassettes...  Exam time must be
 coming up soon.  On the east wall sits a large computer with lots of neat
 accessories.  The only exit is to the south.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D2
 The hallway leads away from here to the south.
 ~
@@ -396,7 +396,7 @@ Hallway~
    This hallway leads east and has an opening to the north and one to the west
 and one to the south.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D0
 Bubbles seem to be coming from the northern entrance.
 ~
@@ -424,7 +424,7 @@ Bubble Land~
 There is only one exit...  To the south (you think).  With all the bubbles you
 can't see anything else in the room.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 5
 D2
 You think the hallway lies to the south.
 ~
@@ -444,7 +444,7 @@ the fact that other than that the room is completely empty of furniture, but
 wait, that pizza box in the corner seems to be acting as a table of sorts with
 all the newspapers supporting it.  There is an exit to the east.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D1
 The hallway extends to the east.
 ~
@@ -477,7 +477,7 @@ this room at least).  There are posters of John all over the walls as well as a
 few of the other Beatles...  Wait you don't see any of Paul...  Strange.  
 There is only one exit, the one to the north.    
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D0
 The hallway is directly to your north.
 ~
@@ -501,7 +501,7 @@ room in a residence is decorated, with a fridge, stove and of course a TV.
 Unfortunately, there does not seem to be any couches or chairs in the room.  
 There is an exit to the north and a door on the east wall with no doorknob.  
 ~
-303 9 0 0 0 0
+303 9 0 0 0 2
 D0
 The hallway leads to the north.
 ~
@@ -534,7 +534,7 @@ Hallway~
 the west and east.  The sound of snoring denotes a lecture hall to the south.
   
 ~
-303 8 0 0 0 0
+303 8 0 0 0 2
 D1
 The hallway continues east.
 ~
@@ -561,7 +561,7 @@ Hallway~
 the west and east.  The sound of snoring denotes a lecture hall to the south.
   
 ~
-303 8 0 0 0 0
+303 8 0 0 0 2
 D1
 The hallway continues east.
 ~
@@ -587,7 +587,7 @@ Hallway~
    The hallway curves around slightly so that you can't quite see what is to
 the west and east.  There is an extraneous exit to the north.    
 ~
-303 8 0 0 0 0
+303 8 0 0 0 2
 D0
 To the north you see... the centre of the building?
 ~
@@ -613,7 +613,7 @@ Hallway~
    The hallway curves around slightly so that you can't quite see what is to
 the est and east.  The sound of snoring denotes a lecture hall to the south.  
 ~
-303 8 0 0 0 0
+303 8 0 0 0 2
 D1
 The hallway continues east.
 ~
@@ -640,7 +640,7 @@ Hallway~
 the west and east.  The sound of snoring denotes a lecture hall to the south.
   
 ~
-303 8 0 0 0 0
+303 8 0 0 0 2
 D1
 The hallway continues east.
 ~
@@ -666,7 +666,7 @@ An Odd Circular Room~
    A small circular room sits in the centre of the building.  There are exits
 to the north and south.    
 ~
-303 8 0 0 0 0
+303 8 0 0 0 1
 D0
 The entrance can been seen to the north.
 ~
@@ -773,7 +773,7 @@ conveyer belt under your feet, and you can see glinting objects ahead, and the
 way back east seems to have disappeared.  The pictures on the walls make you
 feel extremely comfortable.    
 ~
-303 13 0 0 0 0
+303 13 0 0 0 1
 D1
 There isn't an exit in this direction, so don't even bother trying to
 go this way.

--- a/lib/world/wld/304.wld
+++ b/lib/world/wld/304.wld
@@ -30,7 +30,7 @@ causing the ripe ends of the grass stalks to bob lazily back and forth.  To the
 north you spy what appears to be some sort of temple, its great white walls
 blazing with the light of the sun.    
 ~
-304 4 0 0 0 0
+304 4 0 0 0 2
 D0
 You see the entrance to the temple.
 ~
@@ -47,7 +47,7 @@ Before the Temple~
 columns are spaced evenly around the perimeter of the temple, and an arch
 beckons you inside.  
 ~
-304 4 0 0 0 0
+304 4 0 0 0 2
 D0
 There is an arch to the north.
 ~
@@ -166,7 +166,7 @@ The Atrium and Gardens~
 catch the sun's rays coming in from the open sky.  The smell of rich dark earth
 overwhelms your senses, and a small brook winds beneath your feet.    
 ~
-304 0 0 0 0 0
+304 0 0 0 0 2
 D0
 You see a room in the temple.
 ~
@@ -463,7 +463,7 @@ The Balcony~
    You sense that you have reached journey's end.  The balcony overlooks a
 great grassy field.  The sun's rays blind you, and you hear a snort.    
 ~
-304 0 0 0 0 0
+304 0 0 0 0 1
 D0
 You see the Bull's Chamber.
 ~

--- a/lib/world/wld/306.wld
+++ b/lib/world/wld/306.wld
@@ -1367,7 +1367,7 @@ Out on a Limb~
 glancing up higher it is seen that there is still more height to be attained.
 The only direction to travel is back along a branch to the east.    
 ~
-306 0 0 0 0 0
+306 0 0 0 0 3
 D1
 ~
 ~

--- a/lib/world/wld/31.wld
+++ b/lib/world/wld/31.wld
@@ -4,7 +4,7 @@ The Northwest End Of The Concourse~
 goes east, and the bridge is just north of here.  The concourse continues
 south along the city wall.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 You see the Bridge.
 ~
@@ -27,7 +27,7 @@ The Promenade~
 continues further east and to the west you see the city wall.  Park Road
 leads south from here.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 The promenade continues.
 ~
@@ -50,7 +50,7 @@ The Promenade~
 continues both east and west.  South of here you see the entrance to
 the park, and a small building seems to be just west of the entrance.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 You see the promenade.
 ~
@@ -73,7 +73,7 @@ The Promenade~
 continues both east and west.  A small path leads south.  Looking across
 the river you see the levee.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 You see the Concourse.
 ~
@@ -97,7 +97,7 @@ promenade goes west.  Looking across the river you see a building that
 resembles a warehouse.  The Concourse continues south along the city
 wall.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D2
 The Concourse continues south.
 ~
@@ -120,7 +120,7 @@ The Park Entrance~
 the promenade and a small path leads south into the park.  To your east is
 the famous Park Cafe.
 ~
-31 4 0 0 0 0
+31 4 0 0 0 1
 D0
 You see the promenade.
 ~
@@ -155,7 +155,7 @@ A Small Path In The Park~
    You are walking along a small path through the park.  The path continues
 south and east.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 ~
 ~
@@ -171,7 +171,7 @@ A Small Path In The Park~
 just north of here, and Park Cafe is just east of the entrance.  The path
 leads further east and west.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 You see the northern park entrance.
 ~
@@ -191,7 +191,7 @@ A Small Path In The Park~
    You are on a small path running through the park.  It continues west and
 south and just north of here you see the southern wall of Park Cafe.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D2
 ~
 ~
@@ -217,7 +217,7 @@ Park Road~
    The road continues north and south.  A building is just west of here, you
 notice a sign on the door.  The park entrance is to the east.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -250,7 +250,7 @@ The Western Park Entrance~
    You are standing at the western end of the park.  A small path leads east
 into the park and going west through the entrance you will reach Park Road.
 ~
-31 4 0 0 0 0
+31 4 0 0 0 1
 D1
 ~
 ~
@@ -265,7 +265,7 @@ A Path In The Park~
    You are in the park.  The paths lead north and west.  Westward is the
 park entrance and to the east you see a small pond.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -301,7 +301,7 @@ A Path In The Park~
    You are in the park.  The paths lead north and east.  Eastward is the
 park entrance and to the west you see a small pond.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -321,7 +321,7 @@ The Eastern Park Entrance~
 into the park.  Going east through the entrance you will reach Emerald
 Avenue.
 ~
-31 4 0 0 0 0
+31 4 0 0 0 1
 D1
 ~
 ~
@@ -337,7 +337,7 @@ Emerald Avenue~
 promenade and to the west is the park entrance.  To the east is the not very
 big Town Hall of Midgaard.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -359,7 +359,7 @@ S
 Park Road~
    You are on Park Road which leads north and south.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -374,7 +374,7 @@ Emerald Avenue~
    You are standing at a bend on Emerald Avenue.  The road leads north and
 west.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -392,7 +392,7 @@ at the center of the road cross.  Its other end leads directly upwards towards
 the sky.
 A road sign is here.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -435,7 +435,7 @@ Emerald Avenue~
    You are standing at a bend on Emerald Avenue.  The road leads south and
 east.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 ~
 ~
@@ -450,7 +450,7 @@ Park Road~
    You are on Park Road which leads south and north.  Elm Street is east of
 here.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -469,7 +469,7 @@ Elm Street~
    You are on Elm street.  Park Road is to the west and Elm Street continues
 in eastward direction.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 ~
 ~
@@ -483,7 +483,7 @@ S
 The End Of Elm Street~
    You are at the end of Elm Street.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D3
 ~
 ~
@@ -494,7 +494,7 @@ Emerald Avenue~
    You are on Emerald Avenue which continues north.  The Concourse is south
 of here.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -509,7 +509,7 @@ Park Road~
    You are on Park Road which continues north.  The Concourse is south of
 here.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -524,7 +524,7 @@ On The Concourse~
    You are at the southwest corner of the city wall.  The Concourse leads
 both north and east.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -544,7 +544,7 @@ On The Concourse~
    The Concourse continues both east and west.  Emerald Avenue is north of
 here.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -563,7 +563,7 @@ On The Concourse~
    The Concourse continues both east and west.  Park Road is north of here
 and an iron grate leads south to the graveyard.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -587,7 +587,7 @@ On The Concourse~
    You are at the southeast corner of the city wall.  The Concourse leads
 both north and west.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -601,7 +601,7 @@ S
 Park Road~
    You are at Park Road which continues north and south.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -616,7 +616,7 @@ Emerald Avenue~
    You are at Emerald Avenue which continues north and south.  Penny Lane leads
 east from here.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -635,7 +635,7 @@ Emerald Avenue~
    You are standing at a bend on Emerald Avenue.  To the east the road goes on
 and to the south is the Road Crossing.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 ~
 ~
@@ -650,7 +650,7 @@ Emerald Avenue~
    You are standing at a bend on Emerald Avenue.  To the west the road goes on
 and to the north is the Road Crossing.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -665,7 +665,7 @@ Park Road~
    You are at a bend on Park Road.  To the north the road goes on and to the
 east is the Road Crossing.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -680,7 +680,7 @@ Park Road~
    You are at a bend on Park Road.  To the south the road goes on and to the
 west is the Road Crossing.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D2
 ~
 ~
@@ -753,7 +753,7 @@ Penny Lane~
    You are on Penny Lane.  Emerald Avenue is to the west and Penny Lane
 continues in eastward direction.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D1
 ~
 ~
@@ -767,7 +767,7 @@ S
 Penny Lane~
    You are on Penny Lane.  The narrow road continues north and west.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 ~
 ~
@@ -781,7 +781,7 @@ S
 The End Of Penny Lane~
    You are at the end of Penny Lane.  The only exit appears to be south.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D2
 ~
 ~
@@ -793,7 +793,7 @@ A Gravel Road In The Graveyard~
 graveyard.  On both sides of the road grow dark evergreen trees.  An iron
 grate is to the north.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 2
 D0
 Through the solid iron bars you see the Concourse.
 ~
@@ -810,7 +810,7 @@ A Gravel Road In The Graveyard~
    You are on a well-kept gravel road that leads north-south through the
 graveyard.  On both sides of the road grow dark evergreen trees.  
 ~
-31 0 0 0 0 0
+31 0 0 0 0 2
 D0
 The gravel road continues northwards.
 ~
@@ -827,7 +827,7 @@ A Gravel Road In The Graveyard~
    You are on a well-kept gravel road that leads north-south through the
 graveyard.  On both sides of the road grow dark evergreen trees.  
 ~
-31 0 0 0 0 0
+31 0 0 0 0 2
 D0
 The gravel road continues northwards.
 ~
@@ -844,7 +844,7 @@ A Gravel Road In The Graveyard~
    You are on a well-kept gravel road that leads north-south through the
 graveyard.  On both sides of the road grow dark evergreen trees.  
 ~
-31 0 0 0 0 0
+31 0 0 0 0 1
 D0
 The gravel road continues northwards.
 ~
@@ -862,7 +862,7 @@ In Front Of The Chapel~
    You are on an open space before a small chapel.  A gravel road leads north
 through the graveyard and the chapel entrance is to the south.
 ~
-31 0 0 0 0 0
+31 0 0 0 0 2
 D0
 The gravel road continues northwards.
 ~

--- a/lib/world/wld/310.wld
+++ b/lib/world/wld/310.wld
@@ -40,7 +40,7 @@ and sunlight surrounds you.  The air is filled with the sound of chirping birds
 happily building their nests in the depths of the knotted grass.  A wagon trail
 runs in an east-south direction.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D3
 ~
 ~
@@ -54,7 +54,7 @@ strangely enough it is still quite pleasant out.  Crickets chirp merrily, and
 the sun's rays warm your skin.  The wagon trail leads eastwards back into the
 grassland, and dissapears westwards into the forest.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D1
 ~
 ~
@@ -73,7 +73,7 @@ wider here, showing signs of recent heavy use.  The wagon trail runs from west
 to east here, and it looks possible to venture into the forest to the north and
 south.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -95,7 +95,7 @@ S
 The Forest of Graye~
    You in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D2
 ~
 ~
@@ -109,7 +109,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -127,7 +127,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -145,7 +145,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -161,7 +161,7 @@ The Forest of Graye~
 sheer cliff face to the west, rising up above the forest.  There is a sign
 nailed neatly on the cliff wall.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D1
 ~
 ~
@@ -194,7 +194,7 @@ The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.  There is a
 sheer cliff face to the west, rising above the forest.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -217,7 +217,7 @@ The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.  The wagon trail
 ends abruptly here.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -239,7 +239,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -261,7 +261,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -276,7 +276,7 @@ The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.  There is a
 sheer cliff face to the north, rising above the forest.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D1
 ~
 ~
@@ -298,7 +298,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -320,7 +320,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -339,7 +339,7 @@ The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.  There is a
 cliff face to the north.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D1
 ~
 ~
@@ -362,7 +362,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -380,7 +380,7 @@ S
 The Forest of Graye~
    You are in a hardwood forest, walking through noisy leaves.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 3
 D0
 ~
 ~
@@ -396,7 +396,7 @@ The Cliff Wall~
 Sweat stings your eyes, and your breathing becomes ragged.  You can still drop
 safely to the forest floor, or madly continue upwards.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 5
 D4
 ~
 ~
@@ -412,7 +412,7 @@ The Overhang~
 be a nice place to stop an rest..  If you weren't underneath it.  You glance
 around for an alternate path..    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 5
 D1
 ~
 ~
@@ -430,7 +430,7 @@ desperately to the rock face with your other hand.  Returning back west is out
 of the question, but you might be able to pull yourself upwards onto a very
 thin ledge.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 5
 D4
 ~
 ~
@@ -493,7 +493,7 @@ moments just turning around, taking in all that you see.  To the south and east
 you see the forest sweeping outwards from the cliff wall, and to the north you
 see a clearing surrounding a small town.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D0
 ~
 ~
@@ -508,7 +508,7 @@ The Clearing~
    You are in a wide clearing between the city walls and the forest.  You see
 men atop the walls pointing at you and gesturing frantically.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D0
 ~
 ~
@@ -527,7 +527,7 @@ The Clearing~
    You are in a wide clearing between the city walls and the forest.  You see
 men atop the walls pointing at you and gesturing frantically.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D0
 ~
 ~
@@ -550,7 +550,7 @@ The Clearing~
    You are in a wide clearing between the city walls and the forest.  You see
 men atop the walls pointing at you and gesturing frantically.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D0
 ~
 ~
@@ -569,7 +569,7 @@ The Clearing~
    You are in a wide clearing between the city walls and the forest.  You see
 men atop the walls pointing at you and gesturing frantically.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D2
 ~
 ~
@@ -584,7 +584,7 @@ Entrance to the City of Graye~
    You are standing before the great gate of Graye.  Crimson plumed soldiers
 raise the portcullis and urge you the enter quickly.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D0
 Looks like safety.~
 ~
@@ -595,7 +595,7 @@ The Clearing~
    You are in a wide clearing between the city walls and the forest.  You see
 men atop the walls pointing at you and gesturing frantically.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 2
 D1
 The forest look VERY dark.~
 ~
@@ -610,7 +610,7 @@ The Demon's Wood~
    You find yourself among the twisted, gnarled trunks of giant thorn trees.  
 Mist covers the forest floor and everything is completely silent.    
 ~
-310 1 0 0 0 0
+310 1 0 0 0 3
 D0
 ~
 ~
@@ -625,7 +625,7 @@ The Demon's Wood~
    You find yourself among the twisted, gnarled trunks of giant thorn trees.  
 Mist covers the forest floor and everything is completely silent.    
 ~
-310 1 0 0 0 0
+310 1 0 0 0 3
 D1
 Safety!~
 ~
@@ -640,7 +640,7 @@ The Demon's Wood~
    You find yourself among the twisted, gnarled trunks of giant thorn trees.  
 Mist covers the forest floor, and everything is completely silent.    
 ~
-310 1 0 0 0 0
+310 1 0 0 0 3
 D2
 ~
 ~
@@ -655,7 +655,7 @@ The Demon's Wood~
    You find yourself among the twisted, gnarled trunks of giant thorn trees.  
 Mist covers the forest floor, and everything is completely silent.    
 ~
-310 1 0 0 0 0
+310 1 0 0 0 3
 D0
 ~
 ~
@@ -671,7 +671,7 @@ The City Street~
 junction.  There is a castle to the north, and more streets to the east and
 west.  There is a large sign posted on a wall here.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 1
 D0
 You see the castle.~
 ~
@@ -703,7 +703,7 @@ The City Streets~
    Small houses line both sides of the street, and armed guards are posted at
 every junction.  You see a small poster pasted to the wall here.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 1
 D1
 ~
 ~
@@ -720,7 +720,7 @@ The City Streets~
    Small houses line both sides of the street, and armed guards are posted at
 every junction.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 1
 D3
 ~
 ~
@@ -731,7 +731,7 @@ Inside the Castle~
    Everything here is a mess.  Furniture has been overturned, paintings
 slashed, even the gold inlaid tiles have been torn up.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 1
 D1
 ~
 ~
@@ -742,7 +742,7 @@ Entrance to Relnar's Castle~
    You stand before the ajar gate of the castle.  You here complete silence
 from inside.  City life continues to bustle around you.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 1
 D0
 ~
 ~
@@ -887,7 +887,7 @@ you can just barely see one of the castle's towers over the trees.  To the
 north, the land sloped downward, and thick, gnarled thorn trees prevent
 movement to the east or west.    
 ~
-310 4 0 0 0 0
+310 4 0 0 0 4
 D0
 ~
 ~
@@ -905,7 +905,7 @@ thick choking vegetation grabbing your boots.  The path back to the south
 disappears in darkness, and your path continues to dip as you head to the
 north.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 4
 D0
 ~
 ~
@@ -921,7 +921,7 @@ The Valley Floor~
 the east and west.  A sudden gust of wind brings you the smell of sulphur from
 the north.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 4
 D0
 ~
 ~
@@ -937,7 +937,7 @@ The Rift~
 waft their way upwards, stinging your nose sharply.  You sense that a great
 evil is near.    
 ~
-310 0 0 0 0 0
+310 0 0 0 0 4
 D2
 ~
 ~

--- a/lib/world/wld/312.wld
+++ b/lib/world/wld/312.wld
@@ -6,7 +6,7 @@ to the east, some of them very small - obviously single person occupied - others
 are a bit more large with space for more than a few.  To the north a way leads
 through the thick jungle which covers most of the top of this island.  
 ~
-312 4 0 0 0 0
+312 4 0 0 0 1
 D0
 A well-marked path leads deep into the jungle.
 ~
@@ -48,7 +48,7 @@ looks to have a capacity of at least three to four people.  Ways through the
 small village lie to the east and south both of them seeming just as gloomy and
 unappealing as the other.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 A small hut lies to the north.
 ~
@@ -106,7 +106,7 @@ timber and clay with a bit of yellow jungle grass tossed in the cracks.  To the
 south is more of the small footpath that weaves through the small village, a
 small coop for chickens visible in that direction.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 The main path through the clearing lies to the north.
 ~
@@ -129,7 +129,7 @@ Footpath Through Leper's Village~
 To the east is a small chicken coop where clucks and squawks can be heard in a
 constant cacaphony.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 The path leads north past a few huts.
 ~
@@ -154,7 +154,7 @@ evidence it is tough to judge whether or not those huts actually have any
 inhabitants.  To the east is a small fenced-in pig pen with a couple of warty,
 dirty wild boars who glare balefully at any who pass.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 The path leads past a few huts to the main path.
 ~
@@ -261,7 +261,7 @@ most of these huts are comprised; straw, clay and rough-hewn timbers.  The path
 continues to the east and west past a number of huts, both directions eventually
 leading back into the jungle.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 ~
 ~
@@ -286,7 +286,7 @@ perfectly straight rows with no weeds visible whatsoever.  A path south of here
 runs east and west through the jumble of huts which comprise this small
 community.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 ~
 ~
@@ -329,7 +329,7 @@ something quite curious a sign or proclamation of some sort has been erected and
 stands quite large in the center of the community.  To the east and west the
 footpath continues through the village.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 ~
 ~
@@ -392,7 +392,7 @@ clay and rough timbers, north is another such hut but much larger and with a
 cross affixed to the outer wall just right of the door.  This must obviously be
 the chapel for the village.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 1
 D0
 ~
 ~
@@ -431,7 +431,7 @@ into the thick jungle foliage.  The way north is engulfed in deep greenery which
 obscures vision past a point not far distant along the path.  To the west is the
 way into a small community of huts nestled in a clearing in the jungle.  
 ~
-312 4 0 0 0 0
+312 4 0 0 0 3
 D0
 ~
 ~
@@ -447,7 +447,7 @@ Trail Through the Jungle~
 impassable as can be.  The trail itself, however, is well-groomed and kept free
 of debris and obstacles which might trip or scratch a passerby.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -464,7 +464,7 @@ raked or broomed making the way along the path easy and quick.  On either side
 the jungle looms in, its presence huge and unmistakable.  There may be a slight
 break to the west, allowing travel in that direction.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -485,7 +485,7 @@ brightly in the moonlight.  This must be a safeguard put in by the locals so
 that if one were to be wandering along this path late at night there would be no
 way to wander off and get lost in the jungle.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D1
 ~
 ~
@@ -503,7 +503,7 @@ are lined in white stones - markers for any who might be traveling the path by
 moonlight so that they might keep their bearings along the path and not wander
 off into the jungle.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -519,7 +519,7 @@ Trail Through the Jungle~
 south.  Must be some sort of water source north of here.  The path is extremely
 well-kept here as it wends its way through the thick jungle.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -536,7 +536,7 @@ set of log steps lead out to the very edge, allowing for dry feet when drawing
 water.  The path ends at this northern boundary, leading only back to the south
 through the jungle.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -630,7 +630,7 @@ the south is the start of an open area where a few huts have been erected in a
 small conglomeration.  To the north is a trail, less kept than the western path
 but still quite traversable.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -650,7 +650,7 @@ Well-used Trail Through the Jungle~
 footpath with no roots or snags at any point.  The path wends its way south
 through the jungle foliage, the way clear and open.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D1
 ~
 ~
@@ -667,7 +667,7 @@ obstacles or obstructions whatsoever.  The ground which the path travels along
 is so free of debris that it almost appears as if it might have been recently
 swept.  Quite odd for a jungle path.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -684,7 +684,7 @@ leading the way through the thick tangle of the jungle.  From all appearances,
 this trail is cut back daily so that growth from the trees nearby might snag a
 passerby's clothing or skin.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -700,7 +700,7 @@ Well-used Trail Through the Jungle~
 fidgetings of many jungle animals can be heard, their disquiet from your passage
 very evident.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D1
 ~
 ~
@@ -734,7 +734,7 @@ Trail Through the Jungle~
 with no sign of lessening or narrowing.  To the south is an enrance into a large
 clearing in the jungle.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -751,7 +751,7 @@ which might make travel at all hazardous.  The path leads far to the north into
 the jungle or south toward a large opening in the thick, twisted growth of this
 place.  A way through the trees may be available to the east.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -772,7 +772,7 @@ cared for the further it travels in that direction.  It does not get bad enough
 to be called neglected by any means, however it does not hold much of the
 perfection that is evident in the path south of here.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -790,7 +790,7 @@ regularly swept or raked to keep it free of debris.  The branches of the trees
 which normally would hang over the path have been cut and sand down to a dull
 edge to avoid any piercings.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D2
 ~
 ~
@@ -806,7 +806,7 @@ Trail Through the Jungle~
 south.  Small white stones have been placed along the sides of the path to help
 night time passers better see the direction of the path .
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -824,7 +824,7 @@ if someone or someones may be making a point of keeping the trail clear.  The
 trees also look to be cut back from the trail, keeping it free of snags and
 annoying branches.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -840,7 +840,7 @@ Trail Through the Jungle~
 the north.  To the south the path has the look of an oft-traveled path that is
 kept up with some regularity.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -857,7 +857,7 @@ it had not been traveled upon or tended to in quite some time.  To the south the
 trail grows noticably wider as it continues, the trail becoming more and more
 defined the further south the path gets.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -874,7 +874,7 @@ Just to the west is a small pond, an acrid smell emanating from its direction.
 North from here is an opening in the jungle foliage, the volcano rising high
 beyond the clearing's boundaries.  South, the path leads deep into the jungle.
 ~
-312 4 0 0 0 0
+312 4 0 0 0 3
 D0
 ~
 ~
@@ -926,7 +926,7 @@ from its deep innards.  Camped directly at the base is a small cluster of
 dwellings, actually only two dwellings and a rickety-looking pen which holds
 barely a-livestock.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -945,7 +945,7 @@ to the white sand beaches at the shore of the sea.  East a ways there is a small
 log pen for any livestock that might get given to these poor folk by the
 healthier lepers in the village south of here.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -970,7 +970,7 @@ be in pretty bad shape, many holes evident in the roof and walls.  Flys buzz
 about this area, making an annoying buzz.  Most probably they are attracted by
 the stink of the animal pen to the southeast and the hut to the east.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -993,7 +993,7 @@ North is a large hut, almost large enough to be called a hall, a set of steps
 leading up and into the interior.  South is small open area with a pile of ash
 in the center.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D1
 ~
 ~
@@ -1014,7 +1014,7 @@ still move about come to be together.  Not much talking goes on and certainly no
 dancing, however the idea of being together - nearby another human - sometimes
 is all it takes to give the comfort needed by these doomed people.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -1028,7 +1028,7 @@ seperating their livestock, there are droppings from many different kinds of
 animals from pig to chicken to unidentifiable.  The entire affair is ringed by a
 set of logs from the trees of the jungle, tied loosely at the corners.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D3
 ~
 ~
@@ -1070,7 +1070,7 @@ irregular spurts.  The pathetic excuse for an encampment crouches pitifully in
 the presence of this volcano, a constant reminder that sooner or later anyone
 living here will be one with the Eternal Flame which burns within.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D1
 ~
 ~
@@ -1092,7 +1092,7 @@ was most probably some of their last breaths, those men and women made it so
 that future generations would not have to labor so long or hard to consecrate
 the bodies of fallen friends to the volcano and the Eternal Flame within.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D4
 ~
 ~
@@ -1109,7 +1109,7 @@ the climb a bit less effort.  Being that most of the men and women who climb
 this trail are living their last days in pain and misery, this path was made
 with their incapabilities in mind.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D4
 ~
 ~
@@ -1128,7 +1128,7 @@ any time.  It is never contested by any who dwell upon the island whether or not
 the timing is right for the one who is jumping, it is simply accepted that that
 person has had enough of the disease and horror that is leprosy.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D5
 ~
 ~
@@ -1189,7 +1189,7 @@ Cliff~
 and the top.  The steps look natural, made by nature to have happened to have
 worked well as steps.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 4
 D4
 ~
 ~
@@ -1207,7 +1207,7 @@ clean, very white - almost bleached.  It is a very fine sand that makes walking
 a bit more of an effort than normal packed beach sand, however it makes fro such
 beautiful scenery that it is not unpleasant at all.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -1228,7 +1228,7 @@ the east - inland - a steep cliff rises up, cutting off any progress.  The way
 north is cut off by the steep outer wall of a large volcano, one which sends
 plumes of black smoke rising high into the air intermittantly.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D2
 ~
 ~
@@ -1243,7 +1243,7 @@ wall which rises from the sea high into the sky.  Just south from this locale is
 a cliff wall, one which cuts off both south and eastward travel as it is
 certainly too steep to climb.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -1310,7 +1310,7 @@ a very short distance.  A flow of water runs from a small overgrown gully just
 west of here, making its way down a small four inch sand canyon down into the
 sea.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -1328,7 +1328,7 @@ seen growing in abundance.  No signs of habitation are visible, although black
 smoke continues to rise in constant puffs from somewhere on the isle.  Of
 course, it could simply be the volcano that was visible from the sea.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D0
 ~
 ~
@@ -1345,7 +1345,7 @@ of the sun's rays pounding down upon it.  A steep cliff rises directly to the
 north, prohibiting travel in that direction, however the beach does stretch to
 the south for some distance.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 2
 D2
 ~
 ~
@@ -1357,7 +1357,7 @@ In Thick Bracken~
 slow.  Visibility is reduced immediately to almost nothing, the way ahead just
 as mysterious as if it were the darkest of night and there was no light.  
 ~
-312 4 0 0 0 0
+312 4 0 0 0 3
 D1
 ~
 ~
@@ -1373,7 +1373,7 @@ A Tangle of Vines~
 trees in every direction.  The ground is mazed with their clusters of
 criss-crossings, making it easy to trip and fall at any time.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D2
 ~
 ~
@@ -1389,7 +1389,7 @@ Near an Old, Wet, Fallen Tree~
 and the ravages that time brings.  It is covered in thick, green moss from top
 to bottom, crumbling away at the merest of touches.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -1405,7 +1405,7 @@ Through a Tangle of Jungle Brush~
 overgrown jungle just to get through.  Every direction looks just as impossible
 to get through as the next, making muscles ache and strain with every move.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D1
 ~
 ~
@@ -1422,7 +1422,7 @@ sky.  Patches of moss and wraps of vines climb its trunk, clinging to the
 ancient life within.  Looking up into the branches, branches as wide as a normal
 full-grown tree trunk protrude from the higher reaches.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -1443,7 +1443,7 @@ through the things can any way be found out of this mess.  The line of sight
 only goes as far as an arm's length as the weeds which grow here are taller than
 most ordinary men and then some.  Its a good possibility that you may be lost.
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -1460,7 +1460,7 @@ obscuring vision and impeding travel.  The branches are strong and somewhat
 damp, making it difficult to slash through as it would normally be for the
 stiff, brittle branches of the mainland forest trees.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -1477,7 +1477,7 @@ about four feet high dig into its side.  The interior is dark - it does not
 appear that there is any sort of human life within, however one can never be too
 sure.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D1
 ~
 ~
@@ -1493,7 +1493,7 @@ Outside a Hollow Tree~
 east.  The smell of smoke issues from the interior, giving a pretty good
 indication that someone of at least limited intelligence must live within.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D0
 ~
 ~
@@ -1541,7 +1541,7 @@ A Leaf Shrouded Section of the Jungle~
 the leaves which block all sight and direction are easily removable.  Any
 direction looks as good as the other - its all leaves every which way.  
 ~
-312 0 0 0 0 0
+312 0 0 0 0 3
 D1
 ~
 ~

--- a/lib/world/wld/33.wld
+++ b/lib/world/wld/33.wld
@@ -85,7 +85,7 @@ same voice that has saved your life on countless
 occasions, seems to be telling you that something is
 very, very wrong here.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 2
 D1
 It is a normal front door to a house.
 ~
@@ -140,7 +140,7 @@ fireball.  There is nothing here now but blast-marks and
 ashes, and the remains of a trail leading to the east edge
 of this tiny valley.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 2
 D1
 ~
 ~
@@ -240,7 +240,7 @@ traffic in this area, leading into the large depression
 here.  The going looks somewhat dangerous, and you decide 
 to exercise a little caution.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D0
 ~
 ~
@@ -267,7 +267,7 @@ slope to the east, or continue along the flat area to the
 west.  Another slope leads downwards to the south, looking
 unsafe but climbable.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D1
 ~
 ~
@@ -291,7 +291,7 @@ good view of the lower regions of this depression, and you
 think you spot what might be a cave south and down from 
 here...
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D1
 ~
 ~
@@ -332,7 +332,7 @@ a very good idea to try to find a way to get there.
    The only safe way to leave this overlook is to 
 the south.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D2
 ~
 ~
@@ -365,7 +365,7 @@ Looking up, you see sheer rock walls surrounding much
 of the depression, making an effective fortress of
 this place.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D1
 ~
 ~
@@ -383,7 +383,7 @@ of the mountainside.  The whole place seems quiet, too
 quiet in fact.  Your little adventurer's intuition is
 busily warning you of traps.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D0
 ~
 ~
@@ -890,7 +890,7 @@ mountainside, and two open shops made of wood and stone
 are to your north and south.  East-wards this road continues.
    There is a small sign here.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D0
 ~
 ~
@@ -955,7 +955,7 @@ east is an actual road intersection, and to the west you see one
 of the ends of this road.  A large grassy area to the south is
 fenced off for a horse corral.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D1
 ~
 ~
@@ -993,7 +993,7 @@ appears.
 east, and west.  None particularly stand out from the 
 others.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D0
 ~
 ~
@@ -1020,7 +1020,7 @@ building that appears to be a farmer's market.  The road
 you are on continues north, and comes to an intersection 
 just south of here.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D0
 ~
 ~
@@ -1040,7 +1040,7 @@ The Farmer's Market~
 buy the food her family has grown.  She looks bored, but
 not unhappy... no competition!
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D1
 ~
 ~
@@ -1053,7 +1053,7 @@ by the Mountains ends here, curving to become the front
 walk of a private home to the east.  The road runs south
 from this house, towards the center of the village.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D1
 A normal, wooden front door to a normal looking home.  It is
 nothing to write home about.
@@ -1088,7 +1088,7 @@ to the south.  Smoke rises from the chimney in a dark
 stream, and the windows are frosted over with humidity.
 North, you see the main intersection of Stanneg.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D0
 ~
 ~
@@ -1124,7 +1124,7 @@ in the center of the tiny village.  Around you is a rocky
 terrain in the middle of this mountain range...not very 
 many places else to go.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D0
 There is a large set of double doors, made of wood blocking the way.
 ~
@@ -1218,7 +1218,7 @@ the path seems to head towards that dark peak piercing the
 sky.  You notice a few boot-tracks in the earth, seemingly 
 to lead down towards the cottage.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D1
 ~
 ~
@@ -1241,7 +1241,7 @@ place, badly.  You see no signs of life among the wreckage.
 You can enter one of the particularly large holes in the 
 wall to the west, with caution.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 4
 D3
 ~
 ~
@@ -1260,7 +1260,7 @@ dessicated corpse of a man, outstretched and blackened.
 There's not much to see here; whatever decided to destroy 
 this place did it very well.
 ~
-33 0 0 0 0 0
+33 0 0 0 0 1
 D1
 ~
 ~
@@ -1385,7 +1385,7 @@ into the cave.
    Two tunnels lead off from here, one up, one down.  There
 are claw marks leading in either direction.
 ~
-33 585 0 0 0 0
+33 585 0 0 0 4
 D2
 ~
 ~
@@ -1424,7 +1424,7 @@ stone stop abruptly here, where there seems to be a lot
 of unearthed dirt and stone around, heaped upon the floor.  
 You feel uneasy about this place.
 ~
-33 585 0 0 0 0
+33 585 0 0 0 4
 D0
 ~
 ~
@@ -1464,7 +1464,7 @@ closeness of the cave's entrance above you.  There's a
 deep, musky odor in the air, and the giant claw marks 
 continue downwards.
 ~
-33 585 0 0 0 0
+33 585 0 0 0 4
 D4
 ~
 ~
@@ -1484,7 +1484,7 @@ drowning out everything else in the air and making it hard
 to breathe.  Something in your gut begins squirming 
 uncomfortably as you wonder what's ahead...
 ~
-33 585 0 0 0 0
+33 585 0 0 0 4
 D0
 ~
 ~
@@ -1504,7 +1504,7 @@ with tapestries and drapes, and other comforts of human
 life.  There is even a huge-dragon sized bed -- undoubtedly 
 conjured to life by its elder dragon owner.
 ~
-33 584 0 0 0 0
+33 584 0 0 0 4
 D2
 ~
 ~

--- a/lib/world/wld/345.wld
+++ b/lib/world/wld/345.wld
@@ -23,7 +23,7 @@ it anymore. To the north the road is blocked by a fallen tree. To the south
 the road continues. A vine covered brick wall greets the eye to the east,
 effectively hiding what may lay beyond it.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 1
 D2
 ~
 ~
@@ -42,7 +42,7 @@ north and south. There is a break in the wall to the east. A heavy iron bar
 gate stands there allowing a glimpse of what is behind the wall. Next to it is
 an old bronze plaque.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 1
 D0
 ~
 ~
@@ -81,7 +81,7 @@ A Broken Road~
 better to the north. To the south the road is so bad that its not usable. 
 Your view to the east is blocked by a large vine covered wall.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 1
 D0
 ~
 ~
@@ -105,7 +105,7 @@ gate hangs slightly. To the north and south overgrown bushes and tall grass
 seem to harbor unknown secrets. To the east a dirt road leads to do an old
 abandoned building, shrouded in a fog.
 ~
-345 4 0 0 0 0
+345 4 0 0 0 2
 D1
 ~
 ~
@@ -129,7 +129,7 @@ and saftey. A small over-grown path that leads to south, but its unclear where
 it heads. There is an unnatural fog in the air, making seeing very far
 difficult.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D1
 ~
 ~
@@ -152,7 +152,7 @@ collapse the whole wall. To the south there appears to be headstones, with
 someone moving in among them... Or it could just be the swirling fog playing
 tricks. 
 ~
-345 4 0 0 0 0
+345 4 0 0 0 4
 D1
    A heavy iron reinforced oak door.
 ~
@@ -170,7 +170,7 @@ nature. A black wrought iron fence with a gate leads to a path to the south.
 Northeast is a large building in disrepair. Faintly to west, you can make out a
 high wall. 
 ~
-345 4 0 0 0 0
+345 4 0 0 0 2
 D0
 ~
 ~
@@ -264,7 +264,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 4 0 0 0 0
+345 4 0 0 0 2
 D1
 ~
 ~
@@ -285,7 +285,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~
@@ -317,7 +317,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D2
 ~
 ~
@@ -341,7 +341,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~
@@ -368,7 +368,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~
@@ -396,7 +396,7 @@ foreboding in the air, as if some terribly evil is lurking in the area. All
 around the dead seem to call out from beyond the grave. Although this whole
 place is strange there is something odd about a nearby grave stone.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~
@@ -428,7 +428,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~
@@ -453,7 +453,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~
@@ -474,7 +474,7 @@ that there are creatures and other beings around. The area is over grown with
 grass and weeds. Strangely, there is still a well worn path in amongst the
 graves, as if others have passed through here recently.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~
@@ -496,7 +496,7 @@ exposing the it to the elements. To the north, south, east, and west are entry
 ways into the main building. There are benches, in various states of disrepair,
 scattered throughout the space.
 ~
-345 0 0 0 0 0
+345 0 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/35.wld
+++ b/lib/world/wld/35.wld
@@ -8,7 +8,7 @@ to anywhere significant or important but it seems to have made up its mind
 to enter the hills far away north.  A narrow trail scars its way off to the
 east as it leads up towards a hillside.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 1
 D0
 ~
 ~
@@ -29,7 +29,7 @@ sides by tall, stately trees which lend the scene with a sense of quiet
 serenity.
    You can follow the road north or south.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 1
 D0
 ~
 ~
@@ -51,7 +51,7 @@ shouting.
 Village, and a small trail leads through the trees towards the hills to the
 north.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 1
 D0
 ~
 ~
@@ -79,7 +79,7 @@ this land.  The road leads east into the peace and quiet - and dangers -
 of the forest; and to the west it becomes the main street of the town;
 surrounded by a confusion of shops, bars, and market places.
 ~
-35 4 0 0 0 0
+35 4 0 0 0 1
 D1
 ~
 ~
@@ -96,7 +96,7 @@ gate of Midgaard, to the forest of Miden'Nir (Goblinic for 'Green Blood').
 You can still see the city to the east, but if you go south, there is
 fresh air and greenery.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 You can see the walls of the South Gate.
 ~
@@ -114,7 +114,7 @@ The Trail To Miden'Nir~
 the east is easy enough.  To the west, smoke can be seen rising above
 the treetops.  The sprawl of Midgaard lies north of here.
 ~
-35 4 0 0 0 0
+35 4 0 0 0 3
 D0
 To the north, you see the South Gate of Midgaard.
 ~
@@ -142,7 +142,7 @@ The Miden'nir~
    You are in a dark forest.  To the east, mountains block passage.  From
 here, only the lighter forest to the west or south offer a way to travel.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 The mountains can be seen jutting up to the east.
 ~
@@ -165,7 +165,7 @@ The Miden'nir~
 through your hair.  To the north, the forest gets lighter.  However,
 the southern and western paths place you even deeper in the wood.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The forest is lighter in this direction.
 ~
@@ -187,7 +187,7 @@ On a Small Path~
    A path is here, leading east and south through the dark woods of
 Miden'nir.  Mountains slash the scenery to the west of here.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 Wind-swept forest.
 ~
@@ -205,7 +205,7 @@ The Miden'nir~
 in these woods.  The trees become too thick to the west, but you may go
 north, south or travel toward the mountains that lie east of here.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The trees lighten up a bit this way.
 ~
@@ -228,7 +228,7 @@ A Crossroads~
 seem to be closing in on you at this point, and you can barely see
 the sky through the thick branches above your head.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 Trees as far as the eye can see.
 ~
@@ -251,7 +251,7 @@ The Trail~
 impassable mountains glare at you, and the thick woods and undergrowth
 prevent any movement westward.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The trail bends to the north.
 ~
@@ -269,7 +269,7 @@ The Miden'nir~
 in these woods.  You can go north toward the mountains, or west to the
 forest, but the steep mountains prevent any movement east.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The mountains can be seen to the north.
 ~
@@ -293,7 +293,7 @@ that there is something evil hidden in these woods.  The forest
 gets lighter to the north.  The wind kicks up as you ponder your
 options.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 There is a small clearing to the north.
 ~
@@ -311,7 +311,7 @@ The Deep Forest~
 forest seems to close around you, and get darker and more foreboding.
 It might just be time to head back to somewhere safe.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 More forest.
 ~
@@ -339,7 +339,7 @@ The Light Forest~
 trail.  To the east, the forest becomes thick and darker.  South, the
 trail continues.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 A trail leading north-south.
 ~
@@ -363,7 +363,7 @@ boots make a disgusting SQUISH as you walk here.  You can go in any
 of the four cardinal directions from here.  Hopefully, it will be
 dryer.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The Miden'nir continues.
 ~
@@ -391,7 +391,7 @@ Near The Mountains~
 east.  You can only go north and west from here as the rocks stop all
 other movement.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 Many trees to the north.
 ~
@@ -409,7 +409,7 @@ The Fading Trail~
 as the forest is relatively light.  To the south, you can see a
 path.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 You can see a trail this way.
 ~
@@ -432,7 +432,7 @@ The Dark Path~
 continues north and south, and while is much to thick to explore
 west, you can head off into the woods to the west.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The forest gets lighter this way.
 ~
@@ -462,7 +462,7 @@ head are so thick that they block out all direct sunlight.  While
 it is much too thick to go further east, you might be able to make
 your way though the forest to the south and west.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D2
 The thick forest continues.
 ~
@@ -481,7 +481,7 @@ soaked into the ground.  Two carcasses lie in front of you, seeming to look
 up at you.  The forest is impassible to the south, but the other directions
 look ok.
 ~
-35 1 0 0 0 0
+35 1 0 0 0 3
 D0
 Darkness...
 ~
@@ -510,7 +510,7 @@ Deep In The Forest Of Miden'nir~
 To the north, you catch glimpses of daylight.  To the east, you
 simply cannot see.  The trees are close and stifling.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 You see daylight and a trail to follow.
 ~
@@ -529,7 +529,7 @@ in this area rather dark.  The forest continues east, where it meets the
 mountains.  The air is still and stuffy - a stench comes from the west and
 an ugly feeling causes the hair to rise on the back of your neck!
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 It appears to get much darker that direction.
 ~
@@ -572,7 +572,7 @@ but mountains block further exploration in all other directions,
 except south, where you notice a small tunnel dug into the
 mountainside.
 ~
-35 1 0 0 0 0
+35 1 0 0 0 3
 D2
 The tunnel leads into the mountainside.
 ~
@@ -590,7 +590,7 @@ A Tunnel In The Mountains~
 of this forest.  The floor is well worn, and continues south, into the
 mountain, or back north out into the forest.
 ~
-35 1 0 0 0 0
+35 1 0 0 0 1
 D0
 Outside, you see the forest of Miden'nir.
 ~
@@ -608,7 +608,7 @@ A Tunnel In The Mountains~
 the south the passage gets smaller and smaller.  A small alcove has been
 carved into the east wall.
 ~
-35 1 0 0 0 0
+35 1 0 0 0 1
 D0
 The tunnel gets wider in this direction.
 ~
@@ -630,7 +630,7 @@ A Small Alcove~
    A small alcove has been carved out here.  There are a bunch of twigs
 and leaves thrown into a pile here, probably serving as a bed.
 ~
-35 1 0 0 0 0
+35 1 0 0 0 1
 D3
 You see the main passageway.
 ~
@@ -648,7 +648,7 @@ A Tunnel In The Mountains~
 and smaller to the south.  You almost have to hunch over to make your way
 through this area.  A small archway to the south leads into a large chamber.
 ~
-35 1 0 0 0 0
+35 1 0 0 0 1
 D0
 The tunnel continues north.
 ~
@@ -667,7 +667,7 @@ serves as the living quarters for the goblins of Miden'nir.  The bones of
 numbers woodland creatures are strewn about the room, the remanents of a
 recent meal.
 ~
-35 1 0 0 0 0
+35 1 0 0 0 1
 D0
 The tunnel heads north.
 ~
@@ -682,7 +682,7 @@ chimney.  A painted sign is visible on the porch to the west.  You
 could go north or south around the building or leave this place and
 return to the forest.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 You can go north around the Inn.
 ~
@@ -715,7 +715,7 @@ from this angle.  The air here is filled with smells of smoke and cooking.
 South, the front porch is waiting for you... or you can see if there is
 a back door.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D2
 You see the front of the Inn.
 ~
@@ -728,7 +728,7 @@ South Of The Inn~
 through the front door, or west and to the rear of the establishment.  You
 here some muffled cries from a tiny trail leading south of here.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 This way leads to the front of the Inn.
 ~
@@ -752,7 +752,7 @@ keeper and his help throw a good deal of garbage here.  A couple of piles of
 rubbish are to the west, but you will smell the worse for meddling there.  As a
 clean alternative, you can go east around the Inn.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 You can go around the Inn this way.
 ~
@@ -772,7 +772,7 @@ overrun by goblins as of late, and it is no longer safe in these parts.
 The bar is just north of here.  If you'd rather have your own table, one
 is empty to the south.
 ~
-35 12 0 0 0 0
+35 12 0 0 0 1
 D0
 The bar is here, manned by the Innkeeper.
 ~
@@ -801,7 +801,7 @@ would be hard pressed to follow it far.  A number of bushes are trampled on
 and some medium sized branches have been knocked down.  Obviously there has
 been a battle here rather recently.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The Inn lies to the north.
 ~
@@ -820,7 +820,7 @@ hospitality of the Innkeeper, but as of late, he only serves the
 few adventurers that manage to survive a trip through the forest.
 You can leave south and return to the common room.
 ~
-35 40 0 0 0 0
+35 40 0 0 0 1
 D2
 You may retreat south back to the common room.
 ~
@@ -833,7 +833,7 @@ The Bard's Table~
 wooden chairs sits here.  There is a large stain on the table, the remnants
 of a spilled drink.
 ~
-35 8 0 0 0 0
+35 8 0 0 0 1
 D1
 You see the main floor of the Inn to the east.
 ~
@@ -845,7 +845,7 @@ The Garbage Dump~
    You stand knee deep in garbage.  YECCH!!!  It smells terrible and who knows
 what vermin live in these piles of filth...  
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 You can return to cleaner lands this way.
 ~
@@ -869,7 +869,7 @@ On The Trail Of The Horsemen~
    The path continues east and west of here.  You notice fresh tracks in
 the soft ground that show the horsemen fled to the west.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 Back to ambush point.
 ~
@@ -886,7 +886,7 @@ On The Trail Of The Horsemen~
    The path continues east and south.  You notice fresh tracks in the
 soft ground that show the horsemen turned, and fled south.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 The trail continues.
 ~
@@ -903,7 +903,7 @@ On The Trail Of The Horsemen~
    The trail of the horsemen continues east and north along this path
 through the forest.  The tracks are still fresh, so they must be near.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D0
 The trail continues.
 ~
@@ -921,7 +921,7 @@ A Dead End Trail~
 make any further exploration impossible.  Fresh tracks cover the ground, and
 end right here.  The horsemen must be nearby.
 ~
-35 0 0 0 0 0
+35 0 0 0 0 3
 D1
 Back to along the trail.
 ~

--- a/lib/world/wld/36.wld
+++ b/lib/world/wld/36.wld
@@ -5,7 +5,7 @@ wooden gate is rusted open.
    A narrow dirt path leads eastwards into the thick grass and the
 chessboard opens up to the west.
 ~
-36 4 0 0 0 0
+36 4 0 0 0 1
 D1
 A dirt path leads away through the great field north of Midgaard.
 ~
@@ -22,7 +22,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the Black Queen's Rook.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D1
 A black square lies to the east.
 ~
@@ -39,7 +39,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the Black Queen's Knight.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D1
 A white square lies to the east.
 ~
@@ -61,7 +61,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the Black Queen's Bishop.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D1
 A black square lies to the east.
 ~
@@ -83,7 +83,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the Black Queen.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D1
 A white square lies to the east.
 ~
@@ -109,7 +109,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the Black King.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D1
 A black square lies to the east.
 ~
@@ -131,7 +131,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the Black King's Bishop.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D1
 A white square lies to the east.
 ~
@@ -153,7 +153,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the Black King's Knight.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D1
 A black square lies to the east.
 ~
@@ -175,7 +175,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the Black King's Rook.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D2
 A white square lies to the south.
 ~
@@ -192,7 +192,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the Black Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -214,7 +214,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the Black Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -241,7 +241,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the Black Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -268,7 +268,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the Black Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -295,7 +295,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the Black King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -322,7 +322,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the Black King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -349,7 +349,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the Black King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -376,7 +376,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the Black King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -397,7 +397,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -418,7 +418,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -444,7 +444,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -470,7 +470,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -496,7 +496,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -522,7 +522,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -548,7 +548,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -575,7 +575,7 @@ A Black Square~
    You are standing on a black marble square.  You can see a rusty gate
 to the south.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -596,7 +596,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -617,7 +617,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -643,7 +643,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -669,7 +669,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -695,7 +695,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -721,7 +721,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -748,7 +748,7 @@ A Black Square~
    You are standing on a black marble square.  There is a rusty gate
 a short distance to the east.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -775,7 +775,7 @@ A White Square~
    You are standing on a white marble square.  There is a large rusty
 gate to the east.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -801,7 +801,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -822,7 +822,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -848,7 +848,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -874,7 +874,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -900,7 +900,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -926,7 +926,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -952,7 +952,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -979,7 +979,7 @@ A Black Square~
    You are standing on a black marble square.  There is a rusty gate
 to the north.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1000,7 +1000,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1021,7 +1021,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1047,7 +1047,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1073,7 +1073,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1099,7 +1099,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1125,7 +1125,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1151,7 +1151,7 @@ S
 A Black Square~
    You are standing on a black marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1177,7 +1177,7 @@ S
 A White Square~
    You are standing on a white marble square.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1199,7 +1199,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the White Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1221,7 +1221,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the White Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1248,7 +1248,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the White Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1275,7 +1275,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the White Queen's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1302,7 +1302,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the White King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1329,7 +1329,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the White King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1356,7 +1356,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of one of the White King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1383,7 +1383,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of one of the White King's Pawns.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1405,7 +1405,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the White Queen's Rook.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1422,7 +1422,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the White Queen's Knight.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1444,7 +1444,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the White Queen's Bishop.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1466,7 +1466,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the White Queen.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1492,7 +1492,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the White King.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1514,7 +1514,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the White King's Bishop.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~
@@ -1536,7 +1536,7 @@ A Black Square~
    You are standing on a black marble square.  This is usually the home
 of the White King's Knight.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A white square lies to the north.
 ~
@@ -1558,7 +1558,7 @@ A White Square~
    You are standing on a white marble square.  This is usually the home
 of the White King's Rook.
 ~
-36 0 0 0 0 0
+36 0 0 0 0 1
 D0
 A black square lies to the north.
 ~

--- a/lib/world/wld/37.wld
+++ b/lib/world/wld/37.wld
@@ -760,7 +760,7 @@ The pool.~
 rise above the water, blocking your way.  South and west the pool continues and
 north you see the mooring.  
 ~
-37 9 0 0 0 0
+37 9 0 0 0 6
 D0
 ~
 ~
@@ -780,7 +780,7 @@ The pool~
 the cliff rise above the water, blocking your way.  North and west the pool
 continues and east you see the mooring.  
 ~
-37 9 0 0 0 0
+37 9 0 0 0 6
 D0
 ~
 ~
@@ -796,7 +796,7 @@ The pool~
 the cliff rise above the water, blocking your way.  North and east the pool
 continues.  
 ~
-37 9 0 0 0 0
+37 9 0 0 0 6
 D0
 ~
 ~
@@ -812,7 +812,7 @@ The pool~
 rise above the water, blocking your way.  To the north, east and south the pool
 continues.  The water looks quite deep here.  
 ~
-37 9 0 0 0 0
+37 9 0 0 0 7
 D0
 ~
 ~
@@ -832,7 +832,7 @@ The pool~
 the cliff rise above the water, blocking your way, south the pool continues and
 east you see the mooring.  
 ~
-37 9 0 0 0 0
+37 9 0 0 0 6
 D1
 ~
 ~
@@ -865,7 +865,7 @@ Outside the cave~
 out around you.  You may enter the cave by going south, but can head back toward
 the city by going west from here.  
 ~
-37 32768 0 0 0 0
+37 32768 0 0 0 5
 D2
 The cave opening looks inviting - kind of like a mouth, waiting to feed..
 ~
@@ -883,7 +883,7 @@ Outside the capital~
 itself.  You're standing in some low foothils near some rocky ground to your
 east.  South of here a gravelled path leads towards the western highway.  
 ~
-37 32768 0 0 0 0
+37 32768 0 0 0 2
 D1
 The gravelled path ends and the ground becomes rocky.
 ~
@@ -900,7 +900,7 @@ On a gravelled path~
    You are walking along a gravelled path.  North of here the gravel path
 continues, while to the south you enter the bustle of the western highway.  
 ~
-37 0 0 0 0 0
+37 0 0 0 0 2
 D0
 The gravelled path continues...
 ~

--- a/lib/world/wld/38.wld
+++ b/lib/world/wld/38.wld
@@ -189,7 +189,7 @@ S
 The Sewer Main~
 You are in an unfinished room.
 ~
-38 1 0 0 0 0
+38 1 0 0 0 7
 D1
 ~
 ~

--- a/lib/world/wld/39.wld
+++ b/lib/world/wld/39.wld
@@ -233,7 +233,7 @@ while the posts are exquisitely carved into fish sitting on their tails, with
 their mouths around the railing.  Their jeweled eyes wink in the light.  The
 door is a large, fanciful myriad of carvings depicting a local legend.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -309,7 +309,7 @@ festively from the branches of the many trees, and animals cavort under them,
 unafraid.  The cart path continues both toward the street and toward the porch,
 up to you to choose the way.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -541,7 +541,7 @@ aboe, green with moss that thrives in the moist air.  It would be a tight
 squeeze, but you also think you might be able to edge between the wood and the
 rocks to the north, but your ability to return is indeed questionable.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 <NONE>~
@@ -663,7 +663,7 @@ blur.  Skinnier men dart here and there, what they are doing quite unapparent
 to you.  There is a trap door leading to below the decks not far from where you
 stand, while to the south is the door of a cabin.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -684,7 +684,7 @@ dark.  Apparently they have finished unloading cargo and have let their men go
 into the city.  To the east is a bare, wet, windswept area of docks.  Funny,
 but for all the traffic elsewhere nobody is on that section.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -704,7 +704,7 @@ all the way out to the jagged rocks that waves crash against the other side of,
 throwing spray into the air.  It is a good thing those rocks are there to act
 as breakers, or this beautiful beach wouldn't be swimable.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 2
 D0
 ~
 ~
@@ -745,7 +745,7 @@ line, waiting for the front cart to be filled and rush off to the market so
 that they may move up and have their own filled.  A plank ramp leads up onto
 the deck.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -769,7 +769,7 @@ the shore, while further out waves crash into treacherous rocks.  There is a
 slippery rope ladder over the side here, hanging down into the darkness under
 docks.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -787,7 +787,7 @@ rushing both to the market and to the docks, the wideness of the road makes it
 somehow less crowded.  There is loud, bawdy singing to the east somewhere, and
 a sandy beach to the south, strangely flat.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -813,7 +813,7 @@ open door spills the smells of beer and heavier drinks out onto the street,
 along with the bawdy drinking songs the patrons are singing.  Above the door is
 nailed a cracked mug.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 north~
@@ -840,7 +840,7 @@ rush of the ever-present sea breeze.  Looking to the east you can see the rush
 of men on to and off of the dock entrance that is there, while to the west the
 area is peaceful.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -873,7 +873,7 @@ through the residential section of Haven, and to the south are mostly houses.
 The cobbles here are clean, and the smell of salt is strong.  To the north the
 land slopes upward, keeping Haven in its beautiful vale.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -890,7 +890,7 @@ you can see to the east and west.  To the south is Market Path, and beyond that
 you can see flashes of color.  To the north the land continues to slope
 upwards, keeping Haven in its beautiful vale.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -912,7 +912,7 @@ It runs through the residential section of Haven, and to the south are mostly
 houses.  The cobbles here are clean, and the smell of salt is strong.  To the
 north the land slopes upward, keeping Haven in its beautiful vale.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -930,7 +930,7 @@ section of Haven, and to the south are mostly houses.  The cobbles here are
 clean, and the smell of salt is strong.  To the north the land slopes upward,
 keeping Haven in its beautiful vale.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -948,7 +948,7 @@ It runs through the residential section of Haven, and to the south are mostly
 houses.  The cobbles here are clean, and the smell of salt is strong.  To the
 north the land slopes upward, keeping Haven in its beautiful vale.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -967,7 +967,7 @@ you.  Cackling, insane laughter and assorted gibberish can also be heard from
 the darkness created by the overhanging roofs.  It really isn't a wonder people
 hurry past with their noses covered by handkerchiefs.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -990,7 +990,7 @@ cobbles here are clean, and the smell of salt is strong.  To the north the land
 slopes upward, keeping Haven in its beautiful vale.  To the south the town
 spreads before your view like a colorful map.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -1009,7 +1009,7 @@ the vale that Haven now lies in is now nothing more than quick stream.  On the
 other side of the stream begins a dense forest, the leafy foliage and dense
 undergrowth so thick that you can see nothing else.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -1029,7 +1029,7 @@ residents occasionally pass you, smiling happily.  To the west is the
 intersection with Riverwalk, which hardly has any more people than South Gull
 Road has.  There are white benches that you might rest on, however.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -1061,7 +1061,7 @@ road, in small areas before pleasant homes.  To the east beyond a small grassy
 bank the quick stream gurgles merrily on its way to the south and the sea.  
 People stroll slowly along, enjoying the shade and looking at the river.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1080,7 +1080,7 @@ People stroll slowly along, enjoying the shade and looking at the river.  A few
 couples sit on the grass on the bank of the river, talking in low voices as the
 look at each other with love.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1098,7 +1098,7 @@ up and down South Gull Road, and those just resting on the benches.  There is
 even a platform here where a bard might perform.  It is a very peaceful
 intersection.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1121,7 +1121,7 @@ People stroll slowly along, enjoying the shade and looking at the river.  This
 is such a nice place, it is no wonder some people just walk along Riverwalk all
 day, enjoying the scenery.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1139,7 +1139,7 @@ bank the quick stream gurgles merrily on its way to the south and the sea.
 People stroll slowly along, enjoying the shade and looking at the river, which
 gurgles even louder as it flows over the small rocks here.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1157,7 +1157,7 @@ bank the quick stream gurgles merrily on its way to the south and the sea.
 People stroll slowly along, enjoying the shade and looking at the river.  To
 the south there is an intersection, marking the southern end of Riverwalk.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1210,7 +1210,7 @@ waves crashing against rocks somewhere to the south fills the air, along with
 the screams of assorted seabirds.  The salty breeze blows a fine, refreshing
 mist onto you face.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1232,7 +1232,7 @@ The far-off sound of waves pounding rocks comes faintly to your ears.  To the
 south there is a beautiful sandy beach, and the screams of children can be
 heard mingled with the cries of gulls.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -1251,7 +1251,7 @@ south there is a beautiful sandy beach, and the screams of playing children can
 be heard mingled with the cries of gulls.  You can also see the outline of
 jagged rocks far off on the horizon.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -1274,7 +1274,7 @@ far-off sound of waves pounding rocks comes faintly to your ears.  To the south
 there is a beautiful sandy beach, and the screams of children can be heard
 mingled with the hungry cries of gulls.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -1298,7 +1298,7 @@ in a hurry to the beach to retrieve a child, or maybe they went to the market
 for some last minute supplies.  The wind whistles through the cracks on the
 boulders and would set all but a deaf person's teeth on edge.  
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1322,7 +1322,7 @@ Shops line the east, but it appears most of the owners are out to the market.
 One shop is still open, one with a hanging sign nailed above the door,
 portraying a smoking vial.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1344,7 +1344,7 @@ day's find at the market back to their homes.  There is only one shop with its
 door still left open, begging for buisness.  It has a sign nailed above the
 door, one of a crossed sword and mace.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1382,7 +1382,7 @@ do for the ships further down.  The merchant vessels have sails of many colors,
 with flags from assorted kingdoms.  To the north the street is a bit far off,
 while to the south there are some of Haven's famous fishing vessels.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1403,7 +1403,7 @@ merrily, all the way out to the jagged rocks that waves crash against the other
 side of, throwing spray into the air.  It is a good thing those rocks are there
 to act as breakers, or this beautiful beach wouldn't be swimable.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 2
 D0
 ~
 ~
@@ -1422,7 +1422,7 @@ is another small stretch of quicksand beach before the docks begin.  To the
 south the sea begins, pounding aginst the jagged rocks in the quickly deepening
 water.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 6
 D0
 ~
 ~
@@ -1441,7 +1441,7 @@ Are the thick, tall pillars that support the huge docks.  The area under the
 docks is dark.  To the south the sea begins, pounding aginst the jagged rocks
 in the quickly deepening water.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 6
 D0
 ~
 ~
@@ -1464,7 +1464,7 @@ many jagged rocks upon which the waves break.  To the west Sandy Path, earned
 of its name, travels unbroken.  To the east is a wooden shack with a sign
 depicting a boat nailed over the door.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1519,7 +1519,7 @@ inhabitants of this alley shy away from the small amount of light streaming in
 from the south and the intersection, their eyes accustomed to darkness and hurt
 by the natural light.    
 ~
-39 1 0 0 0 0
+39 1 0 0 0 1
 D0
 ~
 ~
@@ -1540,7 +1540,7 @@ not much of a wonder that the people of Haven avoid this place.  The people at
 the comparatively light intersection to the north hurry past with their heads
 down.    
 ~
-39 1 0 0 0 0
+39 1 0 0 0 1
 D0
 ~
 ~
@@ -1573,7 +1573,7 @@ crash hard against the other side of those rocks, throwing spray into the air.
 It is a good thing those rocks are there to act as breakers, or this beautiful
 beach wouldn't be swimable.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 2
 D0
 ~
 ~
@@ -1597,7 +1597,7 @@ the south you can hear the crash of waves breaking on rocks.  If you squint
 perhaps you can see a bit of the shimmering blue of reflected light where the
 winding road breaks between the many houses and establishments.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1685,7 +1685,7 @@ across the single window facing to the south and Sandy Path, serving as a
 curtain.  There is a bin of fish, Haven's main staple, against the west wall.
 The small floor, what isn't covered by a rug, is neatly swept dirt.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D2
 ~
 ~
@@ -1727,7 +1727,7 @@ might have been magnificant, the square, but now the once-beautiful fountain is
 just a granite-incased stagnant puddle, and the square itself is horribly dirty
 and in disrepair.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D3
 ~
 ~
@@ -1756,7 +1756,7 @@ not much of a wonder that the people of Haven avoid this place, using it only
 as a dump.  Light streams in from the east, almost allowing you to see the
 path.    
 ~
-39 1 0 0 0 0
+39 1 0 0 0 1
 D0
 ~
 ~
@@ -1776,7 +1776,7 @@ watch you from the shadows, hostile and almost as large as small cats.  It is
 not much of a wonder that the people of Haven avoid this place.  Somewhere to
 the south there is the soft glow of light.    
 ~
-39 1 0 0 0 0
+39 1 0 0 0 1
 D0
 ~
 ~
@@ -1795,7 +1795,7 @@ to come from everywhere and nowhere at once.  Rats scurry around your feet and
 watch you from the shadows, hostile and almost as large as small cats.  It is
 not much of a wonder that the people of Haven avoid this place.    
 ~
-39 1 0 0 0 0
+39 1 0 0 0 1
 D0
 ~
 ~
@@ -1814,7 +1814,7 @@ alley might be reflections of light in animal...  or human...  eyes.  It isn't
 a wonder people hurry past this intersection with worried glances to the north
 and south.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1841,7 +1841,7 @@ their scents to the breeze that sweeps across the clean cobbles.  Strolling
 residents occasionally pass you, smiling happily.  Perhaps they don't hear the
 soft maniacal laughter that comes from somewhere to the east.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D1
 ~
 ~
@@ -1863,7 +1863,7 @@ golden light onto the street.  Through the tiny, barred window you can catchi
 glimpses of well-armed guards and a sparkling pile of what appears to be gold
 coins.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1886,7 +1886,7 @@ their scents to the breeze that sweeps across the clean cobbles.  Strolling
 residents occasionally pass you, smiling happily.  Somewhere to the southeast
 you can see the tall white tower of the Lord of Haven's Manor House.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -1978,7 +1978,7 @@ wares and people yelling to each other in general are almost overwhelming.  To
 the south the throng thins into a crowd, and to the north you see the same sort
 of encounter you see here.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -2002,7 +2002,7 @@ wares and people yelling to each other in general are almost overwhelming.  To
 the north the throng thins into a crowd, and to the south you see the same sort
 of encounter you see here.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
    The road is in the same condition as here - CROWDED.    
 ~
@@ -2026,7 +2026,7 @@ people moving in all directions.  You can also glimpse the great gate of Haven
 to the north, and flashes of colorful canopies to the south.  One might wonder
 why so many people would be attracted to a fish market, of all things.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
 ~
 ~
@@ -2063,7 +2063,7 @@ Over the clacking of hooves on cobbles and catcalls from neighbors to each
 other you can hear the dull, background roar of sea surf crashing onto rocks.
 The air is hot and humid enough to make the slight breeze refreshing.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D0
    To the north there is a magnificant city gate.    
 ~
@@ -2104,7 +2104,7 @@ leaping fish.  Five feet tall themselves, their jeweled eyes winking, they are
 in the direct center of each gate.  You can tell by the reverant glances of
 those passing by that the people of the town are very proud of their gate.    
 ~
-39 0 0 0 0 0
+39 0 0 0 0 1
 D2
    To the south you see a relatively narrow, crowded winding road leading
 toward the market.    

--- a/lib/world/wld/4.wld
+++ b/lib/world/wld/4.wld
@@ -334,7 +334,7 @@ Toppled Tree House~
 appears that the tree that it was once in has long since toppled and rotted
 away.  This house would be better off as kindling, rather than a place to play.
 ~
-4 8 0 0 0 0
+4 8 0 0 0 3
 D0
 ~
 ~
@@ -384,7 +384,7 @@ logs and leaves.  Small beams of light shine through the roof of the tunnel,
 allowing some glimpse of the many insects and worms that reside here, burrowing
 silently through the decaying pieces of wood.  
 ~
-4 0 0 0 0 0
+4 0 0 0 0 3
 D1
 ~
 ~
@@ -401,7 +401,7 @@ There doesn’t seem to be anywhere in particular that it is coming from though
 stories have often been told of this tunnel being haunted by the spirits who
 died in the great battles that were held here.  
 ~
-4 0 0 0 0 0
+4 0 0 0 0 3
 D0
 ~
 
@@ -423,7 +423,7 @@ lingering heavy in the air.  Blood stains the walls and floor.  Several
 skeletons are scattered about the floor, threatening to trip anyone who passes
 through.  
 ~
-4 0 0 0 0 0
+4 0 0 0 0 3
 D1
 ~
 ~
@@ -547,7 +547,7 @@ forest allowing more to be visible than most would wish to see.  The tunnel
 itself is made up mostly of fungus and rotting bark, its surfaces literally
 crawling with squirming insects and decay.
 ~
-4 0 0 0 0 0
+4 0 0 0 0 3
 D1
 ~
 ~
@@ -677,7 +677,7 @@ A Log Bridge~
 scattered around its edges.  The air is warm and wet, and the slurping sounds of
 a bubbling swamp can be heard nearby.
 ~
-4 0 0 0 0 3
+4 0 0 0 0 2
 D1
 ~
 ~
@@ -919,7 +919,7 @@ more trees begin to appear.  The trees seem to be leaning to one side, almost as
 if they were creating a path for passage.  The pawn shop can be seen to the
 north.  
 ~
-4 8 0 0 0 3
+4 8 0 0 0 0
 D0
 ~
 ~
@@ -936,7 +936,7 @@ Village Pawn Shop~
 items can be seen hanging from the wall, collecting layers of dust and cobwebs.
 A thick, wooden counter bows slightly, its surface cracked with use and age.
 ~
-4 8 0 0 0 0
+4 8 0 0 0 3
 D2
 ~
 ~
@@ -1371,7 +1371,7 @@ of sticky dust and cobwebs.  A few planks have been placed over top, although
 these too are old and rotted.  Insects buzz lazily around, humming contentedly
 as if not often disturbed.
 ~
-4 8 0 0 0 0
+4 8 0 0 0 3
 D1
 ~
 ~

--- a/lib/world/wld/40.wld
+++ b/lib/world/wld/40.wld
@@ -5,7 +5,7 @@ You feel the forces of evil approach you from the north.  Off
 in the distance to the northeast you can see the beginning of
 a large mountain range.
 ~
-40 4 0 0 0 0
+40 4 0 0 0 4
 D0
 ~
 ~
@@ -22,7 +22,7 @@ surround you on almost all sides.  A fair distance off to the
 north, you can see the enormous shadow of a strangely solitaire
 mountain.
 ~
-40 4 0 0 0 0
+40 4 0 0 0 4
 D0
 ~
 ~
@@ -40,7 +40,7 @@ through the rocks to a dark cave located to the north.  Off to the
 northeast, you can see the southern end of what appears to be a large
 mountain range.
 ~
-40 4 0 0 0 0
+40 4 0 0 0 4
 D0
 ~
 ~
@@ -58,7 +58,7 @@ sense fresh air and you surmise that the entrance must be located
 off in that direction.  To the north a small tunnel continues into
 the mountain.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D0
 ~
 ~
@@ -75,7 +75,7 @@ which help you slide through the passageway.  The smell of mouldy
 moss is growing greater the farther north you head, but you can smell
 fresh air off to the south as a light breeze wafts past you.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -91,7 +91,7 @@ The Tunnel~
 appears to open up to the north into a cave of some sort while to
 the east it leads onwards through the mountain.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -107,7 +107,7 @@ The Tunnel~
 see that it is not a highly travelled passageway.  It looks to lead
 in an east-west direction.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D1
 ~
 ~
@@ -124,7 +124,7 @@ The main tunnel appears to curve from south to west but there is an
 entrance into a cave to the north.  The entrance itself looks to be
 unnatural and much more recent than the tunnel or even the cave.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -145,7 +145,7 @@ with condensation and the weight of the rock above you is beginning
 to make you feel almost claustrophobic.  The tunnel makes a jagged
 turn from west to north here.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -162,7 +162,7 @@ eastern and western ends are almots completely shrouded in darkness.
 A small tunnel breaks through the southern wall, and it too is full
 of shadows.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D1
 ~
 ~
@@ -183,7 +183,7 @@ appears to be no other exit from here.  The walls are fairly smooth
 and look to have been naturally carved out of the rock by the passage
 of water.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D3
 ~
 ~
@@ -196,7 +196,7 @@ to turn into a tunnel which leads off to the south.  The cave
 continues northwards deeper into the darkness.
 You notice a large pile of bones in the corner.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D0
 ~
 ~
@@ -216,7 +216,7 @@ The Tunnel~
 in a north-south direction.  The walls are quite smooth, almost as
 if a river had gouged them out of the earth.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -232,7 +232,7 @@ The Hole~
 a fairly wide hole broken through the floor of the alcove.  The only
 other exit is to the north.
 ~
-40 13 0 0 0 0
+40 13 0 0 0 3
 D0
 ~
 ~
@@ -249,7 +249,7 @@ sitting in the floor by the northwestern corner of the walls.  The
 tunnel itself leads off towards the east.  The air here feels very
 damp and you feel like your clothes are becoming sticky with sweat.
 ~
-40 13 0 0 0 0
+40 13 0 0 0 3
 D1
 ~
 ~
@@ -266,7 +266,7 @@ in the air is so thick that you can almost seem it seeping into your
 clothes.  The tunnel continues to the north and west.  A large cave
 opens up to the east.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -288,7 +288,7 @@ giving you a feeling as if you were standing in the rain.  The walls
 of the cave are almost totally shrouded in darkness and shadow as is
 the southern end of the cavern.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D1
 ~
 ~
@@ -306,7 +306,7 @@ and the ground is covered with small pools of stagnent water.
    The tunnel leads away to the south, and to the west you can feel that
 the air is even damper than here.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D2
 ~
 ~
@@ -322,7 +322,7 @@ The Cave~
 large cave.  The cave wall to the east has an opening that appears
 to lead to a junction of several tunnels.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D1
 ~
 ~
@@ -340,7 +340,7 @@ tunnel to the north, whilst the one to the west appears to open
 up almost immediately into a cave.  The tunnels to the south and
 east are totally shrouded in darkness.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -365,7 +365,7 @@ west and north.  You spot a small alcove hidden in the shadows just to
 the south of you, and you can feel a breeze coming from somewhere to the
 north you believe.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -385,7 +385,7 @@ The Smelly Tunnel~
 is a a small light visible off to the north.  As you stop for a
 moment, you notice a strange smell from the north.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -401,7 +401,7 @@ The Cave~
 wind blowing from the north.  To the south you see a small tunnel
 continue into the mountain.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D0
 ~
 ~
@@ -418,7 +418,7 @@ see the sky.  A small tunnel to the south is the only way out.
 You notice the source of the strange smell, all around you there
 are corpses of several monsters.
 ~
-40 8 0 0 0 0
+40 8 0 0 0 2
 D2
 ~
 ~
@@ -437,7 +437,7 @@ the south.  In the mountain there is a cave.  To the north you can
 enter the hills.  There is a small trail leading up a steep hill to
 the east.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 2
 D0
 ~
 ~
@@ -457,7 +457,7 @@ The Foothills~
    You are on a winding path that leads through the foothills on the
 north side of Mount Moria.  The path continues north.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 4
 D0
 ~
 ~
@@ -473,7 +473,7 @@ The Intersection In The Foothills~
 path continues north and south while a rough trail leads east into
 the mountains.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 4
 D0
 ~
 ~
@@ -495,7 +495,7 @@ very large rocks litter this area.  You can go north towards the end
 of the foothills, west to go deeper into the foothills, or south to
 a small path intersection.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 2
 D0
 ~
 ~
@@ -515,7 +515,7 @@ At The Foothills' End~
 where they meet the plains which lie to the north.  You can head back
 into the foothills to the south or the plains to the north.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 4
 D0
 ~
 ~
@@ -531,7 +531,7 @@ The Plains~
 around you notice a small almost invisible trail leading away to the
 west towards a copse of trees.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 2
 D2
 ~
 ~
@@ -549,7 +549,7 @@ a small intersection of paths and off to the east you see that
 the path seems to come to an end as part of the mountain chain
 juts out of the ground, blocking your view of the sky.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 4
 D1
 ~
 ~
@@ -622,7 +622,7 @@ The Lion's Den~
 the small entranceway only to find yourself in what appears to be the
 living den of a large carnivorous animal!
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D2
 ~
 ~
@@ -636,7 +636,7 @@ the side of a large hill.  The hill seems to jut up from the rest of
 the foothills quite unnaturally.  A path leads off towards the east
 as it seems to begin from nothing here.
 ~
-40 0 0 0 0 0
+40 0 0 0 0 2
 D1
 ~
 ~
@@ -654,7 +654,7 @@ width of the tunnel runs at least fifteen feet.  You can feel the
 fresh air coming from the east, and off to the west, it looks to
 lead into darkness.
 ~
-40 8 0 0 0 0
+40 8 0 0 0 2
 D1
 ~
 ~
@@ -675,7 +675,7 @@ sandy floor.  It stands tall enough for you to walk under it without the
 need to hunch over.  A large tunnel leads out of the eastern wall of the
 cavern.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D1
 ~
 ~
@@ -687,7 +687,7 @@ The Steep Trail~
 it begins to pass between the mountains that surround you.  It continues
 through the hills to the east and heads down to the valley to the west.
 ~
-40 4 0 0 0 0
+40 4 0 0 0 5
 D1
 The rocky trail continues.
 ~
@@ -704,7 +704,7 @@ Between The Mountains~
    The trail between the mountains seems almost endless as you continue
 to trek along it.  It continues to both the east and west.
 ~
-40 4 0 0 0 0
+40 4 0 0 0 5
 D1
 The trail continues eastwards.
 ~
@@ -722,7 +722,7 @@ The Foothills~
 a narrow trail leading away to the northwest not too far distant to the
 west.
 ~
-40 4 0 0 0 0
+40 4 0 0 0 5
 D1
 You can head towards the narrow trail this way.
 ~
@@ -741,7 +741,7 @@ trail that leads between the mountains to the west.  The trail through
 them looks to be very long and probably quite tiring.  You spot a narrow
 trail leading away to the northwest not too far distant to the west.
 ~
-40 4 0 0 0 0
+40 4 0 0 0 5
 D1
 You can head towards the narrow trail this way.
 ~
@@ -759,7 +759,7 @@ The Foothills~
 almost straight westwards trail into a trail meandering towards
 the northwest. 
 ~
-40 4 0 0 0 0
+40 4 0 0 0 4
 D0
 A small trail leads away to the northwest.
 ~
@@ -778,7 +778,7 @@ heading to a southwards one.  The walls are cold and seem to be damp
 with moisture.  you can see some greenish moss growing up near the
 roof of the passageway on the northern wall.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D1
 ~
 ~
@@ -796,7 +796,7 @@ nearly as smooth as it was before.  In fact, the floor drops almost
 five feet in jagged steps as you look eastward.  The western path
 seems to be quite smooth however.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D1
 ~
 ~
@@ -812,7 +812,7 @@ The Tunnel~
 to smooth itself out once more.  Looking about, you notice a small
 spring of water bubbling up near the southern wall.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D1
 ~
 ~
@@ -832,7 +832,7 @@ is a fresh change from what would normally be found this far
 underground in that the tunnel seems to open  up into a fairly
 large and well lit cave.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -852,7 +852,7 @@ almost frightening shadows on the walls, almost hiding the two
 tunnels that lead away from here, one to the east and one to the
 west.
 ~
-40 8 0 0 0 0
+40 8 0 0 0 2
 D1
 ~
 ~
@@ -872,7 +872,7 @@ The Maze~
 quite low overhead and the passage twists off into darkness.  The only
 exit from here looks to be off to the west.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D3
 ~
 ~
@@ -886,7 +886,7 @@ front of you in the middle of this large cave.  The fire gives
 off more than enough light to see both the north and south ends
 of the cave.
 ~
-40 8 0 0 0 0
+40 8 0 0 0 2
 D0
 ~
 ~
@@ -908,7 +908,7 @@ The Maze~
 quite low overhead and the passage twists off into darkness.  The only
 exits from here look to be off to the north and south.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -924,7 +924,7 @@ The Maze~
 quite low overhead and the passage twists off into darkness.  The only
 exits from here look to be off to the south and west.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D2
 ~
 ~
@@ -942,7 +942,7 @@ seems to lead slightly down towards the east.
    The tunnel continues on to the east as it plunges deeper into the earth,
 and upwards a bit towards the west where the air seems to be quite damp.
 ~
-40 13 0 0 0 0
+40 13 0 0 0 3
 D1
 ~
 ~
@@ -964,7 +964,7 @@ does not seem to be changing.
 climbs to the west, and to the east, a strange flickering light
 shows that the tunnel opens up into a cave of sorts.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D1
 ~
 ~
@@ -984,7 +984,7 @@ almost frightening shadows on the walls, almost hiding the two
 tunnels that lead away from here, one to the west and one to the
 south.
 ~
-40 8 0 0 0 0
+40 8 0 0 0 2
 D0
 ~
 ~
@@ -1004,7 +1004,7 @@ The Maze~
 quite low overhead and the passage twists off into darkness.  The only
 exits from here look to be off to the east and west.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D1
 ~
 ~
@@ -1020,7 +1020,7 @@ The Maze~
 quite low overhead and the passage twists off into darkness.  The only
 exits from here look to be off to the east and north.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -1039,7 +1039,7 @@ decide to look around the cave.  The walls are slightly damp to
 the touch, and the ceiling is very smooth.  Almost right in the
 centre of the ceiling, a well rounded hole has been made.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D3
 ~
 ~
@@ -1056,7 +1056,7 @@ quite low overhead and the passage twists off into darkness.  The only
 exits from here look to be off to the east and north.  To the north,
 you can see the entrance to what looks to be a large and well lit cave.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -1073,7 +1073,7 @@ quite low overhead and the passage twists off into darkness.  The only
 exits from here look to be off to the east, south, and north.  To the
 south, the tunnel looks to open up into a cavern.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -1093,7 +1093,7 @@ The Maze~
 quite low overhead and the passage twists off into darkness.  The only
 exits from here look to be off to the west and north.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -1112,7 +1112,7 @@ by the sound of your breathing.  Stalactites and stalagmites
 hang down from the ceiling and climb upwards from the ground
 of the cavern respectively.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D1
 ~
 ~
@@ -1132,7 +1132,7 @@ hang down from the ceiling and climb upwards from the ground
 of the cavern respectively.  A narrow tunnel leads away from
 the cave to the north.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D0
 ~
 ~
@@ -1155,7 +1155,7 @@ by the sound of your breathing.  Stalactites and stalagmites
 hang down from the ceiling and climb upwards from the ground
 of the cavern respectively.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D0
 ~
 ~
@@ -1175,7 +1175,7 @@ hang down from the ceiling and climb upwards from the ground
 of the cavern respectively.  A narrow tunnel leads away from
 the cave to the east.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 2
 D0
 ~
 ~
@@ -1196,7 +1196,7 @@ here as it heads through the rock of the mountain.  The western wall
 of the tunnel looks to have broken through a small, natural crack in
 the rock to lead into what appears to be a fairly large cave.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D1
 ~
 ~
@@ -1217,7 +1217,7 @@ only exit is back to the west, where the tunnel leads back through
 the mountain.  There is absolutely nothing of any interest down at
 the end of this passageway either.  How odd.
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D3
 ~
 ~
@@ -1229,7 +1229,7 @@ The Hole~
 north because to leave down into the unknown, you must be able to
 fit through the hole, which is far too small for you!
 ~
-40 9 0 0 0 0
+40 9 0 0 0 3
 D0
 ~
 ~
@@ -1253,7 +1253,7 @@ the east you can see the plains, and just to the north a strange shadow
 seems to be changing shape constantly and almost seems to beckon you to
 enter it. 
 ~
-40 0 0 0 0 0
+40 0 0 0 0 4
 D0
 There is a strange shadow forming before you.
 ~

--- a/lib/world/wld/41.wld
+++ b/lib/world/wld/41.wld
@@ -6,7 +6,7 @@ previously expected as there is a small rivulet of water gushing down
 the one side of the tunnel.  The tunnel appears to extend straight to
 the east for quite some distance.
 ~
-41 13 0 0 0 0
+41 13 0 0 0 3
 D1
 ~
 ~
@@ -24,7 +24,7 @@ for four people to travel abreast with ease.  The walls do not seem to
 be very damp, but there is a small rivulet running along the northern
 wall of the tunnel.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D1
 ~
 ~
@@ -42,7 +42,7 @@ that they begin to close in rather rapidly to the east.  In fact,
 the manner in which they come together almost reminds you of a
 funnel.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D1
 ~
 ~
@@ -61,7 +61,7 @@ the tunnel opens up some more while to the east it dives further down
 into the earth, and you can see a small hole about two feet in diameter
 about waist height in the southern wall.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D1
 ~
 ~
@@ -83,7 +83,7 @@ exit from it; a tunnel leading sharply upwards from the western wall.
 The walls of this cavern are quite indistinct and you cannot see any
 moss or dampness on them whatsoever.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D3
 ~
 ~
@@ -96,7 +96,7 @@ this large cavern.  The cave is lit by the eerie, soft, golden light
 which looks to be emanating from the walls themselves.  The cave
 itself is enormous, extending quite a distance to the west and south.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D2
 ~
 ~
@@ -119,7 +119,7 @@ itself is enormous, extending quite a distance to the east and south.
 There is a hole in the northern wall, about two feet in diameter.
 All that can be seen through the hole is darkness.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D0
 ~
 ~
@@ -144,7 +144,7 @@ quite sharply to the south and west.  To the south, it appears that the
 passage continues, but to the west you can see what almost appears to
 be a golden light.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D2
 ~
 ~
@@ -163,7 +163,7 @@ itself is enormous, extending quite a distance to the west and north.
 A crack in the wall to the east appears to lead into a passageway of
 sorts.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D0
 ~
 ~
@@ -189,7 +189,7 @@ light which looks to be emanating from the walls themselves.  The cave
 itself is enormous, extending quite a distance to the east, south,
 and north.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D0
 ~
 ~
@@ -218,7 +218,7 @@ in the floor reveals little beyond the fact that it seems to be very
 deep and very dark.  There is a very strange smell emanating from the
 hole, it almost smells like something down there is rotting.
 ~
-41 13 0 0 0 0
+41 13 0 0 0 3
 D3
 ~
 ~
@@ -246,7 +246,7 @@ stagnant.  There is no detectable breeze at all but a strange smell
 emanates from the east.  There is a small, almost unnoticed hole in
 the southern wall.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D1
 ~
 ~
@@ -275,7 +275,7 @@ yet the air is quite damp.  The walls have a thin coating of moisture
 upon them which looks and feels somewhat oiley.  The tunnel leads in
 an east-west direction.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D1
 ~
 ~
@@ -300,7 +300,7 @@ passage makes its way deeper into the bowels of the earth.  A bizarre
 shadow in the eastern wall leads you to suspect that a small passage
 meets the tunnel there.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D0
 ~
 ~
@@ -323,7 +323,7 @@ itself is enormous, extending quite a distance to the north and a
 strange shadow formation seems to indicate a passage entrance to the
 west.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D0
 ~
 ~
@@ -347,7 +347,7 @@ at the curved part of the wall, it appears that someone (or something) has
 carved small handholds into the wall to ease passage upwards.  The tunnel
 itself leads off to the east.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D1
 ~
 ~
@@ -364,7 +364,7 @@ and south.  It looks to be wide enough for two people to walk side by
 side with plenty of room.  The passage appears to be almost rectangular
 in form.  Far off to the south you can see the pinpoint of a light.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D0
 ~
 ~
@@ -384,7 +384,7 @@ The Secret Tunnel~
 to have been heavily visited at any time.  It leads northwards towards
 a lit room and south towards what appears to be a chamber.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D0
 ~
 ~
@@ -405,7 +405,7 @@ hold you entranced.
 south.  In the north wall a strange vertical crack looks as if it may
 lead somewhere.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D0
 It looks like quite the tight fit.
 ~
@@ -430,7 +430,7 @@ hold you entranced.
    Looking about the cave, it appears to continue to the east and
 south.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D1
 ~
 ~
@@ -454,7 +454,7 @@ floor climbs upwards toward it?  The tunnel seems to narrow slightly
 more as you look to the south, and widens up somewhat as you look
 northward.  The light to the south continues to flicker.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D0
 ~
 ~
@@ -476,7 +476,7 @@ the west where it leads to a doorway that looks to be about five feet
 across.  The east end of the tunnel comes to a sudden end at a very
 smooth rock wall.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D1
 The rock wall to the east looks like it might be able to be moved.
 ~
@@ -499,7 +499,7 @@ appear to be a natural formation at all, since the walls are far
 too smooth and the doorways to the north and east are both almost
 exactly five feet wide and eleven feet tall.
 ~
-41 9 0 0 0 0
+41 9 0 0 0 3
 D0
 ~
 ~
@@ -519,7 +519,7 @@ hold you entranced.
    Looking about the cave, it appears to continue to the west and
 north.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D0
 ~
 ~
@@ -540,7 +540,7 @@ hold you entranced.
 north.  There is a passageway leading out of the western wall of the
 cave which looks to turn northwards.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 1
 D0
 ~
 ~
@@ -561,7 +561,7 @@ here to the north.  The southern wall is bare and almost seems to
 dance with the shadows created by the flickering light emanating
 from the cave to the east.
 ~
-41 8 0 0 0 0
+41 8 0 0 0 3
 D0
 ~
 ~
@@ -580,7 +580,7 @@ and is a rather tight squeeze.  You'd better hope that there aren't any
 worms or similar creatures down this way since it might be difficult to
 defend yourself in here.
 ~
-41 877 0 0 0 0
+41 877 0 0 0 5
 D0
 You can see a small hole marking the north exit of the crawlway.
 ~

--- a/lib/world/wld/43.wld
+++ b/lib/world/wld/43.wld
@@ -22,7 +22,7 @@ bridge made of ice.  Don't lose your balance!  To the north you see the end of
 the bridge, and past it is vast, white, nothing.  To the northwest you see
 smoke rising from an unknown village.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -43,7 +43,7 @@ off!  Beyond in the distance there is a large pillar of smoke rising of what
 seems to be rising from a small village in the northwest.  You stand there and
 think, Eskimos?    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -67,7 +67,7 @@ An Ice Bridge~
 really are eskimos in this barren land of snow and ice.  There are many black
 dots moving around aimlessly to the northeast.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -88,7 +88,7 @@ suddenly see a field to the north open up.  There are very few footprints in
 the snow.  To the north there is more nothing than you ever thought there could
 be.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -104,7 +104,7 @@ An Icy Crossroads~
 there is a three way split in the trail.  To the north, snow, ice, and black
 figures wondering about.  To the west, a barely definable trail.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -124,7 +124,7 @@ An Icy Trail~
 difficult.  The trail continues to the north where there is a turn in the path
 leading to a wide open field.  Back to the south there is a split in the trail.
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D1
 ~
 ~
@@ -140,7 +140,7 @@ A Turn in an Icy Trail~
 aimlessly in circles to the east.  Far to the east you see what seems to be a
 shoreline.  To the south a path of ice and snow.    
 ~
-43 4 0 0 0 0
+43 4 0 0 0 2
 D1
 ~
 ~
@@ -157,7 +157,7 @@ snow.  There are penguins all about you.  Way to the northeast there is a large
 structure made of ice.  The only thing you see for miles around is
 ice,penguins, and snow.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -178,7 +178,7 @@ and a couple lumps of some sort of creature roam these lands.  The penguins are
 many and with their babies seem many more.  As you scan your surroundings you
 see a large hump of ice to the northeast.  
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -198,7 +198,7 @@ A Snow Field~
 penguins are still waddling around seemingly mindless.  But as you look closer
 at the many tracks there are some that dont look like a bird.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -218,7 +218,7 @@ A Field of Packed Snow~
 track from another.  Although it is very very cold the penguins are still out
 in full force.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -239,7 +239,7 @@ the north a small hole in the ice.  Penguins still skid along their bellies and
 waddle around on thier feet.  You now also see what the animal was that was
 making those tracks earlier.  They are walruses!    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -256,7 +256,7 @@ the north a small hole in the ice.  Penguins still skid along their bellies and
 waddle around on thier feet.  You now also see what the animal was that was
 making those tracks earlier.  They are walruses!    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -276,7 +276,7 @@ A Field of Packed Snow~
 track from another.  Although it is very very cold the penguins are still out
 in full force.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -300,7 +300,7 @@ A Snow Field~
 penguins are still waddling around seemingly mindless.  But as you look closer
 at the many tracks there are some that dont look like a bird.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -325,7 +325,7 @@ and a couple of lumps of some sort of creature roam these lands.  The penguins
 are many and with their babies seem many more.  As you scan your surroundings
 you see a large hump of ice to the northeast.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -350,7 +350,7 @@ and a couple lumps of some sort of creature roam these lands.  The penguins are
 many and with thier babies seem many more.  As you scan your surroundings you
 see a large hump of ice to the northeast.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -370,7 +370,7 @@ A Snow Field~
 penguins are still waddling around seemingly mindless.  But as you look closer
 at the many tracks there are some that dont look like a bird.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -390,7 +390,7 @@ A Snow Field~
 penguins are still waddling around seemingly mindless.  But as you look closer
 at the many tracks there are some that dont look like a bird.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -414,7 +414,7 @@ A Snow Field~
 penguins are still waddling around seemingly mindless.  But as you look closer
 at the many tracks there are some that dont look like a bird.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -438,7 +438,7 @@ A Field of Packed Snow~
 track from another.  Although it is very very cold the penguins are still out
 in full force.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -463,7 +463,7 @@ the north a small hole in the ice.  Penguins still skid along their bellies and
 waddle around on thier feet.  You now also see what the animal was that was
 making those tracks earlier.  They are walruses!    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -485,7 +485,7 @@ all around the hole so the ice is practically see through.  There is an igloo
 to the north which looks well tended for.  All around to the south and east is
 a very large field.    
 ~
-43 4 0 0 0 0
+43 4 0 0 0 2
 D0
 ~
 ~
@@ -510,7 +510,7 @@ you saw earlier is now much closer and strait to the east.  Penguins still skid
 along their bellies and waddle around on thier feet.  You now also see what the
 animal was that was making those tracks earlier.  They are walruses!    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D1
 ~
 ~
@@ -531,7 +531,7 @@ you saw earlier is now much closer and strait to the east.  Penguins still skid
 along their bellies and waddle around on thier feet.  You now also see what the
 animal was that was making those tracks earlier.  They are walruses!    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D1
 ~
 ~
@@ -552,7 +552,7 @@ you saw earlier is now much closer and strait to the east.  Penguins still skid
 along their bellies and waddle around on thier feet.  You now also see what the
 animal was that was making those tracks earlier.  They are walruses!    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D1
 ~
 ~
@@ -573,7 +573,7 @@ you saw earlier is now much closer and strait to the east.  Penguins still skid
 along their bellies and waddle around on thier feet.  You now also see what the
 animal was that was making those tracks earlier.  They are walruses!    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D1
 ~
 ~
@@ -590,7 +590,7 @@ stand up and look out of it.  To the north is a long tunnel with a bright blue
 light coming out of it.  At the end of the tunnel it seems there is a very
 large room.    
 ~
-43 256 0 0 0 0
+43 256 0 0 0 2
 D0
 ~
 ~
@@ -681,7 +681,7 @@ the village of eskimos now.  You see back to the east the trail that continues
 north.  To the west the trail seems very short, but all this white nay be
 affecting your sight.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D1
 ~
 ~
@@ -698,7 +698,7 @@ the snow here are deeper and there are more of them; but not many more.
 Coming closer to the eskimo village you see people bustling about in there
 everyday chores.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -734,7 +734,7 @@ ice and
          L
           L
 ~
-43 4 0 0 0 0
+43 4 0 0 0 2
 D5
 ~
 ~
@@ -748,7 +748,7 @@ wall stands close to twenty feet high and, through the large iron gate set in
 the ice, six feet thick.  In front of the gate stands an engraved sign.  Above
 is a steep icy path that dosen't seem to be possible to climb up.    
 ~
-43 4 0 0 0 0
+43 4 0 0 0 2
 D0
 Nothing.
 ~
@@ -763,7 +763,7 @@ very warm clothes are hurrying about with there buissness.  To the north Arivat
 Avenue runs to a busy town square.  Whale Street runs east ans west.  To the
 south is the giant wall with the large gate set in the ice.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -788,7 +788,7 @@ There are many sled tracks through the area along with many more dog tracks.
 To the south is the main gate of the city and to the north is a busy market
 place.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -806,7 +806,7 @@ how.  There are many people going about thier buissness about you.  To the west
 there is a sign with a tunic on it and to the east a sign with a butcher's
 knife.  Just to the north is a busy square.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -835,7 +835,7 @@ The snow reaches up to the 13' foot mark upon closer examination.  Also on the
 post there is a dark line at the 18.5 mark which must be the highest snow
 fall ever.  There are stairs going down from the south side of the fountain.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -865,7 +865,7 @@ a fresh smell coming from the west and the clink of metal coming from the east.
 To the south is the fountain of clear water and to the north there is the north
 gate.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -890,7 +890,7 @@ top.  The gurgling of the fountain at the square can be faintly heard from
 here.  There is nothing mush to see here but the igloo houses lining the
 streets.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -907,7 +907,7 @@ quite as busy as might have been guessed.  The northern gate here seems to be
 well barred and impassible.  What is out there to the very northern reaches of
 Illniyr?    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -927,7 +927,7 @@ Nunavut Street~
 The weapon shop and the butchery are to the north and south but the doors here
 say private only.  To the east is the east gate of Rankit.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -944,7 +944,7 @@ igloos along the side of them some are bigger than others possibly signifying
 rank or social order.  The gate to to east seems to be well used and well
 maintained.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -969,7 +969,7 @@ sled dogs with there masters coming back from a good hunt.  The other people
 walking along are looking at you like you were a monster; they must not get
 many outsiders.  Just to the east is the eastern gate of Rankit.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -986,7 +986,7 @@ traffic here is almost non-stop.  Many people going to the stores to sell thier
 good and take some to thier familes.  The gate is well tended and hardly makes
 a noise when it opens.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1010,7 +1010,7 @@ Nunavut Street~
 The food supply shop and the fitter are to the north and south but the doors
 here say private only.  To the west is the west gate of Rankit.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1027,7 +1027,7 @@ igloos along the side of them some are bigger than others possibly signifying
 rank or social order.  The gate to to west seems to be well used and well
 maintained.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1052,7 +1052,7 @@ sled dogs with there masters coming back from a good hunt.  The other people
 walking along are looking at you like you were a monster; they must not get
 many outsiders.  Just to the west is the western gate of Rankit.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1069,7 +1069,7 @@ traffic here is much more than that one.  Many people going to the stores to
 sell thier good and take some to thier familes.  The gate is well tended and
 hardly makes a noise when it opens.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1090,7 +1090,7 @@ are few and they seem to shy away from the north side of the street even then.
 The folk poke thier heads out of there igloos watching your every move.  There
 are intersections to the east and west of you.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1107,7 +1107,7 @@ are few and they seem to shy away from the north side of the street even then.
 The folk poke thier heads out of there igloos watching your every move.  There
 are intersections to the east and west of you.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1128,7 +1128,7 @@ are few and they seem to shy away from the north side of the street even then.
 The folk poke thier heads out of there igloos watching your every move.  There
 are intersections to the east and west of you.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1144,7 +1144,7 @@ Intersection of Artic Street and Eskimo Avenue~
 To the west is a street almost void of people and to the south is a fairily
 busy street.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D2
 ~
 ~
@@ -1161,7 +1161,7 @@ are few and they seem to shy away from the north side of the street even then.
 The folk poke thier heads out of there igloos watching your every move.  There
 are intersections to the east and west of you.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1178,7 +1178,7 @@ are few and they seem to shy away from the north side of the street even then.
 The folk poke thier heads out of there igloos watching your every move.  There
 are intersections to the east and west of you.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1199,7 +1199,7 @@ are few and they seem to shy away from the north side of the street even then.
 The folk poke thier heads out of there igloos watching your every move.  There
 are intersections to the east and west of you.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1215,7 +1215,7 @@ Intersection of Artic Street and Inuit Avenue~
 To the east is a street almost void of people and to the south is a fairily
 busy street.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1232,7 +1232,7 @@ prizes.  The street is well maintained to keep the flow of traffic smooth.
 Also the people walking past you give you strange looks from underneath thier
 hoods.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1249,7 +1249,7 @@ prizes.  The street is well maintained to keep the flow of traffic smooth.
 Also the people walking past you give you strange looks from underneath thier
 hoods.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1266,7 +1266,7 @@ prizes.  The street is well maintained to keep the flow of traffic smooth.
 Also the people walking past you give you strange looks from underneath thier
 hoods.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1283,7 +1283,7 @@ prizes.  The street is well maintained to keep the flow of traffic smooth.
 Also the people walking past you give you strange looks from underneath thier
 hoods.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1299,7 +1299,7 @@ Intersection of Whale Street and Inuit Avenue~
 buissness.  To the north is a gate with people constantly going in and out.  
 To the east is the main gate that has very few going back and forth.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1316,7 +1316,7 @@ eastern gate to the south is a fairily busy place with hunters constantly
 coming in and out with pelts and furs to sell to the town shops.  To the north
 is the northern most part of the city.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1333,7 +1333,7 @@ eastern gate to the south is a fairily busy place with hunters constantly
 coming in and out with pelts and furs to sell to the town shops.  To the north
 is the northern most part of the city.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1350,7 +1350,7 @@ eastern gate to the north is a fairily busy place with hunters constantly
 coming in and out with pelts and furs to sell to the town shops.  To the south
 is an intersection of two streets with not many people around.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1367,7 +1367,7 @@ eastern gate to the north is a fairily busy place with hunters constantly
 coming in and out with pelts and furs to sell to the town shops.  To the south
 is an intersection of two streets with not many people around.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1383,7 +1383,7 @@ Intersection of Whale Street and Eskimo Avenue~
 buissness.  To the north is a gate with people constantly going in and out.  
 To the west is the main gate that has very few going back and forth.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1399,7 +1399,7 @@ Whale Street~
 town, lining the streets, because the wind is blowing out of the south.  To the
 west is the main gate of the city which is used rarely.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1415,7 +1415,7 @@ Whale Street~
 town, lining the streets, because the wind is blowing out of the south.  To the
 west is the main gate of the city which is used rarely.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1435,7 +1435,7 @@ Whale Street~
 town, lining the streets, because the wind is blowing out of the south.  To the
 west is the main gate of the city which is used rarely.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1451,7 +1451,7 @@ Whale Street~
 town, lining the streets, because the wind is blowing out of the south.  To the
 east is the main gate of the city which is used rarely.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1467,7 +1467,7 @@ Whale Street~
 town, lining the streets, because the wind is blowing out of the south.  To the
 east is the main gate of the city which is used rarely.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1487,7 +1487,7 @@ Whale Street~
 town, lining the streets, because the wind is blowing out of the south.  To the
 east is the main gate of the city which is used rarely.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D1
 ~
 ~
@@ -1503,7 +1503,7 @@ Snow Lane~
 your hips.  The eskimos walking around and above you have snow shoes on
 allowing them to walk without falling down.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1519,7 +1519,7 @@ Snow Lane~
 your hips.  The eskimos walking around and above you have snow shoes on
 allowing them to walk without falling down.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1535,7 +1535,7 @@ Snow Lane~
 your hips.  The eskimos walking around and above you have snow shoes on
 allowing them to walk without falling down.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1551,7 +1551,7 @@ Snow Lane~
 your hips.  The eskimos walking around and above you have snow shoes on
 allowing them to walk without falling down.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1568,7 +1568,7 @@ this part of town for some reason as the rest of the city.  The igloos still
 line the streets and residents of these igloos poke thier heads out and look at
 you warily.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1585,7 +1585,7 @@ this part of town for some reason as the rest of the city.  The igloos still
 line the streets and residents of these igloos poke thier heads out and look at
 you warily.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1602,7 +1602,7 @@ this part of town for some reason as the rest of the city.  The igloos still
 line the streets and residents of these igloos poke thier heads out and look at
 you warily.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1619,7 +1619,7 @@ this part of town for some reason as the rest of the city.  The igloos still
 line the streets and residents of these igloos poke thier heads out and look at
 you warily.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 1
 D0
 ~
 ~
@@ -1785,7 +1785,7 @@ A Hunting Trail~
 killed to be eaten.  There are eskimo tracks everywhere heading to the east
 were the hunting trail leads on.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D1
 ~
 ~
@@ -1802,7 +1802,7 @@ snow.  Save the very fine foots prints hardly noticeable to the naked eye.  To
 the west is the gate of Rankit and to the south is barren lands of snow and
 ice.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D2
 ~
 ~
@@ -1818,7 +1818,7 @@ A Mud Trail~
 between your toes and is uncomfortably cold.  The trail continues west through
 more mud and back east to dry dirt.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D3
 ~
 ~
@@ -1831,7 +1831,7 @@ begins to freeze.  The mud is becoming harder and a chill wind begins blowing
 from the north and west.  To the east is the warmth of the minotaur city, Dun
 Maura.  To the north is a wasteland of cold.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -1848,7 +1848,7 @@ cold is all that is left.  There seems to be no trace of life anywhere around.
 To the south you must go through the mud and to the north is a sparkeling
 bridge.    
 ~
-43 0 0 0 0 0
+43 0 0 0 0 2
 D0
 ~
 ~
@@ -1865,7 +1865,7 @@ puffs of visible air.  The bridge to the north is madde of ice and the trail
 behind is wet.  The change of climates seems to be very dramatic for such a
 small distance traveled.    
 ~
-43 4 0 0 0 0
+43 4 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/44.wld
+++ b/lib/world/wld/44.wld
@@ -23,7 +23,7 @@ east you see the eastern highway.  The tents are crude, made of thick cloth and
 dyed green to blend in the shades.  Occasionally you hear the sound of a dove
 or a crow.  Oh yes, and of course the clang of sword against shield.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D0
 The clearing continues.
 ~
@@ -37,7 +37,7 @@ planks and rough linen.  They have been dyed green so they blend in the
 surrounding forest.  North the clearing continues, while to the west and east
 are tents.  You can also go south to the eastern highway.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D0
 The clearing continues.
 ~
@@ -91,7 +91,7 @@ bit larger than the rest, suggest which way to go talk to the Boss.  You can
 also enter a smaller tent with dagger symbol over the entrance to your east.  
 North and south the clearing continues.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D0
 The clearing continues.
 ~
@@ -160,7 +160,7 @@ West of you is a small green tent made from crude planks and rough linen, while
 to the south the clearing continues, a wide path cuts into the forest to the
 north.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D0
 ~
 ~
@@ -214,7 +214,7 @@ on the tent, just over the entrance.  To your south you see the side of a crude
 tent with green linen, and a dagger in relief painted on it, while west a
 thicket blocks your way.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D0
 The tent is a dark shade of purple, and is very well hidden in the shade. 
 Near the entrance a small star has been painted with green paint.
@@ -317,7 +317,7 @@ Deep in the forest.~
    It's totally impossible to get any further into the woods.  All around you
 is dense forest, leaving only one direction to travel, namely back south.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D2
 You think you might be able to push through this way.
 ~
@@ -335,7 +335,7 @@ Behind the shubbery.~
 camp.  To your north you might be able to push through the undergrowth and get
 further into the forest, while both south and east the forest is too dense.  
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D0
 You think you might be able to force your way through here.
 ~
@@ -353,7 +353,7 @@ A wide path through the forest~
 clearing, where some creatures can be seen moving between the trees, while to
 the north faint sounds of battle can be heard in the distance.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D0
 ~
 ~
@@ -370,7 +370,7 @@ the eastern and western side.  Small figures moving between the trees can be
 seen to the south, while lound noises of battle fill the air from the north,
 where the great gates of Hannah can be seen in the distance.    
 ~
-44 0 0 0 0 0
+44 0 0 0 0 3
 D2
 ~
 ~

--- a/lib/world/wld/5.wld
+++ b/lib/world/wld/5.wld
@@ -4,7 +4,7 @@ Small Path~
 scenery here is quite beautiful.  You are surrounded by trees and gorgeous
 flowers that make the air smell sweet.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D3
 ~
 ~
@@ -31,7 +31,7 @@ Small Path~
 you will run into.  The trees shade you from the sun, making the temperature
 feel much cooler.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -51,7 +51,7 @@ Farm Entrance~
 powers you and almost knocks you over.  You can see that the farm spreads out
 more to the west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -70,7 +70,7 @@ Small Path~
    The path comes to an end here.  You find yourself standing at the begining
 of the farm.  Where are all the animals?  Maybe they are all hiding.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -86,7 +86,7 @@ Farm Entrance~
 powers you and almost knocks you over.  You can see that the farm spreads out
 more to the west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -110,7 +110,7 @@ Farm Entrance~
 continues.  If you go back to the east, you will be leaving the farm.  Cracked
 corn covers the ground here.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -125,7 +125,7 @@ Farm~
    You're standing at the begining of the farm.  It continues to the east and
 west.  You begin to wonder where the barn is.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -144,7 +144,7 @@ Farm~
    You're standing on the edge of the farm, overlooking a small field.  You see
 several small critters running through the farm.  Maybe you could catch one.  
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -163,7 +163,7 @@ Farm~
    As you step into the farm, you feel your feet sinking into piles of cracked
 corn.  The chickens must not have eaten all of their breakfast.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -182,7 +182,7 @@ Trail~
    You have stepped onto a small trail, heading south.  The entrance to the
 farm is to the northwest.  You can see a large barn to the southwest.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D2
 ~
 ~
@@ -198,7 +198,7 @@ Trail~
 trail.  There isn't much space here to walk.  Just enough for one person.  The
 trail continues to the south.    
 ~
-5 256 0 0 0 0
+5 256 0 0 0 2
 D0
 ~
 ~
@@ -214,7 +214,7 @@ Field~
 making you feel like you're walking through the jungle.  Bugs buzz past your
 ears, tickling them.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -230,7 +230,7 @@ Field~
 a large corn field off to the west.  A large apple tree loaded with ripe apples
 sways in the breeze.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 1
 D0
 ~
 ~
@@ -249,7 +249,7 @@ Field~
    The grass here seems to get somewhat shorter, but not by much.  You can see
 a large corn field off to the west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -264,7 +264,7 @@ Field~
    There is a dead end here.  The weeds are rather high towering over the top
 of your head.  You suddenly feel very lost.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D2
 ~
 ~
@@ -276,7 +276,7 @@ Trail~
 looks to be in pretty good shape.  Maybe it would be worth your time to go have
 a look.    
 ~
-5 256 0 0 0 0
+5 256 0 0 0 2
 D0
 ~
 ~
@@ -419,7 +419,7 @@ Field~
 end?  In the distance to the northwest you can see a corn field.  It looks to
 be rather large.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -434,7 +434,7 @@ Field~
    You find yourself standing at the edge of a corn field.  The corn goes clear
 up to your chin!  How will you ever see in here?    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -525,7 +525,7 @@ Corn Field~
 your feet.  The corn can be seen in the distance to the west.  To the south,
 there is a big red barn.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D2
 ~
 ~
@@ -541,7 +541,7 @@ Corn Field~
 field.  The sound of dead grass fills your ears as it crunches heavily under
 your weight.  The field continues to the west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D2
 ~
 ~
@@ -557,7 +557,7 @@ Corn Field~
 have cut a path through here to make it easier for adventurers like yourself to
 get through here alive.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -573,7 +573,7 @@ Corn Field~
 have cut a path through here to make it easier for adventurers like yourself to
 get through here alive.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -589,7 +589,7 @@ Corn Field~
 fell off from it's post.  Most of the straw has been picked away from its
 fragile little body, most likely by crows.  The field continues to the south.
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -605,7 +605,7 @@ Corn Field~
 field, you spot a barn off in the distance to the southeast.  Maybe you could
 rest there for a bit.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -621,7 +621,7 @@ Corn Field~
 southeast you can see a barn.  It looks to be in excellent condition.  Maybe
 you could stop there for a while and rest.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -637,7 +637,7 @@ Corn Field~
 distance you can see a large barn.  Some noises are coming from within it, most
 likely caused from the animals that live inside.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -653,7 +653,7 @@ Manure Pit~
 around you, tickling your ears.  The manure is up to your knees.  It looks like
 it gets deeper the farther you walk in.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -669,7 +669,7 @@ Manure Pit~
 now covered up to your thighs!  How gross.  Maybe you should get out of here
 before your entire body gets covered.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -686,7 +686,7 @@ The manure is up to your neck and rising quickly.  No one will want to be
 around you for a very long time, unless you can find a place to wash yourself
 off.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -701,7 +701,7 @@ Manure Pit~
    The manure is quite shallow here, enabling you walk.  To the south you see a
 rather large looking stock yard.  Maybe you would have better luck there.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D2
 ~
 ~
@@ -717,7 +717,7 @@ Gates of the Stock Yard~
 animals are before you, most of them either eating or sleeping.  The yard is
 surprisingly clean, of course anything would be compared to the manure pit.  
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -733,7 +733,7 @@ Stock Yard~
 is fenced in with a newly painted fence.  The aroma from the paint is still in
 the air.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -749,7 +749,7 @@ Stock Yard~
 your feet is damp and slightly squishy, most likely caused from the rain.  The
 stock yard continues to the east and west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -765,7 +765,7 @@ Stock Yard~
 like ones of either a goat or a sheep.  The stock yard continues to the east
 and west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -788,7 +788,7 @@ Dead End~
    You have come to a dead end.  The white picket fence is beside you.  You
 stand there for a moment and look at the view of the farm.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D2
 ~
 ~
@@ -799,7 +799,7 @@ Dead End~
    You have come to a dead end.  The white picket fence is beside you.  You
 stand there for a moment and look at the view of the farm.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -811,7 +811,7 @@ Gopher Hole~
 As you bend down, you look into the hole.  You see nothing but blackness.  
 Would it be worth your time to go have a look?    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -830,7 +830,7 @@ Silo~
    A large silo stands before you, most likely used for storing corn.  There is
 a ladder on one of the inside walls.  Maybe you could climb up it.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -909,7 +909,7 @@ Stock Yard~
    You're standing at the edge of the stock yard, looking at a small field to
 the south.  There is a silo to the north.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -925,7 +925,7 @@ Gopher Hole~
 underneath you, what could it be?  You feel your hands sinking into the dirt.
 Hopefully you can get back out.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D4
 ~
 ~
@@ -940,7 +940,7 @@ Gopher Hole~
    You're almost to the bottom of the hole.  The temperature has dropped quite
 a few degrees making you feel cold and damp.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D4
 ~
 ~
@@ -956,7 +956,7 @@ Gopher Hole~
 cold.  You see a small passageway leading to the west.  Where could it be
 going?  Maybe you should go find out.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D3
 ~
 ~
@@ -971,7 +971,7 @@ Gopher Hole~
    As you begin walking through the passageway, you notice how big the gopher
 hole really is.  An entire family must live in here.  But where is everyone?  
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -987,7 +987,7 @@ Gopher Hole~
 pouring down on you, making you feel slightly warmer.  You hear some birds
 singing in the distance.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -1003,7 +1003,7 @@ Stock Yard~
 stables.  You can hear several animals inside shuffling around nervously.  To
 the south there is a large chicken coop.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -1015,7 +1015,7 @@ Stock Yard~
 notice that you're standing at the endge of the stock yard overlooking the
 stables.  The stock yard continues to the west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D3
 ~
 ~
@@ -1030,7 +1030,7 @@ Stock Yard~
    You're standing at the edge of the stock yard.  To the southwest you can see
 the stables.  You can hear the horses inside shuffling around nervously.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -1148,7 +1148,7 @@ Field~
 longer in use.  The ground is very rough and full of small holes.  One might
 fall if they don't watch their step!    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -1164,7 +1164,7 @@ Field~
 you can see a large hole.  It looks big enough to climb in.  But is there
 anything in there waiting for you?    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -1180,7 +1180,7 @@ Field~
 large hole with a black bottom.  Is there even a bottom?  Or just eternal
 darkness?    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -1196,7 +1196,7 @@ Hole~
 darkness.  Would it be worth the risk to climb in there and see whats down
 there?    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -1217,7 +1217,7 @@ alone and lost, almost like a small child.  You look up and see a small beam of
 light.  Can you even get back out of here?  Maybe you should try to "climb up"
 out of the hole.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 S
 T 574
 #575
@@ -1225,7 +1225,7 @@ Field~
    You're standing on the edge of the field.  To the east is a very large hole
 which you could probably fit in.  To the west you see a small chicken coop.  
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -1304,7 +1304,7 @@ Dead End~
 the east.  The chickens are busily running around, probably looking for
 something to eat.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -1332,7 +1332,7 @@ Farm~
 is a dead end to the south, but maybe there is something there that would be
 worth making the trip.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -1354,7 +1354,7 @@ through one of the windows, you see a man inside sitting in a rocking chair.
 He see's you and waves for you to come in.  He looks like a friendly enough
 gentleman.  Perhaps you could get a bite to eat here.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D1
 ~
 ~
@@ -1403,7 +1403,7 @@ Dirt Path~
 the north you can see a small hunters cabin.  Maybe you could go inside and
 rest for a while.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -1419,7 +1419,7 @@ Dirt Path~
 over the years.  You notice some potholes that are big enough for a cat to fit
 into.  Be careful not to fall!  There is a large well to the east.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D0
 ~
 ~
@@ -1435,7 +1435,7 @@ Farm~
 There isn't any water in it, but you could easily climb down into it.  You
 can't see anything past the well, only a small path to the west.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D3
 ~
 ~
@@ -1614,7 +1614,7 @@ Farm~
 seem to have reached the end of the farm.  You breathe in a breath of fresh air
 and feel a sense of accomplishment.    
 ~
-5 0 0 0 0 0
+5 0 0 0 0 2
 D5
 ~
 ~

--- a/lib/world/wld/50.wld
+++ b/lib/world/wld/50.wld
@@ -9,7 +9,7 @@ A Long Tunnel~
    You encounter some rapids as you enter this tunnel cut out of
 the mountains by the river.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 7
 D1
 ~
 ~
@@ -25,7 +25,7 @@ S
 A Long Tunnel~
    The tunnel branches off north.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 7
 D0
 ~
 ~
@@ -43,7 +43,7 @@ S
 A Long Tunnel~
    The tunnel branches off south.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 7
 D1
 ~
 ~
@@ -61,7 +61,7 @@ S
 A Tunnel Intersection~
    The tunnel branches off to the north and south.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 7
 D0
 ~
 ~
@@ -86,7 +86,7 @@ water and lime from above.  The tunnel continues to the east and the
 river leads back west.  Leading upwards to the northwest is a roughly
 hewn hallway.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 7
 D0
 ~
 ~
@@ -109,7 +109,7 @@ A Long Narrow Tunnel~
    The tunnel rises sharply to the east.  Another narrow tunnel
 leads away to the north.
 ~
-50 265 0 0 0 0
+50 265 0 0 0 5
 D0
 ~
 ~
@@ -128,7 +128,7 @@ A Wide Tunnel~
    The tunnel continues east and west.  To the east the tunnel dives
 down into a bright light.  A small passage way opens to the north.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D1
 ~
 ~
@@ -143,7 +143,7 @@ The Cave-In~
    You stand at the edge of a large pile of rubble created from the last
 rockslide.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D2
 ~
 ~
@@ -159,7 +159,7 @@ At The Foot Of The Rubble~
    You are at the bottom of a large pile of rubble.  A tunnel branches
 off to the north and east.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 ~
 ~
@@ -178,7 +178,7 @@ A Cave Entrance~
    You stand in the middle of a large and beautiful cave.  A path leads
 deeper into the darkness.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D2
 ~
 ~
@@ -195,7 +195,7 @@ A Giant Cave~
 Bones of previous adventurers lie strewn on the cavern floor.  There is
 a passage that spirals downwards in the northeast corner of the cavern.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D4
 ~
 ~
@@ -210,7 +210,7 @@ S
 A Narrow Bend~
    The tunnel turns to the south and west.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D2
 ~
 ~
@@ -224,7 +224,7 @@ S
 A Large Cave~
    You are standing in a large cave.  Many furs are spread out on the floor.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 ~
 ~
@@ -238,7 +238,7 @@ S
 A Damp Hallway~
    The walls here are extremely damp, as well as the floor.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D1
 You hear drops of water.
 ~
@@ -253,7 +253,7 @@ S
 An Underground Pool~
    You are wading in a knee deep pool of lime-water.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 6
 D1
 ~
 ~
@@ -268,7 +268,7 @@ A Damp Hallway~
    The walls of the tunnel are extremely damp here.  The tunnel
 leads sharply upwards to the south as it starts to get narrow.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D2
 ~
 ~
@@ -284,7 +284,7 @@ A Narrow Crawlway~
    This crawlway is just big enough for a human to crawl through or a
 halfling to walk through.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 ~
 ~
@@ -304,7 +304,7 @@ A Large Cavern~
    You have entered a very large cavern.  The rock formations would amaze
 almost any dwarf.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 ~
 ~
@@ -319,7 +319,7 @@ A Fungus Patch~
    As you walk through the fungus patch, you are shot at by many millions of
 spores.  You can hardly breathe.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 ~
 ~
@@ -335,7 +335,7 @@ The Fungus Path~
    As you walk along the path, millions of spores are shot at you.  It is
 difficult to breathe.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D2
 A giant mushroom temple stands to the south.
 ~
@@ -352,7 +352,7 @@ The Fungus Temple~
    You find yourself standing inside of a giant mushroom.  The inside
 is decorated in the fashion of a temple.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 ~
 ~
@@ -366,7 +366,7 @@ S
 A Sloping Passage~
    You follow a path sloping down from the fungus temple.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 ~
 ~
@@ -380,7 +380,7 @@ S
 A Sloping Passage~
    You are on a path that gently slopes up from the underground pool.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D0
 You hear sounds of trickling water.
 ~
@@ -397,7 +397,7 @@ The Great Eastern Desert~
 you.  A pyramid lies to the east and a snow-capped mountain range to the 
 west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -420,7 +420,7 @@ The Great Eastern Desert~
 you.  A pyramid lies to the east and a snow-capped mountain range to the 
 west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -443,7 +443,7 @@ The Great Eastern Desert~
 you.  A pyramid lies to the east and a snow-capped mountain range to the
 west.  The hole which you tumbled out of is too high for you to reach.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -466,7 +466,7 @@ The Great Eastern Desert~
 you.  A pyramid lies to the east and a snow-capped mountain range to the
 west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -490,7 +490,7 @@ you.  A pyramid lies to the north-east and a snow-capped mountain range to
 the west.  You spy a narrow dirt trail leading away to the west into the
 foothills.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -519,7 +519,7 @@ The Great Eastern Desert~
 you.  A pyramid lies to the north-east and a snow-capped mountain range to
 the west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -542,7 +542,7 @@ A Small Oasis~
 shade of a few scarce palm trees.  To the north you see a small
 encampment stopped for the day.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 You see three tents and some camels hitched to a stake.  Shadows moving 
 across the tents suggest activity.
@@ -570,7 +570,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -597,7 +597,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -624,7 +624,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north-east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -651,7 +651,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the south-east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -678,7 +678,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the east, it looks enormous, even from this distance.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -706,7 +706,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north-east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -733,7 +733,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north-east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -760,7 +760,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the south.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -788,7 +788,7 @@ The Great Eastern Desert~
 around you.  A pyramid lies to the south.  The gates of a city lie a
 short distance off to the north.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Some city gates stand off to the north.
 ~
@@ -817,7 +817,7 @@ you.  You are standing near a gigantic pyramid located a couple hundred
 meters west of you.  From here you can sense the great evil which resides
 within the massive structure.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -844,7 +844,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Even from here, you can sense a great evil residing within the pyramid
 protruding from the sand to the north.
@@ -872,7 +872,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -899,7 +899,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -926,7 +926,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north and a ruined city to the west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -953,7 +953,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the south.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -980,7 +980,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the south-west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1007,7 +1007,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1035,7 +1035,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1062,7 +1062,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north-west.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1089,7 +1089,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see... and a pyramid in the distance.
 ~
@@ -1116,7 +1116,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the south-west and a deep canyon to the east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1139,7 +1139,7 @@ The Great Eastern Desert~
 you.  A pyramid lies to the south-west and a deep canyon to the east.  Just
 below you can make out a tiny ledge.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1165,7 +1165,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the west and a deep canyon to the east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1192,7 +1192,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the west and a deep canyon to the east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1214,7 +1214,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around  
 you.  A pyramid lies to the north-west and a deep canyon to the east.
 ~
-50 0 0 0 0 0
+50 0 0 0 0 2
 D0
 Sand as far as the eye can see.
 ~
@@ -1238,7 +1238,7 @@ and refresh themselves beside this beautiful oasis.  Three tents and some
 camels make up the party.  From within two of the tents you hear muffled
 voices, obviously surprised at your visit.
 ~
-50 64 0 0 0 0
+50 64 0 0 0 2
 D0
 Some camels are tied up to a mass of stakes plugged into the ground.
 ~
@@ -1266,7 +1266,7 @@ Inside A Small Tent~
 here and there are young-looking men and women, possibly slaves to the
 leader of this band.
 ~
-50 72 0 0 0 0
+50 72 0 0 0 2
 D3
 You see the center of the nomad camp.
 ~
@@ -1279,7 +1279,7 @@ Beside The Camels~
 the ground.  To the east you see a small tent while to the north you see a 
 larger, fancier tent.
 ~
-50 64 0 0 0 0
+50 64 0 0 0 2
 D0
 This tent seems to be the temporary abode of the nomad leader.  You make a
 mental note to visit it before you leave.
@@ -1307,7 +1307,7 @@ The Warriors' Tent~
    This tent has a few furnishings, but mainly it holds the band's 
 protectors.  They all stare at you coldly as you enter.
 ~
-50 72 0 0 0 0
+50 72 0 0 0 2
 D3
 Outside you see some peaceful camels.
 ~
@@ -1320,7 +1320,7 @@ The Main Tent~
 outside.  A fancy carpet lies on the sand and numerous baskets line the
 walls.
 ~
-50 72 0 0 0 0
+50 72 0 0 0 2
 D1
 ~
 ~
@@ -1337,7 +1337,7 @@ The Main Tent~
 definitely rich as you inspect the tapestries, baskets, and a few
 paintings as well.
 ~
-50 72 0 0 0 0
+50 72 0 0 0 2
 D3
 You see the entrance to this tent.
 ~
@@ -1353,7 +1353,7 @@ breaks and you fall...
                                and fall
                                     ... to your death on the rocks below.
 ~
-50 12 0 0 0 0
+50 12 0 0 0 5
 D3
 ~
 ~
@@ -1384,7 +1384,7 @@ The Cave Mouth~
 strange sounds, but can see nothing.  The cave slopes down into the 
 darkness.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D1
 Outside is lighter and very windy.
 ~
@@ -1402,7 +1402,7 @@ haphazardly strewn about and the rotting carcasses, you would guess
 that this is a dragon's lair.  As to what type, you can't really say.
 The cave narrows out into a tunnel to the west.
 ~
-50 201 0 0 0 0
+50 201 0 0 0 5
 D1
 ~
 ~
@@ -1417,7 +1417,7 @@ A Wide Tunnel~
    This tunnel seems to go on forever into the darkness.  You carefully
 feel your way along the walls.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D1
 ~
 ~
@@ -1432,7 +1432,7 @@ A Narrower Tunnel~
    The tunnel becomes very narrow and you fight to squeeze your way through.
 The floor seems to level off a little.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D1
 ~
 ~
@@ -1447,7 +1447,7 @@ A Narrow Crack~
    This part of the tunnel is the hardest to move through as the walls
 move in to meet you.
 ~
-50 265 0 0 0 0
+50 265 0 0 0 5
 D0
 ~
 ~
@@ -1462,7 +1462,7 @@ A Small Cavern~
    It is dark and damp and bats hang from the ceiling.  A narrow crack is
 in the east wall.  The floor now slopes upwards.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D1
 ~
 ~
@@ -1477,7 +1477,7 @@ A Small Shaft~
    From within this shaft you can see a narrow hole in the roof just
 large enough for one person.  Back east is the cavern.
 ~
-50 9 0 0 0 0
+50 9 0 0 0 5
 D1
 ~
 ~

--- a/lib/world/wld/52.wld
+++ b/lib/world/wld/52.wld
@@ -5,7 +5,7 @@ steel gates have been forced open and have rusted in place.  A hollow
 gust of wind blows by you into the deserted, and seemingly destroyed,
 city.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D1
 The desert sands stretch on for miles and miles.
 ~
@@ -25,7 +25,7 @@ streets are barren and windswept and the silence is unending.  To the south
 you see a ruined cottage while north leads into a dark back alley.  Howls
 and screams echo through the deserted city.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 It seems to be a dark alley.
 ~
@@ -55,7 +55,7 @@ side is a collapsed house while on the other is the entrance to a large
 ruined mansion.  Eerie sounds echo within the mansion.  Near the center of 
 town you see a large domed building, relatively intact.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 The remnants of a store lie this way.
 ~
@@ -83,7 +83,7 @@ of the city.  Flowers have withered away and the once lush trees are bare.
 Vines and ivy snake up the sides of the temple and entangle themselves
 around your feet.  A sudden volley of howls pierces the air.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 The garden path continues around the building.
 ~
@@ -113,7 +113,7 @@ of the city.  Flowers have withered away and the once lush trees are bare.
 Vines and ivy snake up the sides of the temple and entangle themselves
 around your feet.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 A side street leads of to the northern half of the city.
 ~
@@ -143,7 +143,7 @@ of the city.  Flowers have withered away and the once lush trees are bare.
 Vines and ivy creep up the sides of the temple and entangle themselves 
 around your feet.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 The garden path continues around the building.
 ~
@@ -173,7 +173,7 @@ of the city.  Flowers have withered away and the once lush trees are bare.
 Vines and ivy creep up the sides of the temple and entangle themselves 
 around your feet.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 Inside the temple, small patches of light shoot through each doorway as
 well as a few cracks in the ceiling.
@@ -203,7 +203,7 @@ baskets, carts, and stands of all shapes and sizes.  Abandoned, these
 little shops still contain some of their goods once sold to a demanding
 public.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 A small table has been toppled over, spilling fine jewellery and gems
 onto the ground.
@@ -232,7 +232,7 @@ The Market Place~
    You stand at the end of the market square.  Stands and carts line
 each side, filled with remnants of fine foods and exquisite goods.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 Tattered carpets and ruined bales of silk sit idly by a run down stand.
 ~
@@ -256,7 +256,7 @@ A Side Street~
 to the south you see the temple.  The incessant howling tears at your
 mind.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D1
 ~
 ~
@@ -278,7 +278,7 @@ nothing but piles of rubble, but some look almost safe enough to venture
 into.
    The street continues north and south and buildings line the street.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -304,7 +304,7 @@ A Side Street~
 Around you stand large piles or rubble where the houses of commoners
 used to be.  A lone howl makes you worry greatly about your safety here.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -333,7 +333,7 @@ biased; these important looking buildings have been almost totally
 destroyed.  There is a hole in the wall of a very large structure to the
 east.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 A small garden path encircles the temple.
 ~
@@ -362,7 +362,7 @@ buildings.  To the west is a dark, foreboding structure while to the
 east lies the entrance to a small tavern.  The street continues north
 and south.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -390,7 +390,7 @@ A Side Street~
    You are at the end of a long street leading to the center of the city.
 A long dark alley runs east and west.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -409,7 +409,7 @@ Under A Ruined Watchtower~
    You stand at the base of a tall watchtower built to protect the city
 from invaders.  From the looks of things, it did not do a good job.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -428,7 +428,7 @@ A Back Alley~
    This alley leads to the rear of what used to be a meat stand.  You wince
 at the stench.  South is one of the city watchtowers.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 You see the back-side of the market place meat stand.
 ~
@@ -447,7 +447,7 @@ in the background.  Hanging on the hooks are very small scraps of meat
 and other game.  This stand is relatively empty, and a sudden burst of
 howling and screaming makes you realize why this is so.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 The market place lies this way.
 ~
@@ -468,7 +468,7 @@ A Back Alley~
    A narrow alley leads east to a wider street and west to one of 
 the city watchtowers.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D1
 A small side street greets you.
 ~
@@ -488,7 +488,7 @@ the floor as if some massive battle had taken place here.  Draped along
 the back wall is a tattered, jet-black banner with the symbol of the
 Darkside set upon it.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D1
 A small side street runs past the building.
 ~
@@ -501,7 +501,7 @@ The Produce Stand~
 swarm all about what seems to be the last remaining bits of food left
 in the city.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 The market place is deserted.
 ~
@@ -519,7 +519,7 @@ The Smithy~
 and items.  The walls have been stripped clean and only a few incomplete
 pieces of armor and weaponry are left.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D1
 A small side street runs past the building.
 ~
@@ -533,7 +533,7 @@ robes and various articles of clothing are now just rags.  You stare at
 the strange piles for a long time until a piercing howl makes you
 think these might be beds.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -554,7 +554,7 @@ A Back Alley~
    A narrow alley leads north to one of the city watchtowers while
 to the south there lies a market stand full of torn clothes and rugs.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 A tall watchtower stands a silent vigil over the city.
 ~
@@ -570,7 +570,7 @@ Under The Watchtower~
    You stand under one of the city watchtowers built to protect
 the city from invaders.  Obviously, it failed.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D1
 ~
 ~
@@ -591,7 +591,7 @@ The Jewellery Stand~
 across the market place.  Most of these trinkets are battered and 
 tarnished and few would have any value anymore.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D2
 The market place is deserted.
 ~
@@ -609,7 +609,7 @@ A Ruined Clay Dwelling~
 and a bed.  A cold fireplace suggests that the city has been abandoned
 for quite a while.  Almost nothing remains of this humble abode.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D1
 Outside is a small side street.
 ~
@@ -622,7 +622,7 @@ A Collapsed Stone Dwelling~
 of debris here and there.  A few rafters still stand with thatched straw
 hanging down and a hot wind gusts through the hollow dwelling.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D1
 A small side street runs past the house.
 ~
@@ -634,7 +634,7 @@ A Back Alley~
    A narrow alley leads west to one of the city watchtowers and east to
 a small side street.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D1
 ~
 ~
@@ -651,7 +651,7 @@ but inside these cramped quarters you discover what used to be a shop
 filled with armor, weapons, and various other goods.  A small sign
 flutters in the wind.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D3
 A small side street runs past the shop.
 ~
@@ -667,7 +667,7 @@ belongings lie under the rubble, but the people they once belonged to are
 not with them.  Looking up you see that the entire second floor and roof 
 has fallen in, leaving a gaping hole above.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D3
 A small side street runs past the tavern.
 ~
@@ -682,7 +682,7 @@ and most of the valuable items have been taken, leaving worthless debris.
 A few chairs have survived, as well as a large curved desk.  To the east
 is a vine-covered archway leading out into a private courtyard.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D0
 The long hallway leads back to the main reception area of the city hall.
 ~
@@ -701,7 +701,7 @@ A large gaping hole in the west wall allows you to see out to one of
 the city's side streets.  Obviously no one will be seeing you through today.  
 Hallways lead south and east.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D0
 Main street runs past the city hall.
 ~
@@ -730,7 +730,7 @@ but fancy, though.  The only thing remaining intact here is a large
 glass cabinet.  A long hallway leads west back to the reception area and
 an ivy-covered archway leads south into a private courtyard.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D2
 ~
 ~
@@ -750,7 +750,7 @@ courtyard still stands, though, defying any attempts to destroy its
 beauty.  Above stands the remnants of one of the watchtowers.  Archways 
 north and west lead back into the city hall.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -766,7 +766,7 @@ A Small Guard House~
 shell, this small shack still stands guarding the entrance both to the
 city and to the city hall.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D0
 Main street runs by this building.
 ~
@@ -779,7 +779,7 @@ A Collapsed Home~
 and a very large blast crater.  Obviously someone or something important 
 was once housed here.  A shrieking howl chills your blood.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D2
 Main street runs past this ruined home.
 ~
@@ -795,7 +795,7 @@ entrance into another building through yet another collapsed wall.
 Between the two buildings are a few blast craters and boulders.  An old
 set of wooden steps leads up to a creaking second floor.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D1
 ~
 ~
@@ -820,7 +820,7 @@ find broken shelves and workbenches with various vials and pouches spilling
 contents all across the floor.  This was possibly the magic shop of the
 city.  The doorway to the east is blocked, making the only exit back west.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D3
 ~
 ~
@@ -831,7 +831,7 @@ A Back Alley~
    A narrow back alley goes south to main street and north towards
 a watchtower.  A mass of howls catches you of guard.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 ~
 ~
@@ -848,7 +848,7 @@ A Back Alley~
 and south towards main street.  To the west is a doorway to a small
 house blocked by debris.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D0
 A tall watchtower stands a silent vigil over the city.
 ~
@@ -865,7 +865,7 @@ Under A Watchtower~
 south and a very weak looking ladder leads up into the tower.  Above you,
 you hear the screams of tens of starving lamias!  Beware!
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D2
 ~
 ~
@@ -891,7 +891,7 @@ yields a dead body floating around in it, skin melted away from months
 of floating in there.  The west wall has collapsed revealing another
 collapsed house.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D0
 ~
 ~
@@ -909,7 +909,7 @@ A Back Alley~
 of the city watchtowers.  Great amounts of steam issue forth from the
 building to the south.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D1
 A watchtower stands a silent vigil over the city.
 ~
@@ -932,7 +932,7 @@ Except for the massive hole in the east wall, everything else looks
 intact, including the windows.  Great amounts of steam issue forth from
 the hole in the east wall.
 ~
-52 8 0 0 0 0
+52 8 0 0 0 1
 D1
 ~
 ~
@@ -949,7 +949,7 @@ On The Second Floor~
 The old rotted floorboards suddenly give way and you fall down, impaling
 yourself on jagged boards below.
 ~
-52 12 0 0 0 0
+52 12 0 0 0 1
 S
 T 5200
 #5246
@@ -958,7 +958,7 @@ The North-West Watchtower~
 from here and you can see all the way to the western mountains.  No wonder
 this place stood for so long.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D5
 The city lies below.
 ~
@@ -972,7 +972,7 @@ from here and you can see all the way to the western mountains.  To the
 south the desert stretches to the horizon.  No wonder this place stood
 for so long.
 ~
-52 0 0 0 0 0
+52 0 0 0 0 1
 D5
 The city lies below.
 ~
@@ -986,7 +986,7 @@ from here and you the desert sand stretches to the horizon.  No wonder
 this place stood for so long.  The ladder leading down seems rotted in
 some places!
 ~
-52 4 0 0 0 0
+52 4 0 0 0 1
 D5
 The city lies below... far, far below.
 ~
@@ -998,7 +998,7 @@ Under A Watchtower~
    As you descend the ladder, the rotted rungs break, sending you quickly to
 your demise far below.  Splat.  
 ~
-52 12 0 0 0 0
+52 12 0 0 0 1
 S
 T 5200
 #5250
@@ -1013,7 +1013,7 @@ strange tongue.
      Wind gusts through the four archways and howls and screams can be
 heard from all parts of the city.
 ~
-52 140 0 0 0 0
+52 140 0 0 0 1
 D0
 A side street leads to the northern half of the city.
 ~

--- a/lib/world/wld/53.wld
+++ b/lib/world/wld/53.wld
@@ -3,7 +3,7 @@ The Great Eastern Desert~
    A vast desert stretches for miles, the sands constantly shifting around
 you.  Rising out of the sand to the north you see a mighty pyramid.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 2
 D0
 The sands of the desert continue onward towards the pyramid.
 ~
@@ -36,7 +36,7 @@ from huge blocks of stone that have been coated over with a rough sandy
 plaster-like substance.  The face of the pyramid is steep, but you think
 you might be able to climb it.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 2
 D2
 Sand as far as the eye can see.
 ~
@@ -188,7 +188,7 @@ pyramid.  The four sides of the pyramid slope sharply down into the
 hot sands in all four cardinal directions.
 A plaque has been set into the sandy stones beneath your feet.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 1
 D0
 The north side of the pyramid slopes down into the sands.
 It looks really dangerous.  I wouldn't go that way.
@@ -339,7 +339,7 @@ The Chamber Of The Efreet~
 Here the flames are nearly as high as your head, singeing your face and 
 evaporating your sweat instantaneously.
 ~
-53 8 0 0 0 0
+53 8 0 0 0 7
 D1
 The pool of fire ends to the east.
 ~
@@ -1240,7 +1240,7 @@ small hole where the stones of the pyramid have collapsed.  Not
 far to the south is a massive roiling sandstorm; the wind from the
 storm howls and bites at your face even here.
 ~
-53 4 0 0 0 0
+53 4 0 0 0 2
 D0
 You see a small hole leading back into the pyramid.
 ~
@@ -1262,7 +1262,7 @@ A Swirling Sandstorm~
 buffet you from all sides, and the sand tears at your skin, blinding
 you and choking you.  You have lost all sense of direction.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 2
 D0
 You see only a wall of whirling, blowing, dry sand.
 ~
@@ -1295,7 +1295,7 @@ A Swirling Sandstorm~
 buffet you from all sides, and the sand tears at your skin, blinding
 you and choking you.  You have lost all sense of direction.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 2
 D0
 You see only a wall of whirling, blowing, dry sand.
 ~
@@ -1328,7 +1328,7 @@ A Swirling Sandstorm~
 buffet you from all sides, and the sand tears at your skin, blinding
 you and choking you.  You have lost all sense of direction.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 2
 D0
 You see only a wall of whirling, blowing, dry sand.
 ~
@@ -1361,7 +1361,7 @@ A Swirling Sandstorm~
 buffet you from all sides, and the sand tears at your skin, blinding
 you and choking you.  You have lost all sense of direction.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 2
 D0
 You see only a wall of whirling, blowing, dry sand.
 ~
@@ -1396,7 +1396,7 @@ storm to the north of you, and presumably the pyramid is somewhere
 beyond it.  Nothing but flat, featureless, open dunes of sand lie in
 every other direction.
 ~
-53 0 0 0 0 0
+53 0 0 0 0 2
 D0
 You see only a wall of whirling, blowing, dry sand.
 ~

--- a/lib/world/wld/54.wld
+++ b/lib/world/wld/54.wld
@@ -66,7 +66,7 @@ People walk to and fro carrying on their day to day business.  The
 Common Square of the people opens up to the south and the Medina
 continues north.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 You see Medina.
 ~
@@ -86,7 +86,7 @@ other such riff-raff wander about hoping to catch those few who
 with open hearts.  The Medina continues to the south and the
 Market Square spreads out to the north.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 You see Market Square.
 ~
@@ -106,7 +106,7 @@ The only hope of making any sense of what is going on here is to wander
 around.  Market Square continues north, west, and east, with the Medina
 trailing off th the south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -130,7 +130,7 @@ The Center Of Market Square~
 of New Thalos.  A large, peculiar looking statue is standing in the
 middle of the square.  The square extends in every direction.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -161,7 +161,7 @@ tower over you.  It is easy to understand why they hang out here once you
 notice the weapon shop and the armoury close by.  Perhaps you might stop
 in and take a look at the wares these shops have to offer.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -187,7 +187,7 @@ South you see the bread stand and west is the entrance to the general
 store.
    The market's sprawl continues east and north of here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -216,7 +216,7 @@ business in the northern end.
    West Main street begins here and heads for the gate, the market's 
 expanse fills the other directions.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -242,7 +242,7 @@ as it passes through the city.  Ishtar drive heads east and west from here
 and the Medina is to the north.  South lies the River Ishtar Bridge and the
 southern gate.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 You see the medina.
 ~
@@ -271,7 +271,7 @@ desert.
    To the south lies the desert and the city of New Thalos is
 to the north.
 ~
-54 4 0 0 0 0
+54 4 0 0 0 1
 D0
 ~
 gate~
@@ -287,7 +287,7 @@ The Southern Bridge~
 Ishtar.  To the south you see the Southern Gate of New Thalos and
 the Common Square stretches out to the north
 ~
-54 4 0 0 0 0
+54 4 0 0 0 1
 D0
 ~
 ~
@@ -309,7 +309,7 @@ of New Thalos.  The makers of the city spared no expense in rebuilding
 the defenses or their home.  The River Ishtar bridge lies to the north
 and the desert to the south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -326,7 +326,7 @@ in New Thalos.  To the north lies the humble store of the merchant
 Ahkeem, his weavings known to be the best in the city.  West of here
 is the entrance to the First Royal Bank of New Thalos.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -350,7 +350,7 @@ Northern Market Square~
 lies the Palace of New Thalos and the Casbah, east west and south of here
 the busy market thrives with life.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -376,7 +376,7 @@ quiet enough so you have to assume the noise comes from the Butchery.
 You have to think for a while before you muster the will to enter this
 shop.  The market continues to the south and west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -401,7 +401,7 @@ market is the hub of the city, all trade and commerce of any significance
 is carried on here.  The market spreads out in all directions save east,
 here Main Street heads for the easter gate.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -425,7 +425,7 @@ Sultan's Walk~
 will take you by the Palace and the Dancing Daemon Inn, and south will put
 you on Market Square.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -443,7 +443,7 @@ small window into the Daemon, seeing many people dancing and drinking.
 After you tend to your other chores you plan on visiting the Daemon.
    The walk continues north and south from here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -461,7 +461,7 @@ hear the faint sound of trumpets announcing the arrival of some duke or
 duchess to the Palace.  Safe haven awaits you to the east in the halls
 of the Daemon, and Sultan's Walk continues north and south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -486,7 +486,7 @@ by the walls of the Palace and the Daemon.  To the north you see
 the heavily guarded gate and can make out faint sounds of trade
 to the south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -505,7 +505,7 @@ in rebuilding the defenses of their home.
    Sultan's Walk runs to the south and the Casbah stretches out east
 and west.  To the north is wilderness.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 gate~
@@ -533,7 +533,7 @@ of this city spared no expense in protecting their home.
 beckons from the west.  To the south lies the entrance the Warriors'
 Guild.
 ~
-54 4 0 0 0 0
+54 4 0 0 0 1
 D1
 ~
 ~
@@ -553,7 +553,7 @@ West Main Street~
 hear the hammering of the repair shop and to the north is the grassy
 field known as Temple Square.  Main street continues east and west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -578,7 +578,7 @@ fixing a pothole.  The road here branches off north and south into
 two alleys behind the stores of the market.  The main street continues
 east and west from here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -604,7 +604,7 @@ commerce taking place.  The air is filled with the smell of gold and
 riches.
 On the wall of the store is a poster.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -625,7 +625,7 @@ East Main Street~
 and, hear the pounding of new metal from the armory.  The Square is
 to the west and a junction is to the East.  
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -642,7 +642,7 @@ of Guildsman Row.  To the South is a dark alley.  The road also
 continues to the East.
 There is a small sign on a wire hanging across the junction.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -678,7 +678,7 @@ you see the open doors of the apothecary shop where one may buy many
 magical livations.
    Main Street continues east and west from here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -702,7 +702,7 @@ East Main Street~
 westward towards the marketplace.  One of the main gates can be seen
 to the east and Braheem's Magic Shop awaits your business to the north.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -726,7 +726,7 @@ of this city spared no expense in protecting their home.
 beckons from the east.  To the north lies the entrance to the Mages'
 Guild.
 ~
-54 4 0 0 0 0
+54 4 0 0 0 1
 D0
 ~
 ~
@@ -759,7 +759,7 @@ and forth from the docks to the warehouse carrying large crates loading
 and unloading the boats as they sail down the river.  To the north is
 one of the entrances of the warehouse and West Ishtar leads east.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -776,7 +776,7 @@ their business of loading and unloading the boats.  An entrance to one
 of the huge warehouses of New Thalos is to the north and the River Ishtar 
 quietly flows by to the south.  Ishtar Drive continues east and west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -797,7 +797,7 @@ the boat ramp.  Catching your balance as you start to slide on the slick
 pavement you grab on to the handrail someone has conveniently placed here.
    To the north is the Shipwright and Ishtar Drive continues east and west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -822,7 +822,7 @@ present on your skin.  Orders and sometimes curses can be heard from
 the west in the direction of the warehouses.  The common square opens
 up to the east and Ishtar Drive continues west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -840,7 +840,7 @@ to you with big eyes and, as you return his gaze, runs off down the road.
    The common square can be seen to the west and Ishtar Drive continues
 to the east.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -860,7 +860,7 @@ East Ishtar Drive~
 here, bordered only by the hay-loft to the north and the River Ishtar to
 the south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -877,7 +877,7 @@ that you have reached the stables.  Arabian stallions as well as many
 other  fine breeds of horses can be purchased for a price.  Ishtar Drive
 continues east and west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -898,7 +898,7 @@ that begins here and heads north.  Sounds of loud drunken folk and
 the occasional screaming cat emenate from the direction.  Luckily
 you have the choice of going east or west down the drive as well.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 You see murky darkness.
 ~
@@ -921,7 +921,7 @@ and wide selection of aquarian delicacies you wonder how much longer
 you can endure the smell!  The River Ishtar flows alongside to the
 south with the drive running along side it east to west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -942,7 +942,7 @@ a hint of your location.  The River Ishtar flows south of you, but looks
 crystal clear, so it cannot be the source of this putrid smell.
 Looking north you notice a small sign hanging over the dump.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -965,7 +965,7 @@ Ishtar.  Boats are moored to the docks here awaiting their masters to
 return from the warehouses and the pubs.  The waters of the River Ishtar
 lap at your feet to the south and Ishtar Drive is to the north.
 ~
-54 4 0 0 0 0
+54 4 0 0 0 1
 D0
 ~
 ~
@@ -982,7 +982,7 @@ jailhouse of New Thalos.  Hopefully you won't ever see this structure from
 the inside.  The northwest tower stands here with a spiral staircase 
 leading up.  The Avenue ends here, only exiting to the east.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1005,7 +1005,7 @@ marble stairs rise towards the entrance of city hall surrounded by
 massive white pillars.
    The Avenue continues east and west from here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1026,7 +1026,7 @@ along it in that direction.  West of here you see the steps of the City
 Hall and notice the increase in the number of guards.
    To the east the Avenue continues.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1046,7 +1046,7 @@ The Casbah~
 at the guards walking along the wall keeping watch.  South of you stands
 the great walls of the Palace and the Avenue goes east and west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1061,7 +1061,7 @@ The Casbah~
    The cobblestone pavement runs along the north wall here.  South of you
 stand the great walls of the Palace and the Avenue goes east and west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1078,7 +1078,7 @@ to and fro with stern intent, and older gentleman swagger down the street
 towards the Library.  To the west you can see the tall towers of the
 northern gate, and the Avenue continues east.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1096,7 +1096,7 @@ stone and look up to see a large, strong guard looking out to the north.
    To the east lies the intersection on Guildsman's Row and the northern
 gate is a short walk to the west.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1114,7 +1114,7 @@ and the smoke rising from the smithy all rush up to greet you.
   The Avenue continues east and west from here and the Row leads
 south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1135,7 +1135,7 @@ Masons' Guild.  Young children with their nannies walk around enjoying
 the saftey of the city.
    The Avenue runs east and west from here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1154,7 +1154,7 @@ few old men hobbling on canes and young men intent on studies are
 the only travelers of the path to the library on a regular basis.
    The Avenue continues east and west from here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D1
 ~
 ~
@@ -1171,7 +1171,7 @@ that direction will take you to the Library and the grand dance hall of
 the city.
    The northeast tower of the wall is accessible here up a spiral staircase.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D2
 ~
 ~
@@ -1192,7 +1192,7 @@ can be entered through the door to the west and the Casbah begins its
 journey a little ways north of here.  The Row and the entrance to the
 dancehall is to the south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1213,7 +1213,7 @@ hall of New Thalos.
    The entrance to the hall is to the west and the Row continues
 northward.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1227,7 +1227,7 @@ S
 Underground~
    The small passage continues north and south.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D0
 ~
 ~
@@ -1242,7 +1242,7 @@ Alley~
    This is a dark alley running between the Palace and City Hall.  Not a
 lot here, unless you're partial to spiders and rats.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1256,7 +1256,7 @@ S
 Alley~
    The alley ends here.
 ~
-54 1 0 0 0 0
+54 1 0 0 0 1
 D0
 ~
 ~
@@ -1276,7 +1276,7 @@ are made.  Along this particular stretch of the row lie the Boyer/
 Fletcher to the west and the Masons' to the east.
    The Row leads off to the south and East Casbah is to the north.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1300,7 +1300,7 @@ Guildsman's Row~
 to the east stands the Craftsmans' Guild.  The row of guilds continues
 north and south from here.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1325,7 +1325,7 @@ Guild, to the west.  To the east is a beautifully sculpted marble door
 allowing entrance to the Museum of the Greater Gods.
    The Row of Guilds leads north and south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1350,7 +1350,7 @@ extra space to erect a shrine to their patron saints.  The result of
 this labor became the Museum of the Greater Gods.
    You may enter the sacred hall to the east.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1371,7 +1371,7 @@ guilds run merchandise from the guildhouses to the shops on Market
 Square.
    The guildhouses lie to the north and Main street is to the south.
 ~
-54 0 0 0 0 0
+54 0 0 0 0 1
 D0
 ~
 ~
@@ -1386,7 +1386,7 @@ Alley~
    Even with your light you cannot seem to penetrate the magical cloak of
 darkness covering this alley.
 ~
-54 5 0 0 0 0
+54 5 0 0 0 1
 D0
 ~
 ~
@@ -1401,7 +1401,7 @@ Alley~
    Even with your light you cannot seem to penetrate the magical cloak of
 darkness covering this alley.
 ~
-54 1 0 0 0 0
+54 1 0 0 0 1
 D0
 ~
 ~
@@ -1420,7 +1420,7 @@ Alley~
    Even with your light you cannot seem to penetrate the magical cloak of
 darkness covering this alley.
 ~
-54 1 0 0 0 0
+54 1 0 0 0 1
 D1
 ~
 ~
@@ -1439,7 +1439,7 @@ Alley~
    Even with your light you cannot seem to penetrate the magical cloak of
 darkness covering this alley.
 ~
-54 5 0 0 0 0
+54 5 0 0 0 1
 D0
 ~
 ~
@@ -1454,7 +1454,7 @@ Alley~
    This is a tiny corner in the alley.  The temple walls are north and
 west.  You notice a fair amount of footprints to the east.
 ~
-54 1 0 0 0 0
+54 1 0 0 0 1
 D1
 ~
 ~
@@ -1473,7 +1473,7 @@ Alley~
    This is a dead end to the tiny alley.  There is an unusual amount of
 wear apparent on the ground.
 ~
-54 1 0 0 0 0
+54 1 0 0 0 1
 D3
 ~
 ~
@@ -1490,7 +1490,7 @@ Alley~
 some shouting and general roadwork to the south.  The ground is rough
 and in need of repair.  In the road is a small pothole.
 ~
-54 5 0 0 0 0
+54 5 0 0 0 1
 D0
 ~
 ~
@@ -1509,7 +1509,7 @@ Alley~
    You are on a small alley between the repair shop and the general
 store.  Nothing much here but small rodents and dust.
 ~
-54 5 0 0 0 0
+54 5 0 0 0 1
 D0
 ~
 ~
@@ -1524,7 +1524,7 @@ Alley~
    This is a small corner in the alley behind the warehouses and the guild
 of warriors.  You notice some small scrapings to the west.
 ~
-54 1 0 0 0 0
+54 1 0 0 0 1
 D0
 ~
 ~
@@ -1538,7 +1538,7 @@ S
 Alley~
    The alley ends here as do the footprints you had noticed earlier.
 ~
-54 1 0 0 0 0
+54 1 0 0 0 1
 D3
 ~
 ~
@@ -1554,7 +1554,7 @@ Underground~
    You are in a small underground passage beneath the city.  You see a
 small glint of light from above and the passage continues south.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D2
 ~
 ~
@@ -1568,7 +1568,7 @@ S
 Underground~
    The passage continues north and south.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D0
 ~
 ~
@@ -1582,7 +1582,7 @@ S
 Underground~
    The tunnel branches here going north, east, and west.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D0
 ~
 ~
@@ -1601,7 +1601,7 @@ Underground~
    The alley turns again here and heads south and west.  You notice a
 small glint of light from above.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D2
 ~
 ~
@@ -1621,7 +1621,7 @@ Underground~
 You also notice the clearing of dust on the ground but can't seem to
 find any door in that direction.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D1
 ~
 ~
@@ -1631,7 +1631,7 @@ S
 Underground~
    The small passage continues north and south from here.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D0
 ~
 ~
@@ -1646,7 +1646,7 @@ Underground~
    The small passage heads north and east from here.  You here the sounds
 of the city above you.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D0
 ~
 ~
@@ -1665,7 +1665,7 @@ Underground~
    The tunnel continues you west and east.  Hopefully you have a good sense
 of direction.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D1
 ~
 ~
@@ -1773,7 +1773,7 @@ A Dark Passage~
 to the west doesn't look quite right but searching it reveals no secret
 doors.  The only exit it seems is east.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D1
 ~
 ~
@@ -1786,7 +1786,7 @@ notice something peculiar about the wall, this time to the north,
 but you fail to find any secret doors.  Voices can be faintly heard
 from the north.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D1
 ~
 ~
@@ -1800,7 +1800,7 @@ S
 A Dark Passage~
    The small passage continues west and east from here.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D1
 ~
 ~
@@ -1821,7 +1821,7 @@ A Dark Passage~
 you find a small ladder half buried in the dirt.  setting it up you find
 a trap door in the ceiling.  The passage continues west from here.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D3
 ~
 ~
@@ -1841,7 +1841,7 @@ S
 Underground~
    The small passage continues west and east.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D1
 ~
 ~
@@ -1855,7 +1855,7 @@ S
 Underground~
    The small passage continues west and east.
 ~
-54 9 0 0 0 0
+54 9 0 0 0 1
 D1
 ~
 ~

--- a/lib/world/wld/55.wld
+++ b/lib/world/wld/55.wld
@@ -221,7 +221,7 @@ large wrought iron gates lie open before you.  Although they might not
 ever be used the priests in the temple are ready to defend themselves,
 should their city ever come under seige again.
 ~
-55 0 0 0 0 0
+55 0 0 0 0 1
 D0
 ~
 ~
@@ -306,7 +306,7 @@ Around the sides are four wrought iron benches with cushions where the
 mages of the land sit and exchange ideas.  To the west stands a two-story
 tower where the leader of the mages' guild performs his experiments.
 ~
-55 16 0 0 0 0
+55 16 0 0 0 1
 D2
 ~
 ~
@@ -343,7 +343,7 @@ either preaching or listening to their fellows preach.  Huge
 marble steps lead up to the gates of the temple and Main Street
 lies to the south.
 ~
-55 68 0 0 0 0
+55 68 0 0 0 1
 D0
 ~
 ~
@@ -749,7 +749,7 @@ Sultan's choice Arabian Stallions, and each has their own trough
 for drinking.  A small boy wanders in sometimes with a shovel to
 remove the offensive by-product of such beasts.
 ~
-55 8 0 0 0 0
+55 8 0 0 0 1
 D1
 ~
 ~
@@ -783,7 +783,7 @@ The Dump~
 to the constant winds blowing down the moutains the smell is usually blown
 outside the walls and over the desert.
 ~
-55 0 0 0 0 0
+55 0 0 0 0 1
 D2
 ~
 ~
@@ -951,7 +951,7 @@ The ruler of all the eastern lands resides in this fine palace, and he is
 not a poor man.  The grand entrance lies byond the gate, and Sultan's Walk
 is to the east.
 ~
-55 0 0 0 0 0
+55 0 0 0 0 1
 D1
 ~
 ~
@@ -1094,7 +1094,7 @@ Outside The Northern Gate Of New Thalos~
    You stand outside the gate of New Thalos.  The city lies to the south,
 and wilderness to the north.
 ~
-55 4 0 0 0 0
+55 4 0 0 0 1
 D0
 ~
 ~
@@ -1109,7 +1109,7 @@ Outside The Eastern Gate Of New Thalos~
    You stand outside the protective walls of the city.  The massive iron
 gate sits to the west and the unknown awaits you eastward.
 ~
-55 0 0 0 0 0
+55 0 0 0 0 1
 D1
 ~
 ~
@@ -1128,7 +1128,7 @@ Outside The West Gate Of New Thalos~
    You stand outside the city walls, the iron gate to the east.  The city
 lies in that direction and the road to Midgaard lies west.
 ~
-55 0 0 0 0 0
+55 0 0 0 0 1
 D1
 ~
 gate~
@@ -1144,7 +1144,7 @@ Outside The Wall~
 ground seems well trodden but you can see no apparent exit save that
 to the north.
 ~
-55 0 0 0 0 0
+55 0 0 0 0 2
 D0
 ~
 ~
@@ -1309,7 +1309,7 @@ trees, you see a delicate white gazebo.
    A path leads out into the hallway and west towards the gazebo.
 To your right stands a gold sign.
 ~
-55 0 0 0 0 0
+55 0 0 0 0 2
 D1
 ~
 ~

--- a/lib/world/wld/56.wld
+++ b/lib/world/wld/56.wld
@@ -118,7 +118,7 @@ On A Rope Bridge~
    The small rope bridge shudders under your weight as you make your
 way across the valley.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -226,7 +226,7 @@ S
 On A Road~
    This long road continues to the east and south.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -240,7 +240,7 @@ S
 On A Road~
    The well kept road continues east and west from here.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -257,7 +257,7 @@ and west towards the Eastern Mountains.  To the north you can see wide
 plains stretching out as far as the eye can see.  South of you begins
 a dark green forest.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -454,7 +454,7 @@ S
 On A Road~
    The road you are on continues east and west.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 4
 D1
 ~
 ~
@@ -468,7 +468,7 @@ S
 On A Road~
    The road you are on continues east and west.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -482,7 +482,7 @@ S
 On A Road~
    The road you are on continues east and west.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -498,7 +498,7 @@ On A Road~
 the River Ishtar.  The road continues north and west from the
 river bank.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D0
 ~
 ~
@@ -995,7 +995,7 @@ and flows west down the mountain.  It looks like there was a terrible
 earthquake here not too long ago, and a path that leads eastwards
 through the mountains is covered with rocks, making passage difficult.
 ~
-56 1 0 0 0 0
+56 1 0 0 0 7
 D1
 ~
 ~
@@ -1010,7 +1010,7 @@ On The Dark River~
    The river flows down the mountain through a large crevasse to the west
 and up into the mountains east.
 ~
-56 1 0 0 0 0
+56 1 0 0 0 7
 D1
 ~
 ~
@@ -1025,7 +1025,7 @@ On The Dark River~
    The walls of this canyon tower overhead as the river continues east
 and west from here.
 ~
-56 1 0 0 0 0
+56 1 0 0 0 7
 D1
 ~
 ~
@@ -1040,7 +1040,7 @@ On The Dark River~
    The walls of rock around you slowly shrink to ground level as the river 
 flows out of the mountains and onto the plains.
 ~
-56 1 0 0 0 0
+56 1 0 0 0 7
 D1
 ~
 ~
@@ -1055,7 +1055,7 @@ On The Dark River~
    The river continues east and west from here out of the foothills
 to the east down into the mountains south of here.
 ~
-56 1 0 0 0 0
+56 1 0 0 0 7
 D1
 ~
 ~
@@ -1070,7 +1070,7 @@ On The Dark River~
    The river, following a low spot in the foothills, bends and twists.
 Tall mountains can be seen off to the south and east.
 ~
-56 1 0 0 0 0
+56 1 0 0 0 7
 D0
 ~
 ~
@@ -1084,7 +1084,7 @@ S
 On The Dark River~
    The river makes a wide sweeping turn here into the mountain.
 ~
-56 1 0 0 0 0
+56 1 0 0 0 7
 D0
 ~
 ~
@@ -1099,7 +1099,7 @@ On The Dark River~
    The river flows west from here into the heart of the mountain and
 east towards the foothills once more.
 ~
-56 9 0 0 0 0
+56 9 0 0 0 7
 D1
 ~
 ~
@@ -1114,7 +1114,7 @@ On The Dark River~
    You can barely make out what is ahead of you as the river flows
 quietly through the passageway.
 ~
-56 9 0 0 0 0
+56 9 0 0 0 7
 D1
 ~
 ~
@@ -1130,7 +1130,7 @@ On The Dark River~
 are small cracks in the passage wall to the north where you might be able
 to get up out of the water.
 ~
-56 9 0 0 0 0
+56 9 0 0 0 7
 D0
 ~
 ~
@@ -1149,7 +1149,7 @@ On The Dark River~
    The river continues east and west from here flowing south of a dark
 ledge high above the water level.
 ~
-56 9 0 0 0 0
+56 9 0 0 0 7
 D1
 ~
 ~
@@ -1164,7 +1164,7 @@ On The Dark River~
    The river flows south through a narrowing part of the passage as it
 progresses deeper into the mountain.
 ~
-56 9 0 0 0 0
+56 9 0 0 0 7
 D1
 ~
 ~
@@ -1181,7 +1181,7 @@ it leads deeper into the mountain.  Unfortunately, the ledge is only
 wide enough to rest upon for a while and there does not appear to be
 any other exits other than rejoining the underground river.
 ~
-56 9 0 0 0 0
+56 9 0 0 0 2
 D2
 ~
 ~
@@ -1194,7 +1194,7 @@ To the south of you stand the might northern gates of New Thalos.  East
 and west of you the grassy fields continue and north, in the distance,
 you see a line of trees.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D0
 ~
 ~
@@ -1218,7 +1218,7 @@ On The Plains~
 closer but still a good distance away.  To the south a small dirt
 path has been trodden into the ground heading towards New Thalos.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D0
 ~
 ~
@@ -1242,7 +1242,7 @@ The Edge Of The Forest~
 continues as far as the eye can see to the east and west.  A
 large expanse of grass spreads out to the south.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -1392,7 +1392,7 @@ the go to great lengths to keep all the roads in order.  Although
 the taxes in New Thalos are higher then other cities in the realm
 most of the money is used for the good of the people.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -1410,7 +1410,7 @@ and the trees lies a great expanse of grassy plains.  South of here,
 beyond the river, lies the Great Eastern Desert.  The road continues
 east and west.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -1426,7 +1426,7 @@ On A Road~
 lands.  The road continues east and west.  To the south you hear the
 sounds of boats traveling the River Ishtar delivering goods.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -1443,7 +1443,7 @@ their goods to the coastline and have them ferried onto ships for
 export.  Travel by foot west will take you through New Thalos up and
 over the Eastern Mountains and down into Midgaard.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -1460,7 +1460,7 @@ beach and onto a dock.  To the north and south you see the coastline
 stretching out before you.  West of here the lowlands roll up into
 huge snow capped mountains.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 2
 D1
 ~
 ~
@@ -1477,7 +1477,7 @@ road to the west.  The dock seems to have been here for quite a long
 time but is still sturdy.  A small ladder has been built on the eastern
 end to allow easy access to and from ships.
 ~
-56 0 0 0 0 0
+56 0 0 0 0 1
 D0
 ~
 ~

--- a/lib/world/wld/57.wld
+++ b/lib/world/wld/57.wld
@@ -347,7 +347,7 @@ possibly small mountains stretch up to the east and west and they have snow
 covered peaks.  There are exits north back into the portal and south into the
 pass.    
 ~
-57 16 0 0 0 0
+57 16 0 0 0 5
 D0
 ~
 ~
@@ -363,7 +363,7 @@ In the Pass~
 to come through the portal the goat herd raise the alarm and an impenetrable
 mist descends upon the valley thwarting any attempt to lay siege to it.    
 ~
-57 0 0 0 0 0
+57 0 0 0 0 5
 D0
 ~
 ~
@@ -383,7 +383,7 @@ goats are standing under them sleeping and just lazing about.  Rivers
 criss-cross the valley and at the far end is a waterfall.  Exits lead back into
 the pass and down into the valley.    
 ~
-57 0 0 0 0 0
+57 0 0 0 0 4
 D0
 ~
 ~
@@ -403,7 +403,7 @@ the bottom of the waterfall.  Exits lead east and west toward groups of goats
 and and west, further into the valley.  Of course there is also and exit back
 into the pass.    
 ~
-57 0 0 0 0 0
+57 0 0 0 0 2
 D0
 ~
 ~
@@ -424,7 +424,7 @@ the 10th sign of the zodiac.  Bones litter the ground around him, most are
 skulls and spines.  Those strange tracks from before are here and they are more
 discernable.  What could they mean?    
 ~
-57 0 0 0 0 0
+57 0 0 0 0 4
 D1
 ~
 ~
@@ -449,7 +449,7 @@ Capricorns' Hill~
 a couch where the lord of the goats rests, and thick moss cushions his head.  
 The air is fetid with the smell of the dead.    
 ~
-57 0 0 0 0 0
+57 0 0 0 0 4
 D0
 ~
 ~
@@ -465,7 +465,7 @@ Descending towards the Waterfall~
 about 300 feet!  Behind the lower part of of it there seems to be a cave.  A
 faint glow can be seen inside.  Whatever could it be?    
 ~
-57 16 0 0 0 0
+57 16 0 0 0 4
 D0
 ~
 ~
@@ -481,7 +481,7 @@ Outside the Cave~
 shape of a pair of scales.  Could it be Libra?  There is a walkway through here
 and the ground falls away on both sides.    
 ~
-57 4 0 0 0 0
+57 4 0 0 0 5
 D0
 ~
 ~
@@ -502,7 +502,7 @@ all their headbutting and grunting.  This tree is very large and stripes that
 have been scored into the tree form a ladder.  Tree sap oozes down the ladder
 and it has a sweet smell.  Little red eyes can be seen up the ladder.    
 ~
-57 0 0 0 0 0
+57 0 0 0 0 2
 D3
 ~
 ~
@@ -574,7 +574,7 @@ On the oaken ladder~
    This ladder is covered in tree sap, you are almost adhered to the trunk.  
 There are noises coming from the top of the tree, slight but still noticable.
 ~
-57 4 0 0 0 0
+57 4 0 0 0 4
 D4
 The sap is runnier above here, probably because its fresher. There's only one way to find out, and that's to go up.
 ~
@@ -597,7 +597,7 @@ Halfway up the Tree~
 sap below.  It gives off a sweet smell that makes a person want to taste it.  
 The noises are more audible here and those ever staring red eyes look menacing.
 ~
-57 0 0 0 0 0
+57 0 0 0 0 4
 D4
 ~
 ~
@@ -620,7 +620,7 @@ noises are now very loud and mournful.  Maybe somethings hurt!  Whatever it is,
 it doesnt sound too good.  Could the thing with red eyes be the one
 moaning?  Or is it something else?    
 ~
-57 4 0 0 0 0
+57 4 0 0 0 4
 D4
 An feeling of oppression coming from above.
 ~

--- a/lib/world/wld/6.wld
+++ b/lib/world/wld/6.wld
@@ -31,7 +31,7 @@ Shore~
 before you.  You hear some birds singing in the distance.  It seems very
 peaceful here.    
 ~
-6 4 0 0 0 0
+6 4 0 0 0 2
 D0
 ~
 ~
@@ -47,7 +47,7 @@ Shore~
 before you.  You hear some birds singing in the distance.  It seems very
 peaceful here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -67,7 +67,7 @@ Sea of Souls~
 the birds on the distance.  The waves intice you to enter the sea, to see what
 lies beyond.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 6
 D1
 ~
 ~
@@ -87,7 +87,7 @@ Sea of Souls~
 the birds on the distance.  The waves intice you to enter the sea, to see what
 lies beyond.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 6
 D0
 ~
 ~
@@ -111,7 +111,7 @@ Sea of Souls~
 the birds in the distance.  The waves intice you to enter the sea, to see what
 lies beyond.    
 ~
-6 128 0 0 0 0
+6 128 0 0 0 2
 D0
 ~
 ~
@@ -135,7 +135,7 @@ Shore~
 water.  You think you could walk through some of the sea, but it might not be
 very safe.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -151,7 +151,7 @@ Shore~
 of open sea.  Waves crash down onto your feet, making you wet.  As you look
 down, you can see footprints in the sand.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -171,7 +171,7 @@ Sea of Souls~
 without a boat.  You feel clams and rocks shuffle underneath your feet as your
 feet sink into the sand of the sea.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -195,7 +195,7 @@ Sea of Souls~
 without a boat.  You feel clams and rocks shuffle underneath your feet as your
 feet sink into the sand of the sea.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 6
 D0
 ~
 ~
@@ -218,7 +218,7 @@ Sea of Souls~
    The sea seems to expand greatly, heading off towards the southwest.  You can
 see a small island off in the distance.  You wonder what could be there.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -242,7 +242,7 @@ Island~
 walking around, you notice several small trees.  The ground is mostly sand.  
 You feel your feet squishing around under you.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -266,7 +266,7 @@ Island~
 surrounded by numerous large trees, shading you from the sun.  The island
 continues to the south.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -285,7 +285,7 @@ Island~
    You have come to the edge of the island.  The ground below you is very
 murky.  You can feet your feet begining to sink into the cold sea.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -304,7 +304,7 @@ Sea of Souls~
    The water before you is calm and quiet.  The only sound you can hear is the
 sound of birds singing in the distance.  You feel very relaxed here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -323,7 +323,7 @@ Sea of Souls~
    The water before you is calm and quiet.  The only sound you can hear is the
 sound of birds singing in the distance.  You feel very relaxed here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -342,7 +342,7 @@ Sea of Souls~
    Everything around you is beginning to look the same.  Some small waves
 gently rock your boat, making you sway to and fro.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -358,7 +358,7 @@ A Small Cove~
 here, but the view is marvelous!  In the distance you can see several little
 animals running around playing.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -370,7 +370,7 @@ Sea of Souls~
 There really isn't much here.  To the south you can see a small island.  What
 could be there?    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -394,7 +394,7 @@ Tunnel~
 island.  The walls of the tunnel are made from seaweed, giving the place a
 weird smell.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -409,7 +409,7 @@ Tunnel~
    As you continue making your way through the tunnel, a horrible smell fills
 your nose.  It smells like dead fish!  There is a small island to the east.  
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -429,7 +429,7 @@ Tunnel~
 disappear, showing you a beautiful island to the east.  You wonder what
 treasures are hidden there.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -445,7 +445,7 @@ Tropical Island~
 are a few scattered palm trees growing in the sand.  As you look down at the
 ground, you notice that the sand is red.  How did this happen?    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D2
 ~
 ~
@@ -460,7 +460,7 @@ Sea of Souls~
    The waves from the sea crash up against your boat, spraying you with a light
 mist.  It feels refreshing and cool on your skin.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -479,7 +479,7 @@ Sea of Souls~
    As you depart from the island, you look around, trying to see another
 island.  There isn't one in view, but that doesn't mean that ones not there.  
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -499,7 +499,7 @@ Sea of Souls~
 childhood fill your mind as the waves threaten to put you to sleep.  There is
 an island to the east.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -515,7 +515,7 @@ Tropical Island~
 village in the distance, to the south.  Maybe you can get something to eat
 there.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -539,7 +539,7 @@ Tropical Island~
 you.  There are coconuts hanging from the palm trees, and you see some
 weed-like flowers growing through the sand.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -554,7 +554,7 @@ Sea of Souls~
    The water is rather calm here, maybe too calm.  Everything around you is
 quiet.  You suddenly feel alone.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -571,7 +571,7 @@ small floating village towards the east.  Maybe there are some shops there
 where you can sell some of the things you have collected through your journey.
   
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D2
 ~
 ~
@@ -587,7 +587,7 @@ Sea of Souls~
 rock back and forth.  To the east you can see a village.  What could be in it?
   
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -607,7 +607,7 @@ Sea of Souls~
 The water looks very cold and the chances of you surviving temperatures like
 that are very slim.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -623,7 +623,7 @@ Floating Village~
 docked at the side of the village.  Many people shuffle around you busily,
 getting supplies and food.  To the east you can see a small pawn shop.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -643,7 +643,7 @@ Small House~
 people like yourself out.  The house should have been knocked down long ago,
 but may have been kept for historical reasons.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D1
 ~
 ~
@@ -699,7 +699,7 @@ Sea of Souls~
 like you could dock your boat at the village and rest for a bit.  There looks
 to be some shops there.  Maybe you should go have a look.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -714,7 +714,7 @@ Narrow Tunnel~
    A narrow path in the sea sits before you.  It seems to lead to an island.  
 You can't whats on the island yet, maybe you should just go there and find out.
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -730,7 +730,7 @@ Narrow Tunnel~
 You can see a little more of the island, but not enough to make out whats
 there.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -749,7 +749,7 @@ Small Cove~
    You find yourself floating into a small cove of the sea.  It looks like
 another dead end.  Guess you'll have to turn around and go a different way.  
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D2
 ~
 ~
@@ -761,7 +761,7 @@ Sea of Souls~
 conecting two islands together.  Off in the distance to the west you can see a
 floating village.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -776,7 +776,7 @@ Hidden Island~
    You have come to a small hidden island.  There doesn't appear to be much
 here, just some wild plants, but it might be worth your time to have a look.  
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -792,7 +792,7 @@ Hidden Island~
 south.  You must have hit a small cluster of islands.  You wonder if anyone
 lives on these islands.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -808,7 +808,7 @@ Dark Isle~
 north.  You can see a small resturant inside.  You can smell some fresh cooked
 food.
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -825,7 +825,7 @@ everything got so dark.  You look up to see a large dome covering the entire
 island!  You reach down and feel the sand.  It's cold and wet between your
 fingers.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D1
 ~
 ~
@@ -841,7 +841,7 @@ Dark Isle~
 be out of luck.  You feel sharp pebbles digging into your feet.  You can hear
 them crunching in the darknesss.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -856,7 +856,7 @@ Sea of Souls~
    The water around you is calm and relaxing.  One could fall asleep in these
 surroundings.  Just don't go getting yourself lost!    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -875,7 +875,7 @@ Sea of Souls~
    The water around you is calm and relaxing.  One could fall asleep in there
 surroundings.  Just don't go getting yourself lost!    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -895,7 +895,7 @@ Scorpion Island~
 to kill them, or let them kill you.  You see a small path between the creatures
 that you could safely walk on.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -911,7 +911,7 @@ Scorpion Island~
 you look down at the ground, you notice that you are surrounded by scorpions!
 Maybe you shouldn't have come here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -926,7 +926,7 @@ Scorpion Island~
    Shadows off of some nearby trees shade you from the sun.  You can feel your
 feet starting to sink into the sand as you continue walking.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D1
 ~
 ~
@@ -947,7 +947,7 @@ several large boulders sticking up from the depths of the water.  Where could
 these enormous rocks have come from?  Be careful not to hit one, you wouldn't
 be likely to survive.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -962,7 +962,7 @@ Sea of Souls~
    An enormous portion of the sea sits before you, waiting to be explored.  
 You can see nothing but water, and a few stray birds flying by.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -985,7 +985,7 @@ Sea of Souls~
    An enormous portion of the sea sits before you, waiting to be explored.  
 You can see nothing but water, and a few stray birds flying by.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1004,7 +1004,7 @@ Sea of Souls~
    An enormous portion of the sea sits before you, waiting to be explored.  
 You can see nothing but water, and a few stray birds flying by.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1020,7 +1020,7 @@ Sea of Souls~
 appear to be much there, but it might be worth your time to stop and have a
 look.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1039,7 +1039,7 @@ Sea of Souls~
    The sea almost seems to end here.  The start of a small island is to the
 south, waiting to be explored.  What creatures will you encounter there?    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1055,7 +1055,7 @@ Forgotten Island~
 to have been abandoned some time ago.  All the trees are dead, the ground is
 covered in twigs and dead leaves.  You suddenly feel alone.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1072,7 +1072,7 @@ layer of sand.  You bend down and brush away some of the sand to expose an
 ancient tablet.  There are drawings on here that you are unable to read.  You
 begin to wonder who was on this island before you, and what happened to them.
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1096,7 +1096,7 @@ Forgotten Island~
 sea.  You feel a sudden sense of freedom come over you.  A small breeze picks
 up, blowing warm air across your face.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D1
 ~
 ~
@@ -1111,7 +1111,7 @@ Sea of Souls~
    You feel your boat gently sway back and forth from the waves of the sea.  
 You can see a small island to the west.  It appears to be abandoned.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1135,7 +1135,7 @@ Sea of Souls~
 One to the west and one to the southeast.  The one to the southeast is rather
 large.  What could be over there?    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1156,7 +1156,7 @@ several large boulders sticking up from the depths of the water.  Where could
 these enormous rocks have come from?  Be careful not to hit one, you wouldn't
 be likely to survive.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D2
 ~
 ~
@@ -1172,7 +1172,7 @@ Sea of Souls~
 off to the south.  The island looks bigger than the rest that you have seen.  
 What could be there?    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1192,7 +1192,7 @@ Dragon Isle~
 island never leave it.  Maybe you should leave before you are spotted as
 someone's lunch.
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1212,7 +1212,7 @@ Dragon Isle~
 footprints in the sand.  You step inside of one, and suddenly feel very scared.
 You're not alone here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D2
 ~
 ~
@@ -1228,7 +1228,7 @@ Sea of Souls~
 to tip over.  You can hear some birds singing in the distance.  You feel very
 peaceful here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1244,7 +1244,7 @@ Sea of Souls~
 and see a large island to the east.  You can see that several large trees have
 been knocked down.  What could have caused something like this?    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1264,7 +1264,7 @@ Sea of Souls~
 to tip over.  You can hear some birds singing in the distance.  You feel very
 peaceful here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1281,7 +1281,7 @@ water.  The water must be very deep here.  As you look over the side of your
 boat, into the water you see nothing but blackness.  It makes you think of
 death.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1300,7 +1300,7 @@ Dragon Isle~
    As you continue on, you pass an old crumbled cave.  It was most likely
 crushed by one of the dragons while removing its prey from the cave.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1316,7 +1316,7 @@ Dragon Isle~
 To the east, the island continues.  To the west is the sea.  Maybe you had
 better leave the island while you still can.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1335,7 +1335,7 @@ Sea of Souls~
    As you continue sailing along, you spot a large island to the east.  The
 island looks to have been left in ruins.  Maybe shouldn't go there.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1351,7 +1351,7 @@ Sea of Souls~
 and see a large island to the east.  You can see that several large trees have
 been knocked down.  What could have caused something like this?    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1368,7 +1368,7 @@ water.  The water must be very deep here.  As you look over the side of your
 boat, into the water you see nothing but blackness.  It makes you think of
 death.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1385,7 +1385,7 @@ water.  The water must be very deep here.  As you look over the side of your
 boat, into the water you see nothing but blackness.  It makes you think of
 death.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1400,7 +1400,7 @@ Sea of Souls~
    As you continue floating along the sea, everthing gets quiet.  Maybe too
 quiet.  You can see a small island in the distance to the southeast.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1416,7 +1416,7 @@ Sea of Souls~
 You can see a small island to the east.  This is perhaps the smallest island
 you have encountered so far.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1433,7 +1433,7 @@ be possible?  The climate is much too warm for there to be snow.  All the
 plants have died and shrivled up, leaving you as the only living thing on this
 island.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D1
 ~
 ~
@@ -1453,7 +1453,7 @@ Ice Isle~
 remains of an old ice fort.  The sun has melted quite a bit of it down, leaving
 nothing but a mound of ice.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1464,7 +1464,7 @@ Sea of Souls~
    The water here is quite cold.  You can see small chunks of ice floating past
 you.  To the west is a small island covered in snow.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1479,7 +1479,7 @@ Sea of Souls~
    The water here is quite cold.  You can see small chunks of ice floating past
 you.  To the west is a small island covered in snow.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1499,7 +1499,7 @@ Sea of Souls~
 waves crashes against your boat, almost tipping you over!  You're sprayed with
 a light mist, leaving your clothes drenched.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1519,7 +1519,7 @@ Forest Island~
 leaving almost no room for you to walk.  You see some wild flowers and weeds
 growing through the tall grass.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1535,7 +1535,7 @@ Forest Island~
 is up to your chin.  You begin to feel like you're in the jungle.  Several bugs
 zoom past your ear, making a soft buzzing sound.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D1
 ~
 ~
@@ -1551,7 +1551,7 @@ Sea of Souls~
 south you can see an island filled with trees.  The shore is not to far off to
 the southeast.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1570,7 +1570,7 @@ Sea of Souls~
    The waves ripple softly, splashing against the side of your boat.  It rocks
 gently, threatening to put you to sleep.  You feel very relaxed here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1589,7 +1589,7 @@ Sea of Souls~
    The waves ripple softly, splashing against the side of your boat.  It rocks
 gently, threatening to put you to sleep.  You feel very relaxed here.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1609,7 +1609,7 @@ Sea of Souls~
 south you can see an island filled with trees.  The shore is not to far off to
 the southeast.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1625,7 +1625,7 @@ Forest Island~
 It almost feels as if you're in quicksand.  The grass is much shorter here,
 showing you the sea to the north and south.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D2
 ~
 ~
@@ -1640,7 +1640,7 @@ Sea of Souls~
    You begin sailing into the unknown.  What things will you encounter?  Will
 you even survive?  Luck doesn't appear to be on your side.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1656,7 +1656,7 @@ Private Island~
 with wild flowers, giving off a sweet scent.  You can see a small house to the
 east.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D1
 ~
 ~
@@ -1672,7 +1672,7 @@ Private Island~
 here very long.  There doesn't appear to be anyone home.  Maybe you should
 leave before someone sees you.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D2
 ~
 ~
@@ -1688,7 +1688,7 @@ Private Island~
 see a small house to the north.  It's constructed of bricks and is by far the
 most beautiful house you have ever seen!    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~
@@ -1704,7 +1704,7 @@ Sea of Souls~
 the north you can see an island.  It doesn't appear to be very big, but it
 might be a good place to stop and rest.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1719,7 +1719,7 @@ Sea of Souls~
    The water here is quite calm, making you feel very relaxed.  Don't get too
 relaxed.  You may fall sleep and tip over!    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1735,7 +1735,7 @@ Sea of Souls~
 up, causing the sea to become wavy.  You grab on to the sides of the boat,
 trying to hang on.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D0
 ~
 ~
@@ -1751,7 +1751,7 @@ Sea of Souls~
 small island off to the west.  It looks nice enough, but looks can be
 deceiving.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1771,7 +1771,7 @@ Sea of Souls~
 up, causing the sea to become wavy.  You grab on to the sides of the boat,
 trying to hang on.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 7
 D1
 ~
 ~
@@ -1787,7 +1787,7 @@ Shore~
 What mysteries could it hold?  Would you survive a journey across it?  You hear
 some birds chirping in the distance.    
 ~
-6 0 0 0 0 0
+6 0 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/60.wld
+++ b/lib/world/wld/60.wld
@@ -5,7 +5,7 @@ large forest of Haon-Dor.  To the east you see the road heading back to the
 walled city, Midgaard, and to the west is a narrow trail leading through the
 forest.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 2
 D1
 To the east a dusty road takes you back to the walls of Midgaard, and its large
 west gate.
@@ -34,7 +34,7 @@ A Trail Through The Light Forest~
 path leading north into the shadows.  To the east is the forest edge and to
 the west the trail leads further into the forest.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 You see evidence of a small path leading through a break in the trees to the
 north.
@@ -71,7 +71,7 @@ A Trail Through The Light Forest~
 west, the forest gradually becomes more dense.  A small forest path leads off
 to the south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D1
 The trail continues eastwards through the young trees.
 ~
@@ -106,7 +106,7 @@ A Trail Through The Dense Forest~
    You are on a trail winding east and west through the dense forest.  To
 the east, the forest gradually seems to become lighter.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D1
 The trail continues eastwards to the younger part of the forest.
 ~
@@ -133,7 +133,7 @@ A Trail Through The Dense Forest~
 west, the trees are so huge and their crowns so dense that forest remains in
 total darkness.  A small path leads south through the trees.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D1
 The trail continues eastwards through the dense forest.
 ~
@@ -168,7 +168,7 @@ A Small Path In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues north and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -194,7 +194,7 @@ A Small Path In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues north and east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -220,7 +220,7 @@ An Intersection In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The forest
 gradually lightens to the east.  Paths lead east, west and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D1
 You can barely make out a clearing to the east.
 ~
@@ -251,7 +251,7 @@ The Forest Clearing~
 protrude from the ground and heavy logs are stacked neatly in a big pile
 supported by stakes set into the ground.  Paths lead north, east and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -295,7 +295,7 @@ Outside A Small Cabin In The Forest~
    You are outside a small cabin built entirely from heavy logs.  There is a
 wooden door to the north and small paths lead west and south through the trees.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The wooden door is quite sturdy but does not appear to be equipped with a lock.
 ~
@@ -365,7 +365,7 @@ A Small Path Through The Light Forest~
    You are on a small path leading through the forest.  The trees are tall and
 slender.  Paths lead north and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path leads north through the young trees.
 ~
@@ -391,7 +391,7 @@ An Intersection In The Dense Forest~
 old trees leave the forest floor in an unreal twilight illumination.  Paths
 lead north, east and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -422,7 +422,7 @@ A Small Path In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues east and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D1
 The small path leads east through the trees.
 ~
@@ -447,7 +447,7 @@ An Intersection In The Dense Forest~
    You are on a small path leading through the dense forest.  The forest
 gradually lightens to the north.  Paths lead north, east and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path leads north to a lighter part of the forest.
 ~
@@ -479,7 +479,7 @@ A Small Path In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues south and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D2
 The small path leads south through the trees.
 ~
@@ -505,7 +505,7 @@ A Small Path In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues north, south and east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -535,7 +535,7 @@ A Small Path In The Dense Forest~
    You are at a turn on a small path leading through the dense forest.  The
 forest seems to become lighter to the west.  The path continues north and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -565,7 +565,7 @@ An Intersection In The Light Forest~
    You are on a small path leading through the forest.  A path leads north to
 a small field and other paths lead east and west into the dense forest.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path leads north to a small, grassy field.
 ~
@@ -596,7 +596,7 @@ A Small Path In The Dense Forest~
    You are on a small path leading through the dense forest.  The forest seems
 to become lighter to the east.  The path continues north and east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -623,7 +623,7 @@ A Small Path In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues south and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D2
 The small path leads south through the trees.
 ~
@@ -649,7 +649,7 @@ A Small Path In The Dense Forest~
 you see a dark cave entrance, leading into a small hillside.  The path
 continues north and east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The small path leads north through the trees.
 ~
@@ -713,7 +713,7 @@ wall-like thicket on the east side of the field.  To the northeast you can see
 a small lake.  A small path leads south through the trees, and the field opens
 up to the north and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 2
 D0
 Wind blowing in from the north carries with it the smell of a newly killed
 animal, as well as the noise of many birds, which you can see circling there.
@@ -755,7 +755,7 @@ grass here has been trampled by the many animals coming here for water, leaving
 the ground covered in tracks of different types.  To the west you see a break
 in the wall of trees surrounding the field, and to the north is a small lake.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 2
 D0
 The animal tracks lead off to the north, and around the lake there.
 ~
@@ -789,7 +789,7 @@ high in the air, and to the north you see a small lake, surrounded by tall
 reeds.  The field continues to the south, and the forest blocks passage to the
 east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 2
 D0
 The lake looks inviting, and you can see some sort of water fowl floating
 around among the reeds.
@@ -840,7 +840,7 @@ at you.  The grass here has been trampled, and a large area around the carcass
 is stained by blood.  A trail leads down the sloping field to a lake, and to
 the south you see the path back to the forest.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 2
 D1
 A small lake lies down the sloping field to the east.  Some of the animals
 that fled from here have gone there, and are watching, waiting for you to
@@ -919,7 +919,7 @@ A Small Path In The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues to the west and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D2
 ~
 ~
@@ -945,7 +945,7 @@ crowns of the old trees leave the forest in an unreal twilight illumination.
 This rough clearing is dominated by a very large oak tree, probably the
 largest in this part of the forest.  The path leads back to the north.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 3
 D0
 ~
 ~
@@ -1056,7 +1056,7 @@ approach, leaving you alone and swaying slightly with the wind.  To your north
 you can see a small log cabin through the trees, and to the southeast there
 seems to be some sort of clearing, with many birds circling above it.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 3
 D1
 Back to the east you see the tree trunk.  It is much less precarious there
 compared to here... perhaps you should go back.
@@ -1206,7 +1206,7 @@ A Shaded Path Through The Forest~
 gradually lightens to the east.  The path continues to the north, and to the
 south you see the main trail.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1232,7 +1232,7 @@ A Shaded Path Through The Forest~
    You are at a turn on a small shadowed path leading through the forest.  The
 forest seems to become lighter to the west.  The path continues north and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1260,7 +1260,7 @@ crowns of the old trees leave the forest floor in an unreal twililght
 illumination.  To the north you see a small clearing.  Paths lead east and
 west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 Through the underbrush you see a small clearing.
 ~
@@ -1291,7 +1291,7 @@ A Shaded Path Through The Dense Forest~
 the old trees leave the forest in an unreal twilight illumination.  The path
 continues north and east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1317,7 +1317,7 @@ A Shadowy Path Through The Dense Forest~
 crowns of the old trees leave the forest in an unreal twilight illumination.
 The path continues north and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1343,7 +1343,7 @@ A Shaded Path Through The Forest~
 forest gradually becomes more dense to the west.  The path continues west and
 south from here.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D2
 Through the trees to the south you can almost see the main trail leading back
 to Midgaard.
@@ -1370,7 +1370,7 @@ A Fork On The Shaded Path Through The Forest~
 forest gradually becomes more dense to the west.  The path branches to the
 north and south here, and also continues to the east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1401,7 +1401,7 @@ At The Fallen Tree~
 amount of the tree has already decomposed, but some pieces remain, scattered
 about the clearing.  Paths border the clearing to the north and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 A shaded path winds its way northeast between the trees.
 ~
@@ -1442,7 +1442,7 @@ An Intersection On The Shaded Path~
 crowns of the old trees leave the forest in an unreal twilight illumination.
 The path continues north, south, and west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1473,7 +1473,7 @@ A Shadowy Path Through The Dense Forest~
 crowns of the old trees leave the forest in an unreal twilight illumination.
 The path continues south and east.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D1
 The path winds its way between the old trees.
 ~
@@ -1500,7 +1500,7 @@ of a path or trail.  More sunlight trickles through the treetops here, making
 your travel a bit easier.  Small animals scurry away as you approach.  You
 are no longer on a path, so you may go whichever way you please.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The trees seem to part, exposing a trail into the shade.
 ~
@@ -1537,7 +1537,7 @@ A Shaded Path Through The Forest~
 gradually lightens to the east.  Paths lead west and south, and you think you
 see a small path leading eastward.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D1
 It looks like a small path begins between two trees to the east, but you
 aren't quite certain.
@@ -1569,7 +1569,7 @@ A Shaded Path Though The Forest~
 gradually becomes more dense to the west.  Paths lead north and east, and you
 see a small clearing to the south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1601,7 +1601,7 @@ north the terrain becomes quite hilly and rough.  The crowns of the old trees
 leave the forest in an unreal twilight illumination.  The path continues north
 and south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 4
 D0
 The path winds its way into the hills and denser forest.
 ~
@@ -1632,7 +1632,7 @@ a very short trail.  It looks like someone begin clearing away the underbrush
 here, but didn't get finished.  You may leave in any direction, but the path
 is to the west.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The trees seem to part, exposing a trail into the shade.
 ~
@@ -1669,7 +1669,7 @@ gradually becomes more dense to the west, and to the northwest the terrain
 is quite hilly.  The path continues north and south.  To the east you see a
 trail winding through the younger section of the forest.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 3
 D0
 The path winds its way between the trees.
 ~
@@ -1713,7 +1713,7 @@ you.  The ground is very rough and rocky here, and only the most hardy plants
 survive.  The crowns of the old trees leave the hills in an unreal twilight
 illumination.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 4
 D0
 All you see are trees and hillsides.
 ~
@@ -1756,7 +1756,7 @@ you.  The ground is very rough and rocky here, and only the most hardy plants
 survive.  The crowns of the old trees leave the hills in an unreal twilight
 illumination.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 4
 D0
 All you see are trees and hillsides.
 ~
@@ -1797,7 +1797,7 @@ In The Dense Forest Between The Hills~
 forest is quite thick here, and the ground is very rough and hilly, halting
 your progress.  The path lies to the south.
 ~
-60 0 0 0 0 0
+60 0 0 0 0 4
 D2
 The path winds its way between the trees.
 ~
@@ -1825,7 +1825,7 @@ you.  The ground is very rough and rocky here, and only the most hardy plants
 survive.  The crowns of the old trees leave the hills in an unreal twilight
 illumination.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 4
 D0
 All you see are trees and hillsides.
 ~
@@ -1868,7 +1868,7 @@ you.  The ground is very rough and rocky here, and only the most hardy plants
 survive.  The crowns of the old trees leave the hills in an unreal twilight
 illumination.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 4
 D0
 All you see are trees and hillsides.
 ~
@@ -1911,7 +1911,7 @@ you.  The ground is very rough and rocky here, and only the most hardy plants
 survive.  The crowns of the old trees leave the hills in an unreal twilight
 illumination.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 4
 D0
 All you see are trees and hillsides.
 ~
@@ -1952,7 +1952,7 @@ In The Dense Forest Between The Hills~
 dense forest spreads out all around you, and the crowns of the old trees leave
 the hills in an unreal twilight illumination.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 4
 D0
 All you see are trees and hillsides.
 ~
@@ -1984,7 +1984,7 @@ occasional hunter or adventurer can be seen, heading to or from the forest.
 To the east is the walled city, Midgaard, and to the west the road ends at
 the head of a narrow trail into a large forest.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 2
 D1
 Far to the east you see the large walls guarding Midgaard.
 ~
@@ -2016,7 +2016,7 @@ occasional hunter or adventurer can be seen, heading to or from the forest.
 To the east is the walled city, Midgaard, and to the west the road continues 
 towards a large forest.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 2
 D1
 Far to the east you see the walls and western gate of Midgaard.
 ~
@@ -2050,7 +2050,7 @@ Midgaard the forest of Haon-Dor.  An occasional hunter or adventurer can be
 seen, heading to or from the forest.  To the east is the walled city, Midgaard, 
 and to the west the road continues towards a large forest.
 ~
-60 4 0 0 0 0
+60 4 0 0 0 1
 D1
 To the east you see the walls and West Gate of Midgaard.
 ~

--- a/lib/world/wld/61.wld
+++ b/lib/world/wld/61.wld
@@ -4,7 +4,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 trunks.  The crowns of the trees must be very dense, as they leave the
 forest floor in utter darkness.  The trail leads east and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 A small shadowy path leads away to the north.
 ~
@@ -38,7 +38,7 @@ ancient trees whose grey trunks remind you of ancient pillars in a
 enormous, deserted hall.  To the south, a frail path leads away from
 the trail.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -76,7 +76,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 ancient trees that stand close on all sides.  Not a sound is to be
 heard - everything is ominously quiet.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -110,7 +110,7 @@ colossal trunk to the west.  Not a sound is to be heard - everything
 is ominously quiet.  The trail leads east and south and there is a
 small path leading off the trail to the north.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 A small path leads north off the trail.
 ~
@@ -143,7 +143,7 @@ A Small Path In The Deep, Dark Forest~
 feel as if the ancient trees observe you in watchful silence.  The path
 continues north and south.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -169,7 +169,7 @@ A Small Path In The Deep, Dark Forest~
    You are on a narrow path leading through the deep, dark forest.  Ancient
 grey trees loom all around you.  The path continues north and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -195,7 +195,7 @@ A Junction In The Deep, Dark Forest~
    You are by a junction where three paths meet.  Ancient grey trees tower
 above you on all sides.  Paths lead east, south and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow path winds its way through the trees to the east.
 ~
@@ -226,7 +226,7 @@ A Small Path In The Deep, Dark Forest~
    You are on a narrow path leading through the deep, dark forest.  Ancient
 grey trees loom all around you.  The path continues north and east.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -253,7 +253,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 standing close on all sides.  The trail leads north and west and to the
 south, a frail path leads away from the trail.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow, dusty trail leads north through the forest.
 ~
@@ -291,7 +291,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 trees that stand close on all sides.  Not a sound is to be heard - everything
 is ominously quiet.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -319,7 +319,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 stand close on all sides.  The trail leads east and south.  To the west, a
 narrow path leads away from the trail.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -356,7 +356,7 @@ A Narrow Trail Through The Deep, Dark Forest~
    You are on a dusty trail winding its way north-south between huge, ancient
 trees that loom ominously above you.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow, dusty trail leads north through the forest.
 ~
@@ -384,7 +384,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 standing close on all sides.  The trail leads north and west and to the
 east, a frail path leads away from the trail.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow, dusty trail leads north through the forest.
 ~
@@ -421,7 +421,7 @@ A Small Path In The Deep, Dark Forest~
    You are on a narrow path leading through the deep, dark forest.  Ancient
 grey trees loom in all directions.  The path continues south and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D2
 The narrow path winds its way through the trees to the south.
 ~
@@ -447,7 +447,7 @@ A Junction In The Deep, Dark Forest~
    You are by a junction where three paths meet.  Ancient grey trees tower
 above you on all sides.  Paths lead north, east and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -479,7 +479,7 @@ A Small Path In The Deep, Dark Forest~
 as if the ancient trees observe you in watchful silence.  The path continues
 north and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -505,7 +505,7 @@ A Small Path In The Deep, Dark Forest~
    You are on a narrow path leading through the deep, dark forest.  Giant,
 grey trees loom ominously on all sides.  The path continues east and south.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow path winds its way through the trees to the east.
 ~
@@ -531,7 +531,7 @@ A Junction In The Deep, Dark Forest~
    You are by a junction where three paths meet.  Ancient, grey trees seem
 to observe you silently you from all sides.  Paths lead north, east and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -562,7 +562,7 @@ A Small Path In The Deep, Dark Forest~
    You are on a narrow path leading through the deep, dark forest.  Ancient,
 grey trees loom everywhere.  The path continues south and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D2
 The narrow path winds its way through the trees to the south.
 ~
@@ -588,7 +588,7 @@ A Small Path In The Deep, Dark Forest~
    You are on a narrow path leading through the deep, dark forest.  Huge,
 ancient trees are on all sides.  The path continues north and south.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -615,7 +615,7 @@ On The River Bank In The Deep, Dark Forest~
 south a fast river is flowing westward through the forest.  Ancient grey
 trees loom on both banks.  The path continues north and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -654,7 +654,7 @@ ancient trees stand so close that the path disappears between the dusty
 roots.  To the south a dark river flows from east to west.  The only exit
 appears to be east.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow path winds its way through the trees to the east.
 ~
@@ -680,7 +680,7 @@ A Small Path In The Deep, Dark Forest~
    You are on a narrow path leading through the deep, dark forest.  Giant,
 grey trees loom ominously all around.  The path continues east and south.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow path winds its way through the trees to the east.
 ~
@@ -707,7 +707,7 @@ A Junction On The River Bank In The Deep, Dark Forest~
 to observe you silently you from all around.  To the south a dark river
 flows from east to west through the forest.  Paths lead north, east and west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -745,7 +745,7 @@ ancient trees stand so close that the path disappears between the dusty
 roots.  To the south a dark river flows from east to west.  The only exit
 appears to be west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D3
 The narrow path winds its way through the trees to the west.
 ~
@@ -772,7 +772,7 @@ A Small Path On The River Bank In The Deep, Dark Forest~
 Ancient grey trees loom everywhere.  To the south a dark river flows
 westward through the forest.  The path continues north and east.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow path winds its way through the trees to the north.
 ~
@@ -804,7 +804,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 standing close on all sides.  The trail leads north and west, and to the
 south a frail path leads away from the trail.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow, dusty trail leads north through the forest.
 ~
@@ -841,7 +841,7 @@ A Narrow Trail Through The Deep, Dark Forest~
    You are on a dusty trail winding its way between huge, ancient trees
 standing close on all sides.  The trail leads east and south.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -869,7 +869,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 trees that stand close on all sides.  Not a sound is to be heard - everything
 is ominously quiet.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -897,7 +897,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 trees that stand close on all sides.  Not a sound is to be heard - everything
 is ominously quiet.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -925,7 +925,7 @@ A Narrow Trail Through The Deep, Dark Forest~
 trees that stand close on all sides.  The tree trunks seem to be covered in
 some sticky substance which gets much stickier towards the west!  Beware!
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The narrow, dusty trail leads east through the forest.
 ~
@@ -973,7 +973,7 @@ The huge, poisonous spider stings you!  You resist the poison!
 The huge, poisonous spider stings you!  You are poisoned!
 The huge, poisonous spider stings you!  You are poisoned!
 ~
-61 12 0 0 0 0
+61 12 0 0 0 3
 D4
 ~
 ~
@@ -987,7 +987,7 @@ substance.  Directly to the west is an immense spider web suspended between
 numerous of the giant trees including the one you are hanging on.  To the
 north is what looks like a large webbed entrance.
 ~
-61 13 0 0 0 0
+61 13 0 0 0 6
 D0
 To the north is what looks like a large expanse of webbing which extends
 very far into the trees.
@@ -1016,7 +1016,7 @@ On The spider web~
 giant web in place.  To the east is a giant tree trunk and to the west is
 an entrance to a cave-like structure made from many layers of spider web.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 6
 D1
 To the east is the giant tree trunk.
 ~
@@ -1044,7 +1044,7 @@ from countless layers of spider web.  Temperature and humidity is very
 high making it hard to breathe the foul air that lingers here.  The walls
 are covered with open cocoons.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 6
 D1
 Compared to this place the east exit looks inviting.
 ~
@@ -1065,7 +1065,7 @@ A Dusty Trail In The Deep, Dark Forest~
    You are on a dusty trail leading through the deep, dark forest.  Ancient
 grey trees loom all around you.  The trail continues north and east.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The dusty trail leads north through the trees.
 ~
@@ -1087,7 +1087,7 @@ A Dusty Trail In The Deep, Dark Forest~
 grey trees loom everywhere.  The trail continues south and west.  A broad
 irregular path leads eastward away from the trail.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The trees standing on the sides of the path have scratch marks on them.
 ~
@@ -1124,7 +1124,7 @@ At The End Of The Trail Through The Deep, Dark Forest~
 grey trees loom all around you.  A small trail leads northwards and the only
 other exit is east, along the main trail.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 A narrow trail leads northwards through the underbrush.
 ~
@@ -1149,7 +1149,7 @@ closely over the path in a somewhat ominous manner, but you easily
 shrug it off.  The trail looks to open up somewhat a short distance
 to the south.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow trail continues northwards through the underbrush.
 ~
@@ -1173,7 +1173,7 @@ trail looks surprisingly well trodden along this part.  The brush
 seems to be bending closely over the path in a somewhat ominous
 manner, but you easily shrug it off.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 A short distance to the north, you can see something shimmering.
 ~
@@ -1191,7 +1191,7 @@ Outside A Cave In The Deep, Dark Forest~
 large ominous-looking cave opening.  The trees here have many marks as if
 something with huge claws has been tearing at them in rage.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The disgusting smell of a large reptile emanates from the cave opening.
 ~
@@ -1218,7 +1218,7 @@ The Cave Of The Green Dragon~
 all sorts and the stench is so massive that you could cut it with a
 knife.  The only exit is to the south.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D2
 The exit leads out into the forest.
 ~
@@ -1235,7 +1235,7 @@ The Narrow Trail~
 usual animal claw marks and bites on the trees are becoming few and far
 between.  The trail continues north.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The narrow trail continues north.
 ~
@@ -1253,7 +1253,7 @@ The Narrow Trail~
 animal life what so ever.  The structure of the surrounding trees forces
 the path to make a sharp turn to the east.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The trail bends east.
 ~
@@ -1272,7 +1272,7 @@ the center.  You notice a wooden door carved into the huge tree to
 the east.  The trail that you followed to get here seems to end at
 the base of the tree.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D1
 The tree door is carved beautifully.
 ~
@@ -1289,7 +1289,7 @@ Inside The Great Tree~
    You have stepped inside of this hollowed tree.  From here steps lead down
 into darkness or you can exit the tree by going west.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D3
 The door is carved beautifully.
 ~
@@ -1307,7 +1307,7 @@ The Underground Hallway~
 The hall leads south to a room where you hear strange noises or you can
 go up the steps.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D2
 The hallway looks quite grand.
 ~
@@ -1326,7 +1326,7 @@ visit but you feel very uncomfortable about spending any amount of
 time here.  The wooden altar seems to almost glow as you enter the
 room.  The only exit is the way you came in.
 ~
-61 9 0 0 0 0
+61 9 0 0 0 3
 D0
 The hallway to the north looks quite grand.
 ~

--- a/lib/world/wld/62.wld
+++ b/lib/world/wld/62.wld
@@ -6,7 +6,7 @@ hazardous, and probably not worth the effort; the energy
 barrier continues up the mountain side out of sight.  The
 only exit is back to the east.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -27,7 +27,7 @@ to the end of the forest, and back east.  Each way the
 strange energy barrier stands just to the north,
 inscrutable, magical, and impenetrable.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -53,7 +53,7 @@ along, you scare a small squirrel, which leaps through
 the barrier without a second thought!  Your hand is still
 repulsed by the magical field, however.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -77,7 +77,7 @@ some sort of glowing energy barrier running through the
 woods.  A game trail, seemingly well traveled, runs east-
 west along the magical barrier's length.  Very strange.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -108,7 +108,7 @@ background.  For a short moment, you wonder if the field
 is keeping something in, or you out.  It makes you
 wonder...
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -134,7 +134,7 @@ skirt the edge of the magical barrier in either direction.
 Curious... who or what is keeping this field in place,
 and for what purpose?
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -159,7 +159,7 @@ north-south here.  The tree looks healthy and unaffected
 by the energy field passing right through its center.
 Odd...
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -185,7 +185,7 @@ rushing noise above the humming of the field.  The trail
 you are on continues to the north and south, only a few
 feet away from the barrier it follows.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -213,7 +213,7 @@ forest.  The trail you are on leads north-south through
 the woods, following the energy barrier all along its
 length.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -243,7 +243,7 @@ penetrating the magical field, however.
    The river seems too wide and too swift to cross here.
 It appears the only way to go is back to the south.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D2
 ~
 ~
@@ -285,7 +285,7 @@ travellers on the forest paths away from here.  The air
 smells of death and decay, and the air is very still.  You
 feel uncomfortable.
 ~
-62 4 0 0 0 0
+62 4 0 0 0 3
 D1
 ~
 ~
@@ -313,7 +313,7 @@ traveller to pass in every cardinal direction, excepting
 the west path seems fairly overgrown...
    You feel watched.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -344,7 +344,7 @@ be well-used and you spot many tracks in the earth.  Again
 the hairs on the back of your neck stand up, and you wonder
 if you're being spied upon.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -364,7 +364,7 @@ overhead and wonder as to the force field's nature.  This
 path leads south into the forest, and westwards along the
 river's edge.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 2
 D2
 ~
 ~
@@ -384,7 +384,7 @@ inbetween the water and the forest's edge.  Once again you
 shiver and feel that unmistakeable sense that you are
 being watched.  Disturbing.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 2
 D1
 ~
 ~
@@ -404,7 +404,7 @@ nice area, however, as evidenced by the amount of traffic
 this path gets.  From the marks in the grass, you guess 
 that this is a favored resting spot.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 2
 D1
 ~
 ~
@@ -420,7 +420,7 @@ however?
    There is a clearing to the north, and the path
 continues to the south.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -442,7 +442,7 @@ the damage.
 nothing.  Something is watching you, you feel it.
 Where?
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -462,7 +462,7 @@ the wood scratched at, and the arrowhead left behind.
 Otherwise, there doesn't seem to be much of interest in 
 this particular section of the woods.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -482,7 +482,7 @@ there seems to be a small clearing to the west.
 have sworn you heard a voice nearby.  Whatever it was, it 
 wasn't speaking common.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -500,7 +500,7 @@ lead away to the east, west, and south from here.  The
 trees above block out the sky fairly effectively, also
 blotting out the glowing energy barrier above your head.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -526,7 +526,7 @@ windingly around the trees to the east and west, the woods
 blocking out whatever may be ahead.  Again you get that 
 strange feeling of being watched.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -547,7 +547,7 @@ an area where a smaller path breaks off from the main track.  Eastwards seems to
 be another small clearing that seems to be well used; there are many tracks
 leading in that direction.  
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -566,7 +566,7 @@ tracks in the earth -- the salt licks must attract
 wildlife for miles around.  You think this would be a good
 place to hide and wait for dinner if you were a hunter...
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D3
 ~
 ~
@@ -580,7 +580,7 @@ area is quiet and serene, except for the energy barrier
 keeping you in to the south.  For just a moment, you wonder
 if you're still being watched...
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -599,7 +599,7 @@ ferns around you rustle gently in the light breeze.
 Somehow, the threatening aura that pervades over the rest
 of the area seems absent here.  You feel almost relaxed...
 ~
-62 4 0 0 0 0
+62 4 0 0 0 3
 D0
 ~
 ~
@@ -615,7 +615,7 @@ broken knife handle, made of bone and dried leather,
 useless now.  You wonder if the owner is watching you 
 now -- something certainly is.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -635,7 +635,7 @@ evidently.  You still feel as if you're being watched in
 the back of your mind, and adrenaline pumps into your
 brain like a lightning fuzz.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -654,7 +654,7 @@ holes in the foliage you spot the magical barrier above
 you, keeping you from escaping by flight.  You feel 
 slightly captured.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -674,7 +674,7 @@ here... it seems as if many have been cut down by some
 sort of crude tools.  This land clearing appears to be 
 especially true to the east.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -697,7 +697,7 @@ smelling brown fluid, tannin evidently, fills many of
 these, soaking into various bits and pieces of animal 
 hides.  Crude, but workable.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D3
 ~
 ~
@@ -712,7 +712,7 @@ here, and it definitely looks as if the forest is ending.
 Eastwards the trail leads on into the thick of the forest.
 A small split off trail leads away to the south here.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -736,7 +736,7 @@ to the side of the mountains.  A side trail leads south
 here, and the trail also leads back into the thick of the 
 forest to the east.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -761,7 +761,7 @@ to the west, and a side trail runs along the forest's edge
 to the north.  To the east, the trail runs deep into the 
 forest out of sight.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 4
 D0
 ~
 ~
@@ -783,7 +783,7 @@ green canopy of leaves overhead make this area fairly dark
 and ominous, and that creepy 'watched' feeling returns to
 hit you with full force.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D2
 ~
 ~
@@ -801,7 +801,7 @@ south.  Two wooden poles with skulls on top warn you away
 from the south, and succeed in making you feel quite
 uncomfortable.  Strange...
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D1
 ~
 ~
@@ -827,7 +827,7 @@ occupants in the ground.  How uncivilized... you hope you
 aren't taken care of in this matter when your time
 comes...
 ~
-62 0 0 0 0 0
+62 0 0 0 0 2
 D0
 ~
 ~
@@ -842,7 +842,7 @@ the corner of your eye catches your eyes, and you turn
 your head.  Nothing, there's nothing there at all.
    You wonder if you're being stalked.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 3
 D0
 ~
 ~
@@ -867,7 +867,7 @@ the energy field meets the northern 'wall'.  The water
 passes right on through the magical barrier, however...
 the barrier is obviously porous to some materials.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 2
 D2
 ~
 ~
@@ -887,7 +887,7 @@ by that means.  The trail you are on runs by the side of
 the river to the east, and a path leads by the forest side
 to the south.
 ~
-62 0 0 0 0 0
+62 0 0 0 0 2
 D1
 ~
 ~
@@ -906,7 +906,7 @@ where a trail leads up to a cave in the mountain side.
 There doesn't seem to be a whole lot to capture your 
 attention here...
 ~
-62 0 0 0 0 0
+62 0 0 0 0 4
 D0
 ~
 ~
@@ -951,7 +951,7 @@ your bile.
    Forcing your eyes open, you notice the warning signs
 painted around the tunnel to the north.
 ~
-62 9 0 0 0 0
+62 9 0 0 0 4
 D0
 ~
 ~
@@ -977,7 +977,7 @@ smell with it.  Again, you consider saving your nose the
 trip west and down the tunnel, and heading back east to 
 the cave entrance.
 ~
-62 9 0 0 0 0
+62 9 0 0 0 4
 D1
 ~
 ~
@@ -1015,7 +1015,7 @@ stomachs you guess.  Oddly enough, you don't even care to
 catalog what they have available -- there's no chance you're 
 going to take any of this...
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D1
 ~
 ~
@@ -1034,7 +1034,7 @@ is lying, the stone next to its hand... this is a suicide
 area!  You look down upon the orc and comprehend its 
 suffering in its twisted form.  How sad.
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D1
 ~
 ~
@@ -1059,7 +1059,7 @@ rest just decompose.  The dim sense of horror budding in
 your head blossoms as you realize the pile in the corner 
 consists of dead orc children awaiting burial.
 ~
-62 12 0 0 0 0
+62 12 0 0 0 4
 D2
 ~
 ~
@@ -1079,7 +1079,7 @@ undrinkable.  Somewhere to the east you hear an orc
 child's whining cry, and a voice hushes it urgently.  
 Beware, orcs!  Adventurers are here!  Hide your children!
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D0
 ~
 ~
@@ -1105,7 +1105,7 @@ twisted piece of wire... one orc's idea of a treasured ring,
 no doubt.  Kicking the trinket away, you try to push the 
 pity out of your heart for these wretches.
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D0
 ~
 ~
@@ -1134,7 +1134,7 @@ turns to horror as you see a horrible creature, half...
 well, half something and half orc dash between two 
 stalagmites.
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D0
 ~
 ~
@@ -1163,7 +1163,7 @@ look at the pile of worthless coins and wonder at the
 image of orcish raiders.
    These orcs aren't raiders, they are victims.
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D0
 ~
 ~
@@ -1181,7 +1181,7 @@ are covered with blood and other, unidentifiable
 substances.  Looking around, your only coherent thought 
 is, 'Don't want to know... don't want to know...'
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D0
 ~
 ~
@@ -1205,7 +1205,7 @@ unless you've the mercy to put them out of their misery.
 wonder what forces are at work here... the barrier, the 
 orcs...  What's going on here?
 ~
-62 8 0 0 0 0
+62 8 0 0 0 4
 D0
 ~
 ~
@@ -1225,7 +1225,7 @@ tunnel.  The smell from the lower tunnel doesn't seem
 nearly as bad here... this might be a good place to rest
 and catch your breath.
 ~
-62 13 0 0 0 0
+62 13 0 0 0 4
 D2
 ~
 ~

--- a/lib/world/wld/63.wld
+++ b/lib/world/wld/63.wld
@@ -12,7 +12,7 @@ humans.  You begin to wonder about what lies ahead.  The air is
 damp here, and even the little light that shines through the
 canopy seems to be absorbed into the webbing.
 ~
-63 4 0 0 0 0
+63 4 0 0 0 1
 D0
 ~
 ~
@@ -29,7 +29,7 @@ limbs are coated with cobwebs and seem unusually strong for tree
 branches.  Paths lead in four directions.  The eastward path goes
 down a bit.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -53,7 +53,7 @@ The Wasp Hive~
 honeycomb in shape and many of the maggots and wasps you see have
 fang-marks on their bodies.  You sense some order in their markings.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -64,7 +64,7 @@ The Webby Passage~
    Another webby passage, all sticky and wet.  Tiny ballooning
 spiders fill the air.  It seems that these young ones are newborns.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -80,7 +80,7 @@ Beneath The Busy Path~
 the footsteps suggest a primitive order in there movement.  The light
 seems brighter upwards.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D3
 ~
 ~
@@ -96,7 +96,7 @@ On The Busy Path~
 with one big difference.  The spiders here are carrying ant-corpses,
 as well as rats, wolves, and humans.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D2
 ~
 ~
@@ -112,7 +112,7 @@ On The Busy Path~
 with one big difference.  The spiders here are carrying ant-corpses,
 as well as cats, wolves, and humans.  
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -128,7 +128,7 @@ On The Busy Path~
 with one big difference.  The spiders here are carrying ant-corpses,
 as well as cats, dogs, and humans.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -153,7 +153,7 @@ cricket feelers.  The other is well-kept and suitable for smooth
 travelling.  The webbing that was prevalent in earlier rooms is almost
 non-existant now.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -173,7 +173,7 @@ A Fuzzy Tree Limb~
 seem to have 'hairs' sprouting from its bark.  As you look closer
 you see millions of aphids covering each limb.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D2
 ~
 ~
@@ -188,7 +188,7 @@ The Tree Trunk~
    You feel that you can rest here safely.  There is evidence of
 webbing here, but it is of a finer quality.
 ~
-63 4 0 0 0 0
+63 4 0 0 0 2
 D1
 ~
 ~
@@ -205,7 +205,7 @@ as evidenced by the remains before you.  The area is cluttered with
 desiccated corpses, apparently bitten but unwebbed, and drained of
 their life juices.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -221,7 +221,7 @@ The Wolf Spider Lair~
 save an exit.  The wolf spider keeps no corpses here, but rather
 throws them out at her leisure.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -233,7 +233,7 @@ The Webless Path~
 The path continues northward, where you find that you may have
 to tightrope your way across a ravine.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -251,7 +251,7 @@ Below you can see a prismatic web with lots of animal bones caught in it:
 some bear and small deer bones in fact.  No human skeletons are visible 
 (yet).
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -271,7 +271,7 @@ The Rainbow Web~
 sharp colors and contrasts.  The resident here seems to have a command
 of light as well.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D4
 ~
 ~
@@ -283,7 +283,7 @@ The Web Forest~
 anymore, but disjointed make-shift silken made shafts, sticky to the
 touch, and webby in texture.  This is another world it would appear.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -299,7 +299,7 @@ The Slave Pit~
 'Get back to work, maggots!'  Rails upon rails of mined gold and silver
 clutter the trail beneath you.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -315,7 +315,7 @@ The Tether Path~
 well-lit by the golden orbs that hang from the sides, you can see
 the paths become finer and finer in quality.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -329,7 +329,7 @@ S
 A Road Crossing~
    Another shifty little strand of webs, almost ethereal in nature.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D3
 ~
 ~
@@ -346,7 +346,7 @@ it.  You are definitely not in the Midgaardian realms anymore.  Just
 where you are you can't tell.  It feels like you're moving through
 ether.  You can still get back down to more surer lands.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -362,7 +362,7 @@ The Entrance Of The Ethereal Web~
 in and out, each strand reveals a different hue from black to green 
 to blue.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D2
 ~
 ~
@@ -376,7 +376,7 @@ here too, and eaten later.  You sense that the maker of this
 place has an appetite for dragon meat, and uses this room as a
 breeding area.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D4
 ~
 ~
@@ -389,7 +389,7 @@ flickers within the ether.  You see many flying creatures --
 insects, pegasi, and dragon wormkins -- navigate the dangerous
 passages of the web.  Exits go in many directions.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -413,7 +413,7 @@ Through The Trees~
 trees.  Various leaves and other debris that the many drones have
 not picked up yet lie here.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -433,7 +433,7 @@ Above The Clouds~
 of the larger dragons that do wish to fly seem to fly away
 from the sticky strands of the web.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -453,7 +453,7 @@ On A Cloud~
 this is not a typical cloud, but it might be the nest of an aerial
 creature.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D5
 ~
 ~
@@ -464,7 +464,7 @@ A Link In The Ethereal Web~
    This is another link in the ethereal web.  Various creatures seem
 to get caught (or hypnotized) by its sticky strands.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -479,7 +479,7 @@ The Tenuous Strand~
    Very windy here since it goes up into the sky somewhat.  Still, it
 is safe enough to move around.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D2
 ~
 ~
@@ -499,7 +499,7 @@ The Elder Wormkin's Room~
 of arcane lore clutter the area, along with shards of armor and
 weaponry.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D5
 ~
 ~
@@ -510,7 +510,7 @@ Another Tree Limb~
    Once again the web crosses another tree limb.  To the side you
 see the possible entrance to another creature's lair.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -530,7 +530,7 @@ The Bird Spider's Lair~
 jewels and weapons suggest the inhabitant must have powerful
 jaws.  Beware!
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D5
 ~
 ~
@@ -541,7 +541,7 @@ A Link In The Ethereal Web~
    This is another link in the ethereal web.  Various creatures
 seem to get caught (or hypnotized) by its sticky strands.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D2
 ~
 ~
@@ -560,7 +560,7 @@ The Quiet Tree Top~
    This is a quiet tree top.  Downwards you can see a familiar path
 that may lead back to Midgaard.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -580,7 +580,7 @@ On The Web~
 of a powerful beast.  Dragon, you think.  You shiver in your boots
 as you tiptoe along this section of the web.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -599,7 +599,7 @@ The Ki-Rin Chamber~
    A wise ki-rin was entrapped here many years ago.  It is from her
 that the ruler of this realm draws magical strength.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -611,7 +611,7 @@ A Link In The Ethereal Web~
 seem to get caught (or hypnotized) by its sticky strands.  To
 the north you sense the heavy breathing of a fiery animal.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -627,7 +627,7 @@ Yevaud's Lair~
 out, 'BEWARE, the Usurper of Midgaard lives here!  FLEE while you can!'
 But even Yevaud has his master... or so you deduce.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D2
 ~
 ~
@@ -640,7 +640,7 @@ seem to get caught (or hypnotized) by its sticky strands.  A
 single spider line lies to the north, while ghastly seemings are
 due southward.  The grim entrance of Arachnos' Lair is downward.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -665,7 +665,7 @@ a torch lit chamber where the souls of unavenged adventurers
 come and gnash their teeth.  The howls and screams of many
 echo through the hall ways.  You see one definite path ahead.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -676,7 +676,7 @@ The Guardian's Room~
    A chair sits here for a tireless guardian who ensures that no
 soul escapes.  Other than that, the room is undecorated.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -693,7 +693,7 @@ They search for those who killed them without warrant, and seek
 the free souls of living beings to inhabit and perhaps adventure
 once more.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -706,7 +706,7 @@ They search for those who killed them without warrant, and seek
 the free souls of living beings to inhabit and perhaps adventure
 once more.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -724,7 +724,7 @@ hear.  The walls are thin and wispy.  The only light you receive is
 the shimmering from the strand of the ethereal web you used to get
 here.  
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -737,7 +737,7 @@ the ether you seen a single shack up ahead with a light in the window.
 You sense a great evil coming from the north and feel inclined to go
 back on the ethereal web and take your chances there.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -752,7 +752,7 @@ The Single Spider Line~
    A single spider line supports you once more.  The shack comes
 closer into view and you are even more inclined to go back now.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -769,7 +769,7 @@ north, if you dare enter it.  You get the sneaking feeling you should
 go back now.  The skies above you darken and roar with the laughter
 of thunder.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D0
 ~
 ~
@@ -800,7 +800,7 @@ The Entrance To The Arachnos' Lair~
    All strands inevitably lead here, the center of the web, the
 entrance to Arachnos' Lair.
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -814,7 +814,7 @@ web, surprisingly unsticky.  The strand does not vibrate like the
 others.  A few ballooning spiders pass by, cackling 'You're gonna
 die, you're gonna fry.  Good bye!'
 ~
-63 0 0 0 0 0
+63 0 0 0 0 2
 D1
 ~
 ~
@@ -830,7 +830,7 @@ The Great Door~
 of ancient runes and names of Midgaard heroes are etched into
 the webwork.  Perhaps lists of victims?  You can't tell.  
 ~
-63 8 0 0 0 0
+63 8 0 0 0 2
 D0
 ~
 door~
@@ -849,7 +849,7 @@ Prime Material Plane.  Coffers upon coffers of gold, magical
 jewels and gems await.  Unfortunately Arachnos is a baggy spider
 too, and webs all her treasures to her beautiful silken body.
 ~
-63 64 0 0 0 0
+63 64 0 0 0 2
 D2
 ~
 door~

--- a/lib/world/wld/64.wld
+++ b/lib/world/wld/64.wld
@@ -99,7 +99,7 @@ considering that they are not volcanos.
    The path leads into the woods to the east, and back up
 the mountain to the west.
 ~
-64 0 0 0 0 0
+64 0 0 0 0 3
 D1
 ~
 ~
@@ -121,7 +121,7 @@ by the lava here?  A rusty ring sticks out of the earth
 in the center... a trapdoor?  This is almost too good to
 be true!
 ~
-64 0 0 0 0 0
+64 0 0 0 0 3
 D3
 ~
 ~

--- a/lib/world/wld/65.wld
+++ b/lib/world/wld/65.wld
@@ -4,7 +4,7 @@ The Path To The Dwarven Village~
 you, you can see the Turning Point, and to the north the path continues 
 toward the mountains.
 ~
-65 4 0 0 0 0
+65 4 0 0 0 2
 D0
 The path continues.
 ~
@@ -21,7 +21,7 @@ The Path At The Base Of The Mountain~
    Now you are at the bottom of a rugged mountain.  The forest around you
 is very dense, and it seems very dark to the north.
 ~
-65 0 0 0 0 0
+65 0 0 0 0 4
 D0
 The path coninues up the mountain.
 ~
@@ -56,7 +56,7 @@ The Top Of The Mountain~
 leading down the mountain.  To the east and west you see entrances to
 what seems like mines.
 ~
-65 0 0 0 0 0
+65 0 0 0 0 4
 D1
 An entrance to the mountain which seems to lead underground.
 ~
@@ -94,7 +94,7 @@ The Entrance To The Mountain~
    Here is an entrance to the mountain.  The door looks very well built,
 and you can hear noise coming from within.
 ~
-65 0 0 0 0 0
+65 0 0 0 0 2
 D1
 ~
 ~
@@ -839,7 +839,7 @@ The Treasury~
    This room appears to be the Queen's Treasury.  There is one
 exit, back to the east.
 ~
-65 520 0 0 0 0
+65 520 0 0 0 1
 D1
 ~
 door~

--- a/lib/world/wld/7.wld
+++ b/lib/world/wld/7.wld
@@ -103,7 +103,7 @@ The Forest Arden~
 and unknown wildlife.  A path leads north and south into the forest.  There is a
 gilded plaque affixed to a boulder.  
 ~
-7 0 0 0 0 3
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -146,7 +146,7 @@ about their daily business.  The courtyard extends in all directions except to
 the east which leads to the gate of the castle.  A steady flow of peasants
 merchants and a few nobles pass by.  
 ~
-7 0 0 0 0 2
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -172,7 +172,7 @@ other.  A knight strolls through the courtyard and the peasants and merchants
 stare at his back with a look of hate after he passes.  They do not seem to be
 very happy.  
 ~
-7 0 0 0 0 2
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -198,7 +198,7 @@ overhead providing a sense of security.  A couple of beggars look up imploringly
 hoping for some charity but everyone ignores them.  To the west lies the main
 entrance to the castle.  
 ~
-7 0 0 0 0 2
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -310,7 +310,7 @@ defense in case the castle's defenses can not hold the outer wall.  The outer
 wall is set aside for the poor quarter while the wealthier inhabitants crowd the
 inner circle.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -335,7 +335,7 @@ the castle.  The stone walls shine a bright white from heavy polishing and the
 massive blocks fit together seamlessly.  To the west a fountain flows underneath
 a large statue of Uther Pendragon.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D0
 a door
 ~
@@ -356,7 +356,7 @@ Cobblestone Road~
 statue of Uther Pendragon and three women.  The sounds and smells to the south
 must be from the castle stables.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -380,7 +380,7 @@ Cobblestone Road~
 fly from the towers high above and all of the buildings gleam of white stone.  
 Several knights seem to be coming and going to the North.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -400,7 +400,7 @@ Cobblestone Road~
 breeze on every tower.  The buildings to the south seem to be filled with the
 sounds of women laughing and gossiping.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D1
 ~
 ~
@@ -421,7 +421,7 @@ snap in the wind.  Everything seems perfect except for the fact that the general
 mood in the castle seem to be depressing.  A tall fence to the south blocks the
 view, but not the sound, of men on horseback.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -442,7 +442,7 @@ be heard and there is some excitement in the crowd.  Several knights in full
 combat gear are among the crowd.  It is easy to pick out those who won and those
 who lost recently.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -466,7 +466,7 @@ Cobblestone Road~
 blocks are placed so precisely that seams are barely visible.  Pennants and
 different seals adorn the spires and walls.
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D1
 ~
 ~
@@ -482,7 +482,7 @@ Cobblestone Road~
 alleys travelling north and south.  A small, friendly building to the south
 looks inviting.  A nice change from the majority of the people in Camelot.
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D1
 ~
 ~
@@ -502,7 +502,7 @@ Cobblestone Road~
 Everyone seems subdued and to have accepted some fate they did not want.  It is
 as if the spirit had been taken away from the city.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D1
 ~
 ~
@@ -522,7 +522,7 @@ Cobblestone Road~
 A drunken ruckus can be heard to the south.  It sounds like it may be the only
 place in Camelot having a good time.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D1
 ~
 ~
@@ -542,7 +542,7 @@ West Lane~
 rusted and look like they haven't been used for a very long time.  A dirt path
 follows the wall to the north and south.  
 ~
-7 0 0 0 0 1
+7 0 0 0 0 0
 D0
 ~
 ~
@@ -563,7 +563,7 @@ boat is tied up to a small dock here.  A cloaked figure is sitting in the back,
 holding a long pole.  This boat looks to be a ferry between the shore and some
 unseen destination through the fog to the west.
 ~
-7 0 0 0 0 2
+7 0 0 0 0 0
 D1
 ~
 ~
@@ -580,7 +580,7 @@ blows from the north but not enough to dispel the fog.  The owner of the boat
 slowly pushes the boat onward with his pole.  The fog is too thick to discern a
 destination.
 ~
-7 0 0 0 0 2
+7 0 0 0 0 0
 D1
 ~
 ~
@@ -613,7 +613,7 @@ the massive castle resting in the middle of the lake on a small island.  The sky
 looks darker to the north and you catch a scent of death and decay from a gust
 of wind in that direction.
 ~
-7 0 0 0 0 2
+7 0 0 0 0 0
 D0
 ~
 ~

--- a/lib/world/wld/70.wld
+++ b/lib/world/wld/70.wld
@@ -4,7 +4,7 @@ The Fissure Under The Ledge~
 pool.  The water trickles quietly down from the ledge above you.  The water
 smells like the water in a sewer.
 ~
-70 13 0 0 0 0
+70 13 0 0 0 5
 D4
 ~
 ~
@@ -20,7 +20,7 @@ The Muddy Sewer~
    You are standing in mud to your knees.  This is not the kind of place
 for a picnic.  The muddy sewer stretches further into the south.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D2
 You see the muddy sewer continuing into the darkness to the south.
 ~
@@ -38,7 +38,7 @@ The Muddy Sewer Junction~
 no person has ever put his foot here before.  It is too muddy for that
 anyway.  The sewer leads north, south and east from here.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 The muddy sewer stretches into the dark to the north.
 ~
@@ -67,7 +67,7 @@ comfortable since you are used to a somewhat different environment.
 The sewer leads to the north of here.  In the middle you can just
 make out an enormous drainpipe leading down.
 ~
-70 13 0 0 0 0
+70 13 0 0 0 5
 D0
 North.  The muddy junction lies in that direction.
 ~
@@ -110,7 +110,7 @@ The Muddy Sewer~
 dark around here and the mud is sticking to your legs, not very pleasant.
 The pipe leads east and south from here.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 4
 D1
 East.  The mud stretches on into the darkness.
 ~
@@ -134,7 +134,7 @@ The Muddy Sewer~
 this has the advantage that it is not hot, it is rather cold actually.
 The pipe bends to the north and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 The muddy sewer pipe leads into a bend that goes east.
 ~
@@ -158,7 +158,7 @@ The Muddy Sewer Bend~
 your knees in something that resembles mud, but you're not quite sure.
 The bend in which you stand leads west and south.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D2
 The pipe leads into a intersection that goes south and east.  The floor here 
 is still covered in mud.
@@ -184,7 +184,7 @@ wrong it is the smell, the sounds, the total darkness that surrounds you.
 Everything here is so depressing.  The pipe leads on with a trail of thick
 mud to the north, east and south.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 4
 D0
 North.  The pipe goes into a bend with a load of mud all the way up the walls.
 The bend leads west.
@@ -217,7 +217,7 @@ The Sewer Junction~
 what you'd think was an air shaft.  The sewer pipes lead to the north,
 south, east and west.  It look quite impossible to force your way up.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 3
 D0
 North.  Mud is the floor basis in that direction.  Yummy.
 ~
@@ -251,7 +251,7 @@ A Bend In The Sewer Pipe~
    You are in a bend in the sewer pipe.  A strong smell seeps in from the
 north.  The sewer goes north and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 2
 D0
 North.  You are staring into a huge junction with exits in all directions.
 ~
@@ -268,7 +268,7 @@ The Muddy Sewer Pipe~
    You have entered a kind of tube intersection that leads south, west
 and east.  Your legs are covered in mud up to the knees.  REAL yucky!  
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D1
 East.  There is less mud in that direction, or that's your impression.
 ~
@@ -297,7 +297,7 @@ The Bend In The Muddy Sewer~
 It is absolutely inconceivable how all this mud could have been placed
 here.  The pipe leads to the west and south.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D2
 South.  There is even more mud that way, incredible!  Although it looks
 like an intersection in the sewer system that leads east and south.
@@ -323,7 +323,7 @@ your hips.  >BWAADR<.  All that fills your mind right now is the dream of
 a hot bath.  This is NOT very clean mud you know, remember you're in the
 sewer!  The pipes leads north, south and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 North.  Sludge and sediment fills this corridor of the sewer that leads
 into a bend going west.
@@ -363,7 +363,7 @@ inappropriate, as the smell would keep any intelligent creature from even
 thinking of anything but getting away from this foul end of the WORLD.
 The bend goes from north to west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 North.  Filled with mud, that place looks like an impassable intersection
 with pipes leading north and east.
@@ -388,7 +388,7 @@ The Old Well~
 sewer leads to the east from here and the well leads down into darkness.
 Metal bars implanted in the side of the well lead down as a ladder.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 3
 D1
 East.  You see, because of the utter darkness that surround you, absolutely
 nothing.  Your light isn't of much use for that kind of distance.
@@ -412,7 +412,7 @@ The Ordinary Bend~
    You are in the middle of a bend in the pipe system of the sewer system, 
 WHAT a place!!!  The pipe leads to the south and the east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D1
 East.  What a quiet place you've found there.  It is an intersection that has
 pipeways going north and east.
@@ -429,7 +429,7 @@ S
 The Sewer Junction~
    You are in a junction that leads north, west and south.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 North.  You see a bend.
 ~
@@ -452,7 +452,7 @@ The Ordinary Junction~
    This looks like an ordinary junction, actually it seems very quiet
 here.  The pipelines lead west, east and north.
 ~
-70 13 0 0 0 0
+70 13 0 0 0 1
 D0
 To the north you can see a junction like this one, leading north and west.
 ~
@@ -475,7 +475,7 @@ A Quiet Pipe Junction~
    This is the kind of place to rest, though the smell could be a LOT
 better than this.  The sewer goes east, north and west from here.
 ~
-70 13 0 0 0 0
+70 13 0 0 0 1
 D0
 In that direction, you can't see anything.  It is just too dark.
 ~
@@ -504,7 +504,7 @@ and fall and fall...
 ... And come to an abrupt end.  THIS is strange indeed.  There is an arched
 entryway leading down.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D5
 Down.  It is utterly dark that way, though you can make out an intersection
 of sewer pipes leading west, north and east.
@@ -517,7 +517,7 @@ The Sewer~
    You are standing in mud up to your ankles.  This is an intersection with 
 sewer pipes leading east, south and west.
 ~
-70 13 0 0 0 0
+70 13 0 0 0 1
 D1
 To the east there is a peculiar looking round room.
 ~
@@ -540,7 +540,7 @@ Another Intersection~
    You have never seen anything so BORING... This is an intersection with
 pipes leading north, south and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 To the north there is an intersection, where the pipes are leading west and
 east.  You notice that the floor to the west is covered in mud.
@@ -593,7 +593,7 @@ S
 The Sewer Junction~
    You stand in a junction of sewer pipes leading north, east and west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 ~
 ~
@@ -614,7 +614,7 @@ The Triple Junction~
    You stand in the middle of a huge junction of concrete sewer pipes.  The 
 pipes lead into three different directions: east, south and west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D1
 East.  You can see a bend in the sewer pipe leading north.
 ~
@@ -640,7 +640,7 @@ There are enormous concrete pipes leading north, south, east and west.
 There is also a metal ladder built into the concrete wall leading up through
 a layer of garbage.  
 ~
-70 13 0 0 0 0
+70 13 0 0 0 1
 D0
 To the north you can see a huge triple junction with sewer pipes leading
 west and east.
@@ -679,7 +679,7 @@ S
 A Triple Junction~
    You stand in a junction with pipes leading west, north and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 To the north there is an ENORMOUS quadruple sewer junction, all lit up by
 an odd light.
@@ -701,7 +701,7 @@ S
 A Bend In The Sewer Pipe~
    You can look in two directions where the pipe leads: south and west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 2
 D2
 To the south you can see another bend leading west.
 ~
@@ -718,7 +718,7 @@ The Sewer Pipe Bend~
    You can look in two different directions where the pipe goes: west and 
 north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 2
 D0
 North.  You see another bend leading west.
 ~
@@ -737,7 +737,7 @@ The Pit~
 there is a pit leading down.  There are bars set in the side of the pit
 wall functioning as a ladder.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D3
 West.  You can see a dimly lit quadruple junction with an exit up.
 ~
@@ -757,7 +757,7 @@ you are certain that the doorway is in the opposite direction of what
 it was when you entered.  It now leads east.  There is only this one
 exit.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D1
 You can just make out a smaller room with a chair.
 ~
@@ -768,7 +768,7 @@ S
 The Three Way Junction~
    You are standing in a junction of pipes that lead west, east and south.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D1
 East.  You can make out a dimly lit Guard Room.
 ~
@@ -790,7 +790,7 @@ The Sewer Store Room~
    You stand in a small room lit by a single torch set in the wall.  The only 
 way out of here is to the north.
 ~
-70 8 0 0 0 0
+70 8 0 0 0 1
 D0
 To the north you see a pipe junction.
 ~
@@ -803,7 +803,7 @@ The Shaft~
 ladder is your tool to work your way down if you so wish.  The sewer pipe
 leads south from here.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D2
 To the south you can see the pipe leading further south into darkness.
 ~
@@ -827,7 +827,7 @@ The Sewer Entrance~
 you an air shaft leads up into sunlight.  It seems totally impossible to go
 up that way.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 To the north you can just make out a huge shaft leading down.
 ~
@@ -844,7 +844,7 @@ The Junction Going Three Ways~
    You are in a passageway in the pipes of the sewer system leading north,
 east and west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 You see a sewer pipe leading north.
 ~
@@ -868,7 +868,7 @@ the feeling of being watched.  To the south there is an entrance to a
 larger room.  The room is lit by five torches, also set in the walls.  To
 the west there is a doorway leading out to the sewers.
 ~
-70 8 0 0 0 0
+70 8 0 0 0 1
 D2
 You can see an even larger room than this one, filled with light.
 ~
@@ -887,7 +887,7 @@ it. This is strange as it looks as if the glitter lights the whole room.
 It looks very bright.  To the south the floor is covered with yucky water.
 The north leads to a sort of a guard room.
 ~
-70 8 0 0 0 0
+70 8 0 0 0 1
 D0
 To the north you can see the guard room.
 ~
@@ -904,7 +904,7 @@ The Pool In The Sewer~
    You stand in water to your waist.  To the north is the entrance to this
 room.  A single door leads east.
 ~
-70 8 0 0 0 0
+70 8 0 0 0 1
 D0
 To the north you see the entrance to this room.
 ~
@@ -922,7 +922,7 @@ The Sewers~
 You can see a shaft leading up but it looks too difficult to go up
 that way.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D2
 ~
 ~
@@ -932,7 +932,7 @@ S
 The Junction~
    You stand in a junction leading north, west and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 ~
 ~
@@ -956,7 +956,7 @@ The Small Room~
 to have been bolted to the rock floor.  A doorway leads south and another
 leads east into darkness.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D1
 Utter darkness...
 ~
@@ -973,7 +973,7 @@ The Sewer Pipe~
    You are in what reminds you of a foul sewer, as if you liked being here!  
 You can see two exits leading either north or south.
 ~
-70 8 0 0 0 0
+70 8 0 0 0 1
 D0
 ~
 ~
@@ -989,7 +989,7 @@ The Grand Sewer~
    You are in a grand sewer pipe.  This stretches toward the south.  It is
 large indeed!  A doorway leads to the east from here.
 ~
-70 8 0 0 0 0
+70 8 0 0 0 1
 D0
 To the north you can see a doorway.
 ~
@@ -1011,7 +1011,7 @@ The South End Of The Grand Pipe~
    You stand in water to your knees.  A doorway leads west from here.  The
 pipe stretches north.
 ~
-70 8 0 0 0 0
+70 8 0 0 0 1
 D0
 You see a lot of pictures decorating the walls.
 ~
@@ -1027,7 +1027,7 @@ The Edge Of The Water Sewer~
    You stand in a room where half of the floor is covered in water.  The
 water leads east and a doorway leads west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 3
 D1
 You can hardly make out much more than that the next place is in a pipe 
 with more water.
@@ -1048,7 +1048,7 @@ The Dark Hallway~
    You can't see much of this, even with a light.  The hallway goes into a
 passageway to the south.  A doorway leads west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D2
 You can see nothing at all because it is completely dark in that direction.
 ~
@@ -1065,7 +1065,7 @@ The Dark Passageway~
    You can't see anything but the ground where you put your feet.  The 
 passageway seems to continue south and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1084,7 +1084,7 @@ The Dark Passageway~
    You can't see anything but the ground where you put your feet.  The
 passageway seems to continue south and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1103,7 +1103,7 @@ The Dark Passageway~
    You can't see anything but the ground where you put your feet.  The
 passageway seems to continue south and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1124,7 +1124,7 @@ The passageway seems to continue west and north.  To the east there
 is water covering the floor and that leads through an arched entry
 to a watery sewer.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 1
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1152,7 +1152,7 @@ The Watery Sewer Bend~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to bend and lead south and west.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D2
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1175,7 +1175,7 @@ The Watery Sewer~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to lead south and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1198,7 +1198,7 @@ The Watery Sewer~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to lead south and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1221,7 +1221,7 @@ The Watery Sewer Junction~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to lead into a junction going south, north and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1250,7 +1250,7 @@ The Watery Sewer~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to lead south and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1273,7 +1273,7 @@ The Watery Sewer Junction~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to lead into a junction that goes north, south and east.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1302,7 +1302,7 @@ The Watery Sewer~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to lead south and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1325,7 +1325,7 @@ The Watery Sewer Bend~
    You can't see anything but the water you're in up to your hips.  The sewer
 seems to bend and lead west and north.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see anything in that direction and your light isn't enough to light
 that far.
@@ -1351,7 +1351,7 @@ mostly because of the trickling of water.  The water from the sewer actually
 washes over this ledge and makes it quite slippery.  From here it drops, 
 like a waterfall, into the pool far down.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D2
 You can't see a thing.  It is too dark.
 ~
@@ -1376,7 +1376,7 @@ washes over this ledge and makes it quite slippery.  From here it drops,
 like a waterfall, into the pool far down.  Under you there is a small fissure
 in the rock.  It seems big enough to contain a few people.
 ~
-70 9 0 0 0 0
+70 9 0 0 0 5
 D0
 You can't see a thing.  It is too dark.
 ~

--- a/lib/world/wld/71.wld
+++ b/lib/world/wld/71.wld
@@ -6,7 +6,7 @@ The air is damp and the rock on which you stand is slippery.  The pool
 seems too dark to make anything clear.  The pool seems to extend to the
 east.  The rock can be climbed upwards from here.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D1
 The pool extends eastwards, but you cannot find enough room to move in that
 direction.
@@ -26,7 +26,7 @@ smell the foul stench of the slimy sediment as you try not to get covered
 by the falling sludge.  To the east there is an entryway leading out from
 here and it seems absolutely impossible to force the muddy descent.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D1
 East.  You see nothing of interest.
 ~
@@ -43,7 +43,7 @@ Under The Dark Pit~
 with only two exits, up and east.  A tall ladder has been left here so
 that you can climb up through the pit without the use of a rope.
 ~
-71 9 0 0 0 0
+71 9 0 0 0 1
 D1
 ~
 ~
@@ -70,7 +70,7 @@ A Muddy Bend In The Sewer System~
 sewer.  The 'floor' is covered completely by mud!  This includes covering
 your legs up to your knees as well.  The pipe leads west and south.
 ~
-71 9 0 0 0 0
+71 9 0 0 0 4
 D2
 To the south there is less mud than here!  It actually seems to end there!
 You have a felling it would be nice to have your feet free from mud again.
@@ -94,7 +94,7 @@ A Junction In The Sewer Pipes~
    You stand in the middle of what looks like a triple junction of pipes
 going east, west and north.
 ~
-71 9 0 0 0 0
+71 9 0 0 0 1
 D0
 You can see a mud area starting in that direction.
 ~
@@ -118,7 +118,7 @@ up.  The only secure point here is the metal bars that are cemented into the
 sides, the ones that you cling frantically to so that you don't fall.  Who
 knows how deep this well is?  The bars lead down and up and nowhere else.
 ~
-71 9 0 0 0 0
+71 9 0 0 0 5
 D4
 There is a slight, dim light from above, or maybe it is just your imagination.
 Anyway it SEEMS darker down here than up there, if that is possible.
@@ -146,7 +146,7 @@ safe, solid ledge under your feet.  The ledge continues to the east but not
 back south.  It seems that the ledge is too narrow to turn on so you'll have
 to continue forward.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D1
 The ledge continues east.
 ~
@@ -186,7 +186,7 @@ there is no way of turning around on this all too narrow path.  There IS
 another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D0
 North.  The ledge leads into a corner and turns eastward.
 ~
@@ -211,7 +211,7 @@ there is no way of turning around on this all too narrow path.  There IS
 another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D0
 North.  The ledge leads further north.
 ~
@@ -236,7 +236,7 @@ there is no way of turning around on this all too narrow path.  There IS
 another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D0
 North.  The ledge leads further north.
 ~
@@ -261,7 +261,7 @@ there is no way of turning around on this all too narrow path.  There IS
 another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D0
 North.  The ledge leads further north.
 ~
@@ -285,7 +285,7 @@ The Southwestern Corner Of The Ledge~
 the north of here.  The ledge seems to lead around some sort of Abyss of
 total darkness.  The ledge seems to have an odd-looking edge here.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D0
 North.  The ledge leads further north.
 ~
@@ -330,7 +330,7 @@ don't resemble pipes anymore.  They look more like a real stone tunnel,
 or a passageway hewn directly into the rock.  The ways from here lead
 north, east and west.
 ~
-71 9 0 0 0 0
+71 9 0 0 0 1
 D0
 North.  You see a ledge to something that looks like an abyss.
 ~
@@ -352,7 +352,7 @@ there is no way of turning around on this all too narrow path.  There IS
 another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D1
 The ledge leads further east.
 ~
@@ -384,7 +384,7 @@ has an exit going to the south.  Though you could jump into mid-air,
 but it probably wouldn't be such a good idea.  The way south is in
 utter darkness.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 4
 D0
 ~
 ~
@@ -408,7 +408,7 @@ The Northeastern Corner Of The Ledge~
 safe, solid ledge under your feet.  The ledge continues to the west and
 leads south from here into darkness.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D2
 ~
 ~
@@ -446,7 +446,7 @@ another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.  And THAT is west of here
 so watch your step.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D2
 The ledge leads further south.
 ~
@@ -467,7 +467,7 @@ another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.  And THAT is west of here
 so watch your step.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D2
 The ledge leads further south.
 ~
@@ -488,7 +488,7 @@ another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.  And THAT is west of here
 so watch your step.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D2
 The ledge leads further south.
 ~
@@ -509,7 +509,7 @@ another exit from here but that leads right into mid-air and with high
 probability of a free fall session afterwards.  And THAT is west of here
 so watch your step.  You also see a small opening to the east.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D1
 East.  You stare into darkness.
 ~
@@ -533,7 +533,7 @@ The Southeastern Corner Of The Ledge~
 north of here.  The ledge seems to lead around some sort of abyss of total
 darkness.
 ~
-71 13 0 0 0 0
+71 13 0 0 0 5
 D0
 North of here you can see a ledge.
 ~
@@ -586,7 +586,7 @@ Under The Shaft~
    A ladder leads up from here to the Shaft.  A small opening leads west
 from here.
 ~
-71 9 0 0 0 0
+71 9 0 0 0 5
 D3
 You can see a narrow ledge going north and south.
 ~
@@ -603,7 +603,7 @@ The Sewer Line~
    You are in a narrow part of the sewer.  Down the sewer continues and to
 the north is the ledge.
 ~
-71 9 0 0 0 0
+71 9 0 0 0 3
 D0
 You can see the southern part of the ledge.
 ~

--- a/lib/world/wld/72.wld
+++ b/lib/world/wld/72.wld
@@ -42,7 +42,7 @@ The Lair~
 also see a lot of slime.  On the wall is a torch sitting in its sconce.  To
 the north is a wooden door.
 ~
-72 8 0 0 0 0
+72 8 0 0 0 1
 D0
 You can see the inner lair.
 ~
@@ -77,7 +77,7 @@ The Lair~
    On the floor you see a lot of human decay, like bones and skulls.  You
 also see a lot of slime.  On the wall is a torch sitting in its sconce.
 ~
-72 8 0 0 0 0
+72 8 0 0 0 1
 D0
 You see another part of the lair.
 ~
@@ -112,7 +112,7 @@ The Lair~
    On the floor you see a lot of human decay, like bones and skulls.  You
 also see a lot of slime.  On the wall is a torch sitting in its sconce.
 ~
-72 8 0 0 0 0
+72 8 0 0 0 1
 D0
 You see another part of the lair.
 ~
@@ -147,7 +147,7 @@ The Lair~
    On the floor you see a lot of human decay, like bones and skulls.  You
 also see a lot of slime.  On the wall is a torch sitting in its sconce.
 ~
-72 8 0 0 0 0
+72 8 0 0 0 1
 D2
 You see another part of the lair.
 ~
@@ -177,7 +177,7 @@ The Lair~
    On the floor you see a lot of human decay, like bones and skulls.  You
 also see a lot of slime.  On the wall is a torch sitting in its sconce.
 ~
-72 12 0 0 0 0
+72 12 0 0 0 1
 D0
 You see another part of the lair.
 ~
@@ -211,7 +211,7 @@ The Lair~
    On the floor you see a lot of human decay, like bones and skulls.  You
 also see a lot of slime.  On the wall is a torch sitting in its sconce.
 ~
-72 8 0 0 0 0
+72 8 0 0 0 1
 D0
 You see another part of the lair.
 ~
@@ -242,7 +242,7 @@ The Lair Entrance~
 you can see some slime at the lower part of the door.  You also see
 some skulls and some broken bones.
 ~
-72 13 0 0 0 0
+72 13 0 0 0 2
 D0
 You can see the lair.
 ~
@@ -262,7 +262,7 @@ S
 The Crawlway~
    You are in a narrow crawlway.  It is rather boring here.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You see a four-way junction.
 ~
@@ -279,7 +279,7 @@ The Four-Way Junction~
    You are in a sewer junction.  To the north is a small hole, to the west
 is a narrow crawlway and to the east and south the sewer continues.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D0
 You can see a small cave-like room.
 ~
@@ -305,7 +305,7 @@ S
 The Small Cave~
    You are in a collapsed sewer drain, which now is more like a small cave.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D2
 You look back into the four-way junction.
 ~
@@ -316,7 +316,7 @@ S
 The Sewer Drain~
    You are in a dry sewer drain which bends to the north.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D0
 You can see the drain continuing north.
 ~
@@ -332,7 +332,7 @@ S
 The Sewer Drain~
    You are in a dry sewer drain which bends to the east.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You can see the drain continuing east.
 ~
@@ -349,7 +349,7 @@ The End Of The Drain~
    You are at the end of the drain around you the sewer has collapsed, the
 only exit is west.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D3
 You see the sewer drain.
 ~
@@ -362,7 +362,7 @@ The Half-Wet Drain~
 the north it looks more dry, south however the drain runs down into
 some water.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 4
 D0
 To the north lies a dry four-way junction.
 ~
@@ -384,7 +384,7 @@ Under Water In The Sewer~
 better continue onwards before you drown.  It is a good thing that you can
 hold your light above the water-level.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 6
 D0
 It is hard to see, but it looks like the drain runs slightly upwards.
 ~
@@ -402,7 +402,7 @@ The Half-Dry Drain~
 bit downwards into some water to the east you can see a small hole.  To the
 west you see another drain.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 4
 D0
 You see the drain running down into some water.
 ~
@@ -431,7 +431,7 @@ S
 The Very Small Room~
    You are in a very small room, it is pretty uninteresting.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D3
 Through the little hole you can see a half-dry drain.
 ~
@@ -443,7 +443,7 @@ A Dry Sewer Drain~
    You are in a dry but dirty sewer drain.  The drain continues east and
 south.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You see a half-dry drain.
 ~
@@ -459,7 +459,7 @@ S
 A Boring Drain~
    You are in yet another sewer drain.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D0
 You see a sewer drain continuing to the north.
 ~
@@ -476,7 +476,7 @@ The Sewer Drain~
    You are in a sewer drain, there is nothing special in here, except for a 
 loud echo.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You can see another sewer drain.
 ~
@@ -497,7 +497,7 @@ S
 The Sewer Drain~
    You are in a drain, with some slimy water on the floor.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You see a sewer bend.
 ~
@@ -518,7 +518,7 @@ The Sewer Bend~
    You find yourself in an ordinary sewer bend, which bends from west to
 north.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D0
 You see a sewer drain.
 ~
@@ -537,7 +537,7 @@ scratches on the pipe wall, as if from a gigantic rat.  North and
 south the sewer continues as usual, but west it looks a little
 strange.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D0
 You see nothing but a sewer drain.
 ~
@@ -560,7 +560,7 @@ The Sewer~
 You see some odd scratches on the pipe wall, as from a gigantic rat.  There 
 is a sewer drain south.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D2
 You see a sewer drain.
 ~
@@ -574,7 +574,7 @@ the pipe wall, as from a gigantic rat.  And you can see a lot of organic
 decay like bones from animals AND humans.  West the drain runs slightly
 upwards.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You see a sewer junction.
 ~
@@ -593,7 +593,7 @@ substance you see a lot of decay.  You see some odd scratches on the wall,
 as if from a gigantic rat.  Both to the east and west the pipe seems to run
 down.
 ~
-72 13 0 0 0 0
+72 13 0 0 0 3
 D1
 You see a sewer.
 ~
@@ -610,7 +610,7 @@ The Strange Sewer~
    You are in an ordinary sewer except for a lot of scratches on the sewer
 wall, and a lot of debris on the floor.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You see a sewer.
 ~
@@ -631,7 +631,7 @@ The Sewer~
    You are in a sewer with more scratches on the walls.  And of course a whole
 lot of decay.  The drain runs east and north.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D0
 You see yet another sewer line.
 ~
@@ -649,7 +649,7 @@ The Sewer Drain~
 room.  You see some odd scratches on the drain wall, as if from a gigantic
 rat.  The sewer leads south.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D1
 You see a cave-like room.
 ~
@@ -666,7 +666,7 @@ The Rat's Lair~
    You are in a little cave.  You are able to see quite a lot of debris on
 the floor.  There is a sewer drain west of here.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 3
 D3
 You see the sewer system that way.
 ~
@@ -679,7 +679,7 @@ The Wall Of The Abyss~
 exit leading up as well, though you'll have to open the tiny rock again to
 do so.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 5
 D4
 ~
 rock~
@@ -695,7 +695,7 @@ The Entrance~
 you from inside the walls.  In the middle of the room there is a small altar.
 To the north there is a small round door.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 1
 D0
 A beam of red light seeps through a hole in the door.
 ~
@@ -721,7 +721,7 @@ The Corridor~
    The corridor is glowing oppressively in a red hue.  You can hear wailing
 through an open black hole to the east.  To the south there is a round door.
 ~
-72 8 0 0 0 0
+72 8 0 0 0 1
 D1
 The hole seems more black than the night.  It is appears to be "eating" the
 red light around it.
@@ -774,7 +774,7 @@ The T-Crossing~
 the west.  To the south there are a black hole.  There is writing
 in the wall.  Wails can be heard from the south.
 ~
-72 13 0 0 0 0
+72 13 0 0 0 1
 D1
 It is too dark to tell.
 ~
@@ -802,12 +802,7 @@ The Firedeath~
    This room is very hot.  There are flames surrounding you.  You can
 see no exits at all!  Skeletons are lying all over the floor.
 ~
-72 12 0 0 0 0
-E
-skeletons~
-   The skeletons looks like they had suffered the death of hunger.  One of them
-looks like he has written something at the wall.  
-~
+72 12 0 0 0 1
 E
 writing wall~
    The writing says 'A prayer to the GODS will not be heard, though the only
@@ -820,7 +815,7 @@ The Torture Room~
 are hanging in rusty chains.  In the middle of the room there is a big metal 
 box, covered with dust.  To the south you can just make out a small exit.
 ~
-72 8 0 0 0 0
+72 8 0 0 0 1
 D2
 It is too dark to tell.
 ~
@@ -845,7 +840,7 @@ the place, and makes you feel sick.  Small flames sometimes shoot
 up from the hot mud.  To the west there is a small door.  To the 
 north you can see an iron door.
 ~
-72 12 0 0 0 0
+72 12 0 0 0 5
 D0
 It is too dark to tell.
 ~
@@ -863,7 +858,7 @@ On The Walls Of The Abyss~
 ground down below.  You cannot see anymore handholds below you and thus
 this stops your journey down, as the only exit is up.
 ~
-72 9 0 0 0 0
+72 9 0 0 0 5
 D4
 ~
 ~

--- a/lib/world/wld/73.wld
+++ b/lib/world/wld/73.wld
@@ -3,7 +3,7 @@ Cave Entrance~
    You are standing in the cave entrance.  It is very dark down here.  There
 is writing on the wall.  There is an exit to the north.  A stairway leads up.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 To the north you can see a small tunnel.
 ~
@@ -24,7 +24,7 @@ Cave Tunnel~
    You are walking in a tunnel.  It is very cold.  You can feel the presence
 of a living thing... SOMEWHERE.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 To the north you can see the tunnel continuing.
 ~
@@ -40,7 +40,7 @@ S
 Cave Room~
    You are standing in a room.  It is much cooler now.  The walls are glowing.
 ~
-73 8 0 0 0 0
+73 8 0 0 0 1
 D1
 To the east you see the tunnel going downwards.
 ~
@@ -61,7 +61,7 @@ The Cave T-Cross~
    You are standing in a mudlike substance.  The smell here is awful, it is
 rotten.  To the west you can see some light.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 2
 D1
 To the east the tunnel still goes downwards.
 ~
@@ -91,7 +91,7 @@ The Cave Turning-Point~
 before I disappear?'  To the south you notice a flat round stone is blocking the
 way.  To the west you can see mud.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 2
 D2
 You can see an opening behind the stone.
 ~
@@ -115,7 +115,7 @@ for ages.  In the middle of the room you see a socket with a crystal globe.
 The globe glows with a pulsing light.  To the north you see a stone door.
 To the south you see a grey block.
 ~
-73 8 0 0 0 0
+73 8 0 0 0 1
 D0
 You see a round stone door.
 ~
@@ -141,7 +141,7 @@ The Mudhole~
    You are standing in a lot of mud.  The mud goes to your chest.  You feel
 the presence of something IN the mud.  The only obvious exit is to the west.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 6
 D0
 You can see nothing at all.
 ~
@@ -156,7 +156,7 @@ S
 A Tunnel~
    The mud goes to your knees.  Otherwise the tunnel looks very normal.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 5
 D0
 ~
 ~
@@ -176,7 +176,7 @@ The Long Tunnel~
    Here there is almost no mud, as you stand at the top of a small rock.  Just
 beside you there are a sign which says 'WARNING!  The worms are dangerous!'
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 You can see a lot of mud... Yuck!
 ~
@@ -194,7 +194,7 @@ The Hot Room~
 cold.  To the north it goes downwards into some mud.  There are also an
 exit to the west.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 You see a lot of mud.
 ~
@@ -211,7 +211,7 @@ The Small Room~
    As you look around you notice a small statue.  There are exits to the west
 and to the east.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D1
 It is pitch dark out there.
 ~
@@ -233,7 +233,7 @@ The Stalagmite Cave~
    You are standing in a stalagmite cave.  Water is dripping from the walls.
 It is very cold in here.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 2
 D0
 ~
 ~
@@ -257,7 +257,7 @@ The Stalagmite Tunnel~
    You has entered a small tunnel.  Here it is quite dry.  Maybe it would be a
 good idea to rest here.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 You can see a small cave to the north.
 ~
@@ -273,7 +273,7 @@ The Spongy Room~
    You definitely do NOT like this area.  It is very dank, and most of the
 room is wet.
 ~
-73 12 0 0 0 0
+73 12 0 0 0 3
 D1
 ~
 ~
@@ -288,7 +288,7 @@ The Stalagmite T-Cross~
    You are standing in a cross.  To the north you can see some light.
 Otherwise it is dark.
 ~
-73 12 0 0 0 0
+73 12 0 0 0 1
 D0
 You see some light ahead.
 ~
@@ -308,7 +308,7 @@ The Blind End Room~
    This room is obviously a blind end.  To the north you see a primitive
 picture.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 You see a primitive picture of some people dancing around a huge sun.  The
 sun is about 7 feet in diameter, which shows the size of the picture.
@@ -332,7 +332,7 @@ people dancing around a moon which is drawn on the floor.  It looks very
 old, and it is very dusty.  To the south you see the back side of a secret
 door.
 ~
-73 521 0 0 0 0
+73 521 0 0 0 1
 D2
 You can see a picture with some people crawling around a huge moon.
 ~
@@ -344,7 +344,7 @@ The Square Lair~
    You are standing in the south-east part of the lair.  You can see a skeleton
 lying in the corner.
 ~
-73 8 0 0 0 0
+73 8 0 0 0 1
 D0
 Another part of the lair.
 ~
@@ -369,7 +369,7 @@ The Square Lair~
    You are standing in the north-east part of the lair.
 You see a sign on the wall.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D1
 You see a wooden door.
 ~
@@ -397,7 +397,7 @@ The Square Lair~
    You are standing in the north-west part of the lair.  Here there is another
 sign.  There is an exit from the lair to the north.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 You see a small tunnel leading north.
 ~
@@ -425,7 +425,7 @@ The Lair End~
    You can see a table in front of you.  It is very dusty.  Five skeletons are
 sitting around the table.  Exits are north and east.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 The northern part of the lair.
 ~
@@ -458,7 +458,7 @@ The East Tunnel~
    You are standing in dark tunnel, the exits are east and west.  To the west
 you see a wooden door.
 ~
-73 12 0 0 0 0
+73 12 0 0 0 1
 D1
 You can see a muddy tunnel.
 ~
@@ -474,7 +474,7 @@ S
 The North Tunnel~
    You are standing in a dark tunnel, it leads upwards.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 The dark tunnel continues.
 ~
@@ -496,7 +496,7 @@ The L-Shaped Room~
    You are standing in deep darkness.  To the south there is a small exit.
 To the east you can see a gaping hole.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D1
 ~
 ~
@@ -511,7 +511,7 @@ The Circular Hall~
    You are standing in round hall.  To the north, east and south you can see
 a stone head hanging on the walls.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 You see a red dragon's head hanging on the wall.
 ~
@@ -557,7 +557,7 @@ A Dusty Tunnel~
 Otherwise it is quite boring here, looks like a place to rest!  To the west
 you see the outline of a door.  A tunnel leads to the east.
 ~
-73 12 0 0 0 0
+73 12 0 0 0 1
 D1
 You see a tunnel which leads downwards.  It is quite dark.
 ~
@@ -575,7 +575,7 @@ The Crossing~
 in every direction, except up and down.  In the dust you notice strange
 footprints.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 ~
 ~
@@ -603,7 +603,7 @@ The L-Shaped Room~
 tunnel to the east.  You feel very afraid!
 A sign is hanging on the wall.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 2
 D0
 ~
 ~
@@ -624,7 +624,7 @@ of bones are scattered all over the floor.  On the walls you can see
 some burned shapes.  You smell burnt flesh.  Two creatures are half
 melted into the floor.
 ~
-73 8 0 0 0 0
+73 8 0 0 0 2
 D0
 You can see a long tunnel.
 ~
@@ -641,7 +641,7 @@ The Burnt Room~
    You are in a room, which once has at one time been quite burnt.  There
 is writing on the wall.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D2
 You can see a red glow...
 ~
@@ -660,7 +660,7 @@ S
 The Windy Tunnel~
    You are standing in a tunnel.  Above you, you can feel a breeze.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D1
 It is too dark to tell.
 ~
@@ -680,7 +680,7 @@ The Glittering Room~
    This room is very bright.  On the walls you can see some silver.  Exits
 are west, east and south.
 ~
-73 8 0 0 0 0
+73 8 0 0 0 1
 D1
 ~
 ~
@@ -702,7 +702,7 @@ S
 The Secret Passageway~
    You have entered a tiny room.  There is only an exit to the west.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D3
 You can see a light to the west.
 ~
@@ -715,7 +715,7 @@ The End Of Long Tunnel~
 grey mass.  To the east you can see a tremendously long tunnel, but you know
 that, you were just there.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 5
 D1
 A long tunnel.  JUST like in the description!
 ~
@@ -737,7 +737,7 @@ The Stair-Room~
 walls.  You can feel that darkness is ruling the place.  There is one exit:
 south.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D2
 Nothing but darkness...
 ~
@@ -749,7 +749,7 @@ A Dark Tunnel~
    You are standing in a dark tunnel.  It continues to the north and to the
 south.  Bones are spread on the floor.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 1
 D0
 ~
 ~
@@ -768,7 +768,7 @@ The Entrance To The Lair~
    The smell here is awful.  To the south you can see some smoke.  A tunnel
 leads north and east.
 ~
-73 13 0 0 0 0
+73 13 0 0 0 2
 D0
 ~
 ~
@@ -789,7 +789,7 @@ The North-Eastern Part Of The Basilisk's Cave~
    It is hard to see here because of the smoke.  To the north you can barely
 see a small tunnel.  Other exits are to the south and to the west.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 2
 D0
 ~
 ~
@@ -808,7 +808,7 @@ The South-Eastern Part Of The Basilisk's Cave~
    There is a very small hole in wall from which the smoke is coming from. 
 Otherwise it is pitch black.  Exits are north and west.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 2
 D0
 You can see nothing but smoke.
 ~
@@ -830,7 +830,7 @@ The North-Western Part Of The Basilisk's Cave~
 makes you feel sick.  This place where the Basilisk sleeps.  Watch out...
 maybe it is not far from here...
 ~
-73 9 0 0 0 0
+73 9 0 0 0 2
 D1
 ~
 ~
@@ -848,7 +848,7 @@ S
 The South-Western Part Of The Basilisk's Cave~
    You can see nothing but smoke.  
 ~
-73 9 0 0 0 0
+73 9 0 0 0 5
 D0
 ~
 ~
@@ -867,7 +867,7 @@ The Small Cave~
    You are standing in small cave.  You can see some light at the end.  Exits
 are north and south.
 ~
-73 13 0 0 0 0
+73 13 0 0 0 2
 D0
 You can see only smoke.
 ~
@@ -884,7 +884,7 @@ The Northern End Of The Pool~
    You have wet feet, you are standing in water.  The water looks calm.  You
 can see that it is a big lake.  Light seeps from the water.
 ~
-73 8 0 0 0 0
+73 8 0 0 0 4
 D0
 You can see a small cave.
 ~
@@ -906,7 +906,7 @@ The Pool~
    You are swimming in water.  It is getting deep here.  It is also dark in
 this end.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 6
 D2
 You can see some bubbles in the water.
 ~
@@ -922,7 +922,7 @@ S
 The South End Of The Pool~
    You standing in water up to your neck!  You can only see water.
 ~
-73 8 0 0 0 0
+73 8 0 0 0 5
 D0
 You can see calm water.
 ~
@@ -938,7 +938,7 @@ S
 The Pool~
    You are swimming in DARKNESS.  You feel something touching your right leg.
 ~
-73 9 0 0 0 0
+73 9 0 0 0 6
 D0
 To dark to tell.
 ~

--- a/lib/world/wld/74.wld
+++ b/lib/world/wld/74.wld
@@ -120,7 +120,7 @@ clusters of drooping white hyacinths.  Soft white cobbles have been trod into
 the ground to create this functional and beautiful pathway.  This appears to be
 the beginning or end of the path.    
 ~
-74 4 0 0 0 0
+74 4 0 0 0 2
 D3
 ~
 ~
@@ -140,7 +140,7 @@ the ground to create this functional and beautiful pathway.  The path ends to
 the east at the entrance to the cemetery.  The noises of the city have faded
 away.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D1
 ~
 ~
@@ -186,7 +186,7 @@ flowers has been uprooted violently, leaving a shallow hole in the dirt near
 the path.  A few dismembered hyacinth petals litter the ground near the hole.
 A hole has been dug in the ground here.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -226,7 +226,7 @@ Intricate in design and strong of structure, this gate looks adequate enough at
 keeping people out when closed and locked.  The round, cobbled path ends here,
 leaving visitors to tread on the lawn while visiting the cemetary.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -251,7 +251,7 @@ groundskeepers can easily access all the plots without disturbing the graves
 themselves.  Far to the east, you can just make out the roof of a large, marble
 mausoleum.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -269,7 +269,7 @@ more than a name carved into it.  These look to be rather new in comparison to
 some of the larger and more elaborate grave markers to the north.  One grave
 lies open and waiting to be filled, its tombstone unmarked as of yet.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -292,7 +292,7 @@ alone.  The tombstones are mostly standard marble or granite squares with no
 more than a name carved into it.  The gravemarkers here are a bit more
 weathered than those to the south.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -315,7 +315,7 @@ alone.  The tombstones are mostly standard marble or granite squares with no
 more than a name carved into it.  The gravemarkers here are a bit more
 elaborate and older by generations.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -338,7 +338,7 @@ markers draw the eye to the dainty-sized graves where children who have passed
 are laid to rest.  Enormous bouquets of flowers decorate each melancholy grave,
 a tribute to the tiny lives snuffed out before their time.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D1
 ~
 ~
@@ -366,7 +366,7 @@ markers draw the eye to the dainty-sized graves where children who have passed
 are laid to rest.  Enormous bouquets of flowers decorate each melancholy grave,
 a tribute to the tiny lives snuffed out before their time.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D1
 ~
 ~
@@ -387,7 +387,7 @@ two or three grave markers, but some support as many as a dozen.  In general,
 the tombstones here are less expensive, granite blocks with very few elaborate
 statues or sculptures.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -404,7 +404,7 @@ two or three grave markers, but some support as many as a dozen.  In general,
 the tombstones here are less expensive, granite blocks with very few elaborate
 statues or sculptures.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 4
 D0
 ~
 ~
@@ -421,7 +421,7 @@ two or three grave markers, but some support as many as a dozen.  In general,
 the tombstones here are less expensive, granite blocks with very few elaborate
 statues or sculptures.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 4
 D0
 ~
 ~
@@ -437,7 +437,7 @@ Empty Plots~
 grass is, as of yet, a blanket of untouched greenery.  Here and there a stake
 has been driven in the ground to mark future sites.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -475,7 +475,7 @@ the deceased in classic art.  Here and there a monument stands among the
 majestic statues.  If possible, it appears as if the grass is even more
 meticulously maintained here.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -512,7 +512,7 @@ majestic statues.  If possible, it appears as if the grass is even more
 meticulously maintained here.  A tall elm tree shadows this corner of the
 cemetery..    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -553,7 +553,7 @@ maintained daily, is free of footprints and the gravesites are clear of
 flowers.  It is eerily quiet here.  To the east you see a large circle of
 burned grass.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D1
 ~
 ~
@@ -570,7 +570,7 @@ service tables and chairs would be set up here, along with a podium for the
 head cleric.  A low white chain circles the area, marking it off from the rest
 of the graveyard.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -594,7 +594,7 @@ keep graverobbers from disturbing these great heroes.  Each crypt is a work of
 art in marble or stone unrivaled by any other architecture in the graveyard.  
 A copper-walled crypt, highly polished and gleaming, is to the east.
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -631,7 +631,7 @@ keep graverobbers from disturbing these great heroes.  Each crypt is a work of
 art in marble or stone unrivaled by any other architecture in the graveyard.  
 A round crypt with flag-bearing pinnacles is to the east.
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -669,7 +669,7 @@ keep graverobbers from disturbing these great heroes.  Each crypt is a work of
 art in marble or stone unrivaled by any other architecture in the graveyard.  
 A low crypt crowned with gargoyles sits to the east.
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D0
 ~
 ~
@@ -752,7 +752,7 @@ doors are two matched statues of the snake-headed god of death in the primitive
 cultures.  The doors are left unlocked so that families may view the deceased
 before the ceremonies that put them in the ground permanently.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D1
 ~
 ~
@@ -771,7 +771,7 @@ spirit, releasing it from the body.  The grass here is burned to black ash, but
 the area immediately surrounding it is carpetted with lush greenery and clumps
 of sweet-smelling flowers.    
 ~
-74 0 0 0 0 0
+74 0 0 0 0 2
 D3
 ~
 ~

--- a/lib/world/wld/75.wld
+++ b/lib/world/wld/75.wld
@@ -6,7 +6,7 @@ singing in them.  North the forest is darker and the trees much larger.  To the
 south the forest comes to an end and expands into a large open field.  A trail
 leads east and south.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D1
 Deep in the Forest.
 ~
@@ -56,7 +56,7 @@ An Open Field~
 tall green grass and wild flowers grow freely only stopping short at a trail
 that runs north and south.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 2
 D0
 The Forest Edge.
 ~
@@ -80,7 +80,7 @@ a calm pool does when disturbed.  The trail disappears under patches of grass,
 it doesn't appear to have been traveled recently.  The trail here runs north
 and south, large enough for a small wagon.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 2
 D0
 An Open Field.
 ~
@@ -104,7 +104,7 @@ side of the trail.  Various areas of the trail are covered with small plants
 and weeds.  The trail here runs north and south, just wide enough for a small
 wagon or a horse and rider.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 2
 D0
 An Open Field.
 ~
@@ -127,7 +127,7 @@ An Open Field~
 In the northern distance the plants growing are more familar.  Something beside
 the road looks out of place.  To the south the trail begins to get thinner.  
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 2
 D0
 An Open Field.
 ~
@@ -174,7 +174,7 @@ and flowers grow everywhere some reaching heights that are as large as trees.
 Perhaps they are trees.  Unusual sounds can be heard in the distance.  The path
 runs north and south.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D0
 An Open Field.
 ~
@@ -192,7 +192,7 @@ A Narrow Path~
 flowers.  Song birds can be heard in the distance but the songs are not ones
 you have heard before.  The path twists and leads to the north and west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D0
 A Narrow Path.
 ~
@@ -211,7 +211,7 @@ been built here.  The stones of the path are old and broken.  The strange
 noises seem to be getting louder.  The air grows thick from the sweet smell of
 the flowers.  The old, stone path leads east and west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D1
 A Narrow Path.
 ~
@@ -236,7 +236,7 @@ of singing, screeching, and calling are becoming familiar.  But there is still a
 bizarre chatter, where it comes from is still unknown.  The stone path runs
 east and west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D1
 The Trail to Zamba.
 ~
@@ -257,7 +257,7 @@ center of the massive gate the trail leads to a small opening.  The air is cool
 and gentle, the strong floral smell begins to weaken.  Several noises escape
 the gate, sounds of civilization.  A small path leads east and west.    
 ~
-75 32772 0 0 0 0
+75 32772 0 0 0 3
 D1
 The Trail to Zamba.
 ~
@@ -282,7 +282,7 @@ here look at you curiously for a moment before returning to their duties.  To
 the east stands the gates of Zamba.  The stone path leads east and west with
 many straw huts scattered about.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 1
 D0
 A Straw Hut.
 ~
@@ -417,7 +417,7 @@ buried under white sand.  Straw huts continue in all directions.  Although you
 still hear the sound of rushing water you also hear the faint sounds of music
 further west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 1
 D0
 A Straw Hut.
 ~
@@ -504,7 +504,7 @@ wood, perhaps not as grand as you are familar with but a much more attractive
 building compared to the small huts.  To the west appears to be the formation
 of mountains.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 1
 D0
 A Straw Hut.
 ~
@@ -561,7 +561,7 @@ mountain or had built a fortress on the surface to appear as a mountain.  The
 huge stone building rises high into the sky, a long set of steps lead upward.
 To the north and south the sand continues.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 1
 D0
 A Sandy Clearing.
 ~
@@ -591,7 +591,7 @@ a primitive machine used to weave cloth has been positioned under a shaded
 tree.  The sounds of crashing water is loud.  The air smells salty with a
 slight aroma of cooked fish.  The sandy track leads north, south and west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Small Street.
 ~
@@ -621,7 +621,7 @@ north, on the string hang several fish of various shapes and sizes.  To the
 west, east and south stands an open sandy path.  North a small path leads into
 a group of large trees with huge wide leaves centered to the tops of the trees.
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Cluster of Fruit Trees.
 ~
@@ -647,7 +647,7 @@ the silence is replaced by loud frantic chattering from all around you high in
 the trees.  A large sandy path leads south.  To the east a narrow path full of
 thick vines leads deeper into the trees.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D1
 Jungle Passage.
 ~
@@ -671,7 +671,7 @@ stretching toward the sky in a oddly tilted fashion.  Other types of trees grow
 here that have sharp pointy bark.  Thick vines twist and turn clinging to
 everything.  A small path leads off to the east and west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D1
 Jungle Passage.
 ~
@@ -694,7 +694,7 @@ The Jungle~
 growing space.  Bright, colorful butterflies flutter high in the trees.  A
 small path leads off to the east and west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D1
 Jungle Passage.
 ~
@@ -718,7 +718,7 @@ slight wind catches the small leaves of the vines making them appear to grow as
 they sway in the wind.  A small path leads west.  Further to the east there
 seems to be a clearing.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D1
 A Clearing in the Jungle.
 ~
@@ -745,7 +745,7 @@ as if ready to bite.  In one of its clawed hands it holds a twisted dagger.
 The dagger is of fine steel and appears to have been placed in the claw after
 the statue was made.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D3
 Jungle Passage.
 ~
@@ -769,7 +769,7 @@ and thick.  A small group of butterflies busily flutter about in a cluster of
 flowers.  A large yellow flower silhouettes one of the patches of light, for
 some reason it stands alone as if the other plants fear to grow beside it.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 3
 D0
 A Sandy Clearing.
 ~
@@ -966,7 +966,7 @@ At this close a distance looking upward all you can see are rows and rows of
 steps all identical as they spirial upward.  Glancing downward there is but one
 step then the sandy ground.
 ~
-75 32772 0 0 0 0
+75 32772 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -992,7 +992,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32772 0 0 0 0
+75 32772 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1018,7 +1018,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1044,7 +1044,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1070,7 +1070,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1096,7 +1096,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1122,7 +1122,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1148,7 +1148,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1174,7 +1174,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Stone Steps.
 ~
@@ -1200,7 +1200,7 @@ smoothed and widened for easy climbing.  Handcarved into the side of the
 mountain are strange symbols and beasts.  The steps lead up and down, you can
 go no other way.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 5
 D4
 Iron Doors.
 ~
@@ -1230,7 +1230,7 @@ The sounds of the water roars as it echos up the mountain side.  A strong wind
 from the west threatens to push you over the side.  Should you climb down or
 should you brave the unknown and enter the doors to the south?    
 ~
-75 32772 0 0 0 0
+75 32772 0 0 0 5
 D2
 Iron Doors.
 ~
@@ -1772,7 +1772,7 @@ sand looking for their next meal.  To the west the ocean washes up to the beach
 washing away the sand under it.  The wind blows in softly across the waves
 carrying with it the salty smell of the ocean.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1815,7 +1815,7 @@ north.  White waves roll in onto the sand washing away some of the bird prints.
 To the east a few small buildings can be seen in the distance..  The sand
 extents off to the north and south.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1835,7 +1835,7 @@ many bird shaped prints seem to run back and forth to the edge of the ocean.
 To the east stands several small buildings made of wood.  The sand leads off to
 the north, south, and east.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1858,7 +1858,7 @@ A Sandy Beach~
 patches of wild grass grows scantly around.  Several trees grow to the north
 and east of the sand.  To the west the ocean spreads far into the distance.  
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1877,7 +1877,7 @@ east.  To the west the ocean washes up the beach and crash onto a group of
 jagged rocks clustered below the trees.  To the south the sandy trail leads off
 to a wider strip of beach.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D2
 A Sandy Beach.
 ~
@@ -1890,7 +1890,7 @@ A Sandy Beach~
 north.  White waves roll in onto the sand washing away some of the bird prints.
 To the east a sandy clearing.  The sand extents off to the north and south.  
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1914,7 +1914,7 @@ layer of sand and leaving behind shells of various sizes most of which are just
 broken pieces.  The air is salty and warm as it blows in from the west.  The
 sand continues to the north and south.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1933,7 +1933,7 @@ sand looking for their next meal.  To the west the ocean washes up to the beach
 washing away the sand under it.  The wind blows in softly across the waves
 carrying with it the salty smell of the ocean.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1953,7 +1953,7 @@ animal tracks lead away from the mounds toward the coast disappearing into the
 water.  The current here is gentle and softly caresses the edge of the bank.  
 The sand leads off to the north and south.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1972,7 +1972,7 @@ sand looking for their next meal.  To the west the ocean washes up to the beach
 washing away the sand under it.  The wind blows in softly across the waves
 carrying with it the salty smell of the ocean.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -1992,7 +1992,7 @@ a drop off overlooking jagged rocks.  West the ocean rolls in onto the sand
 gently washing away several of the footprints.  East is a large cluster of
 trees.  To the north a sandy path out.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 4
 D0
 A Sandy Beach.
 ~
@@ -2011,7 +2011,7 @@ Market Row~
 out from the shops from all the activity around them.  To the north stands a
 large building made of wood and large stones.  The road leads east and west.  
 ~
-75 32772 0 0 0 0
+75 32772 0 0 0 1
 D0
 A Magic Shop.
 ~
@@ -2034,7 +2034,7 @@ Market Row~
 from the shops from all the activity around them.  To the south a native fruit
 stand sits.  To the east stands a small shop.  To road leads west.    
 ~
-75 32768 0 0 0 0
+75 32768 0 0 0 1
 D1
 A Path.
 ~

--- a/lib/world/wld/78.wld
+++ b/lib/world/wld/78.wld
@@ -17,7 +17,7 @@ sun.  Strange sounds echo in the trees as animals call out to those of their
 own kind.  Northward lies the Western Highway and to the south you can make out
 what seems to be a small village.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 3
 D2
 ~
 ~
@@ -38,7 +38,7 @@ horizon, tops of chimneys can be seen.  You get an eerie feeling you are being
 watched.  The path runs north and west, westerly you can make out the sounds of
 merchants calling out their wares.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 3
 D0
 ~
 ~
@@ -58,7 +58,7 @@ carefully hand picked and polished before being skillfully laid into the dirt.
 Easterly will take you back to the Western Highway, while just through the gate
 is the Village of Gideon to the south.    
 ~
-78 32772 0 0 0 0
+78 32772 0 0 0 3
 D1
 ~
 ~
@@ -92,7 +92,7 @@ away by the occasional breeze.  To the north lies the village gate, while
 Mahnra Road continues on east and west where you will find various shops and
 merchants.  To the south you hear water bubbling.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -118,7 +118,7 @@ southwest.  A stray cat lies in the middle of the road cleaning itself
 gingerly.  Mahnra road runs easterly and westerly and to the south is Vestra
 Court that leads to the village fountain.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D1
 ~
 ~
@@ -140,7 +140,7 @@ from a front porch with a knowing look on his face.  The homes are modest but
 look well kept and each has a feeling of comfort to them.  Mahnra Road
 continues to the east and west.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D1
 ~
 ~
@@ -158,7 +158,7 @@ stand in groups giggling at the boys as they play in the street.  To the north
 you can see a small park, west will take you back to the gate, and to the south
 lies Shantrell Lane.  
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -180,7 +180,7 @@ into the pond causing a slight splash, as birds sing merrily in the trees.  A
 lone fisherman sits on the opposite bank, nodding off into slumber, waiting for
 the big one to bite.  Southward will take you back to Mahnra Road.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D2
 ~
 ~
@@ -198,7 +198,7 @@ roads of Gideon.  No homes can be found here but yet it is meticulously
 groomed.  The flowers grow tall under the trees that shade them from the noon
 sun.  Northward is Mahnra Road and to the south is Talipia Way.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -216,7 +216,7 @@ from house to house begging for scraps.  A young woman works carefully tending
 her garden, stoping occasionally to fan herself.  Talipia Way continues on
 westward, while to the north lies Shantrell Lane.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -233,7 +233,7 @@ rather close together just as the neighbors seem to be close with each other.
 Two women sit on a veranda sipping refreshing drinks watching their children
 play together.  Talipia Way continues on to the east and west.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D1
 ~
 ~
@@ -251,7 +251,7 @@ birds in the trees.  To the northwest you can just make out the sound of
 bubbling water, while Talipia Way continues on east and west.  Northward will
 lead you to Vestra Court and the village gate.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -274,7 +274,7 @@ themselves.  Houses are scattered here and there each with a small garden to
 the side of them.  Directly north the fountian lies, while Talipia Way
 continues to the east and west.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -295,7 +295,7 @@ northward Mahnra Road and southward Talipia Way.  Westward you can see a row of
 high hedges that border the village fountain.  Along the hedgeline flowers
 bloom scenting the air with a slight fragrance.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -318,7 +318,7 @@ behind trees as the echos of dogs barking ring through the air.  To the west
 you see the baker's shop, eastward the continuation of Mahnra Road and
 southerly Lantoom Court.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D1
 ~
 ~
@@ -339,7 +339,7 @@ blue flowers growing in marble pots.  High hedges can be seen to the east,
 providing privacy for the fountain.  Northward will take you to Mahnra Road,
 while southward is Talipia Way.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -359,7 +359,7 @@ Village of Gideon, Talipia Way~
 water that can be heard to the northeast.  Northward takes you to Vestra Court
 and then on to Mahnra Road, while to the east and west Talipia Way continues.
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -382,7 +382,7 @@ along the ground batting playfully at leaves and twigs, while the birds sing
 their love songs soothingly.  A slight mist rises from the fountain and is
 carried along the air, cooling it slightly.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -409,7 +409,7 @@ spot in the village.  Northward is the door leading to the bakery.  Westward
 you see the general store, while eastward Mahnra Road leads back to the village
 gate and fountain.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 The pine door is open facing the street.  The smells coming from the opening
 entice your olfactory as well as your tummy.    
@@ -449,7 +449,7 @@ to the post.  Villagers rush past you on the way to do errands, each with a
 pleasant smile on their face.  To the south Pinery Lane leads to the west gate
 and Talipia way continues on the east.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -487,7 +487,7 @@ Children run past you laughing merrily.  To the north you can make out what
 looks to be the general store, while on to the south is a residential area.  
 Directly west stands a gate.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -508,7 +508,7 @@ cat they take to flight immediately.  A woman rushes out of her home seemily in
 a grand hurry as she heads northward toward Pinery Lane.  Talipia Way leads
 east back to the residential area of Gideon.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D0
 ~
 ~
@@ -524,7 +524,7 @@ Village of Gideon, Talipia Way ~
 They rise to the sky tall and stately.  Talipia Way continues on easterly and
 westerly, and to the south, there appears to be a forest.    
 ~
-78 32768 0 0 0 0
+78 32768 0 0 0 1
 D1
 ~
 ~
@@ -541,7 +541,7 @@ you will find Pinery Lane that will take you to Talipia Way to the south, the
 residential area of Gideon and to the north Mahnra Road where you can find the
 general store, bakery and the northern gate.    
 ~
-78 32772 0 0 0 0
+78 32772 0 0 0 1
 D1
 ~
 ~

--- a/lib/world/wld/79.wld
+++ b/lib/world/wld/79.wld
@@ -340,7 +340,7 @@ movement seem to extend only to the up and down directions.  Unless you
 want to let go of the secure and seemingly unmovable chain, then those are
 the directions you should take from here.
 ~
-79 4 0 0 0 0
+79 4 0 0 0 5
 D4
 Upwards, you see the chain disappearing into the clouds above.
 ~
@@ -361,7 +361,7 @@ seems like a totally impossible task.  The ascend is the only way ahead
 for you.  Otherwise you would risk death by falling to the hard ground
 below.  DO NOT DESCEND NOW OR YOU WILL SURELY DIE!!!!
 ~
-79 4 0 0 0 0
+79 4 0 0 0 5
 D4
 That way seems to be the only way away from here.
 ~
@@ -383,7 +383,7 @@ and down.  No way are you going to descend now... You've only just begun
 your climb.  Besides it could cost you your life.  Look down and you'll
 see why.
 ~
-79 4 0 0 0 0
+79 4 0 0 0 5
 D4
 There seems to be only one way from here and that's up.
 ~
@@ -405,7 +405,7 @@ originating from within the Chain *ITSELF*.  It says 'Welcome back some
 other time, stranger.  Your company is always... hmmm... interesting.  God
 Speed.'  The chain extends further down through the now spreading clouds.
 ~
-79 4 0 0 0 0
+79 4 0 0 0 5
 D4
 It seems to you that the Chain is dissolving again.  Maybe it is just an 
 illusion, but still...
@@ -426,7 +426,7 @@ you can now see the Mansion of Naris, Residence of the Greater God Redferne.
 The chain beneath you seems to evaporate in the mustering clouds that
 surround you by now.
 ~
-79 4 0 0 0 0
+79 4 0 0 0 5
 D4
 You see the sunny top of the clouds.  Beyond these, the Mansion towers before
 your eyes.  Beautiful!!

--- a/lib/world/wld/83.wld
+++ b/lib/world/wld/83.wld
@@ -30,7 +30,7 @@ can see.  The sand beneath your feet is moist, perfect for making a sand castle
 if you wanted to.  To the east, there is a path that rims the shore around this
 part of the sea.
 ~
-83 4 0 0 0 0
+83 4 0 0 0 6
 D3
 The sea is all that you see to the west.    
 ~
@@ -43,7 +43,7 @@ The Sea~
 sight north and east.  However, reefs, trees, and dense seaweed make it
 impossible to reach the shore from here.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 You see land to the north, but you cannot climb up on the shore from here.
 ~
@@ -71,7 +71,7 @@ The Sea~
 north, south, and east.  However, reefs, trees, and dense seaweed make it
 impossible to reach the shore from here.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 You can see land to the north.
 ~
@@ -99,7 +99,7 @@ The Sea~
 sight north and east.  However, reefs, trees, and dense seaweed make it
 impossible to reach the shore from here.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 You can see land to the north.
 ~
@@ -127,7 +127,7 @@ The Sea~
 sight north and east.  There is a clear and seemingly safe path to the shore
 due east.    
 ~
-83 4 0 0 0 0
+83 4 0 0 0 7
 D0
 Rippling water is all you see to the north.    
 ~
@@ -155,7 +155,7 @@ The Sea~
 sight north and east.  However, reefs, trees, and dense seaweed make it
 impossible to reach the shore from here.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.    
 ~
@@ -183,7 +183,7 @@ The Sea~
 sight north and east.  However, reefs, trees, and dense seaweed make it
 impossible to reach the shore from here.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -211,7 +211,7 @@ The Sea~
 in plain sight north and east.  However, reefs, trees, and dense seaweed make
 it impossible to reach the shore from here.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -271,7 +271,7 @@ south, nothing but water and sky can be seen except for the faint outline of
 the shore bordering the sea just under the horizon.  Below you, the deep blue
 sea looks very deep and formidable.  Not recommended for swimmers.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -301,7 +301,7 @@ south, nothing but water and sky can be seen except for the faint outline of
 the shore bordering the sea just under the horizon.  Below you, the deep blue
 sea looks very deep and formidable.  Not recommended for swimmers.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see to the north.
 ~
@@ -331,7 +331,7 @@ south, nothing but water and sky can be seen except for the faint outline of
 the shore bordering the sea just under the horizon.  Below you, the deep blue
 sea looks very deep and formidable.  Not recommended for swimmers.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -361,7 +361,7 @@ but water and sky can be seen except for the faint outline of the shore
 bordering the sea just under the horizon.  Below you, the deep blue sea looks
 very deep and formidable.  It is not recommended for swimmers.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -391,7 +391,7 @@ south, nothing but water and sky can be seen except for the faint outline of
 the shore bordering the sea just under the horizon.  Below you, the deep blue
 sea looks very deep and formidable.  Not recommended for swimmers.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -421,7 +421,7 @@ south, nothing but water and sky can be seen except for the faint outline of
 the shore bordering the sea just under the horizon.  Below you, the deep blue
 sea looks very deep and formidable.  Not recommended for swimmers.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -451,7 +451,7 @@ south, nothing but water and sky can be seen except for the faint outline of
 the shore bordering the sea just under the horizon.  Below you, the deep blue
 sea looks very deep and formidable.  Not recommended for swimmers. 
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -481,7 +481,7 @@ south, nothing but water and sky can be seen except for the faint outline of
 the shore bordering the sea just under the horizon.  Below you, the deep blue
 sea looks very deep and formidable.  Not recommended for swimmers.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -510,7 +510,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 ~
 ~
@@ -535,7 +535,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -564,7 +564,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -593,7 +593,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -622,7 +622,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -651,7 +651,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -680,7 +680,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -709,7 +709,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -738,7 +738,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -767,7 +767,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -796,7 +796,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -825,7 +825,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -854,7 +854,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -883,7 +883,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -912,7 +912,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -941,7 +941,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -970,7 +970,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -999,7 +999,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1028,7 +1028,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1057,7 +1057,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1086,7 +1086,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1115,7 +1115,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1144,7 +1144,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1173,7 +1173,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1202,7 +1202,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1231,7 +1231,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1260,7 +1260,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1289,7 +1289,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1318,7 +1318,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1347,7 +1347,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1376,7 +1376,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1405,7 +1405,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1434,7 +1434,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1463,7 +1463,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1492,7 +1492,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1521,7 +1521,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see to the north.
 ~
@@ -1550,7 +1550,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1579,7 +1579,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you see to the north.
 ~
@@ -1610,7 +1610,7 @@ center.  The hut is suspended about 3 meters from the ground by some wooden
 poles of some sort, the only means of entrance being the rope ladder hanging
 down from a hole in the center.    
 ~
-83 0 0 0 0 0
+83 0 0 0 0 2
 D0
 Rippling water spreads out as far as you can see in every direction.
 ~
@@ -1644,7 +1644,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 You see a small island to the north.
 ~
@@ -1673,7 +1673,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1702,7 +1702,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see to the north.
 ~
@@ -1731,7 +1731,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1760,7 +1760,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1789,7 +1789,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1818,7 +1818,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1847,7 +1847,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1876,7 +1876,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1905,7 +1905,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1934,7 +1934,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1963,7 +1963,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -1992,7 +1992,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -2021,7 +2021,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -2050,7 +2050,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -2079,7 +2079,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 0 0 0 0 0
+83 0 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -2108,7 +2108,7 @@ the water seems peaceful, there is still danger lurking behind every wave.
 Below you, the water is a dark blue, indicating that it is very deep and
 extremely dangerous.  
 ~
-83 4 0 0 0 0
+83 4 0 0 0 7
 D0
 Rippling water is all that you can see in every direction.    
 ~
@@ -2375,7 +2375,7 @@ boat.  You can see for many miles in every direction, but you see nothing but
 water, water, and more water.  The ladder leading back to the deck is the only
 way out of here, unless you wanted to jump...
 ~
-83 16 0 0 0 0
+83 16 0 0 0 5
 D0
 You have a wonderful view of the ocean from up here.  You see nothing but water to the north.
 ~
@@ -2466,7 +2466,7 @@ getting back to the surface as your arms grow tired of flailing about.  Your
 vision fades to black as you lose conciousness and drown in your sleep. 
 @n
 ~
-83 4 0 0 0 0
+83 4 0 0 0 6
 D0
 ~
 ~
@@ -2623,7 +2623,7 @@ ocean travel.  There is a roof over the stern of the boat, forming a room that
 is obviously used to provide shelter during harsh weather.  A flap of thick
 cloth acts as a door to the cabin.
 ~
-83 0 0 0 0 0
+83 0 0 0 0 2
 D2
 A large flap of canvas separates the cabin from the rest of the boat.    
 ~

--- a/lib/world/wld/86.wld
+++ b/lib/world/wld/86.wld
@@ -31,7 +31,7 @@ casually winds up the steep hill to a dark appearing Keep atop the hill.
 Ravens call from the nearby trees and smoke can be seen to the north.  While a
 small muddy trail leads off to the west.    
 ~
-86 1 0 0 0 0
+86 1 0 0 0 4
 D0
    The trees slowly inch back, revealing more of the road to the north.    
 ~
@@ -55,7 +55,7 @@ the spokes.  The vines have twined themselves tightly but do not hinder
 movement to the north.  The path also curves to the east and fades as it slopes
 down the steep hill.    
 ~
-86 1 0 0 0 0
+86 1 0 0 0 4
 D0
    This old rusted wrought iron fence lays open to the north.    
 ~
@@ -85,7 +85,7 @@ doors hang on their hinges, neither inviting nor imparing entrance.  Thick dust
 lays everywhere and spiderwebs fill the corners dampening the sounds that come
 from deep within the keep.    
 ~
-86 1 0 0 0 0
+86 1 0 0 0 2
 D0
    This old weather beaten wooden door barely keeps the weather and critters
 out.    
@@ -270,7 +270,7 @@ and fill the air with the rustling of their feathers.  The path leads in two
 directions the east and west.  Tall hedges and a wrought iron fence prevent
 movement to the north and south.    
 ~
-86 64 0 0 0 0
+86 64 0 0 0 2
 D1
    A dirt path winds along in this direction.    
 ~
@@ -290,7 +290,7 @@ looms nearby and an old balcony can be seen just above the first floor windows.
 The trees have grown in about the old courtyard making travel in all directions
 impossible, save to the west.    
 ~
-86 1 0 0 0 0
+86 1 0 0 0 2
 D3
 ~
 ~
@@ -434,7 +434,7 @@ the leaves and sway some of the lighter branches along this dirt path.  A break
 in the foliage appears to the north and the dirt path continues on to the west.
   
 ~
-86 1 0 0 0 0
+86 1 0 0 0 2
 D0
    A small clearing lays beyond the tree break.    
 ~
@@ -453,7 +453,7 @@ Grand Duke Kalithorn's Keep.  In every direction trees block the view and low
 growing raspberr and prickly rose bushes block further travel.  A small rock
 formation lay at the very edge of the path.    
 ~
-86 81 0 0 0 0
+86 81 0 0 0 2
 D2
    A dirt path continues on in this direction.    
 ~
@@ -491,7 +491,7 @@ heard.  Thick wooden support posts keep the earth from caving into this small
 tunnel that leads forever downwards.  There is a wooden ladder that leads down
 and up.  
 ~
-86 1 0 0 0 0
+86 1 0 0 0 5
 D4
    There is a large stone door above.    
 ~

--- a/lib/world/wld/9.wld
+++ b/lib/world/wld/9.wld
@@ -193,7 +193,7 @@ The Beach Head~
 There isn't much to see here and there is no way to cross the steep
 rocky cliffs that wall in this place.
 ~
-9 0 0 0 0 0
+9 0 0 0 0 2
 D2
 ~
 ~
@@ -204,7 +204,7 @@ The North Channel~
    The river splits as runs up against the island and a navigatble
 channel slips off to the north and west.
 ~
-9 4 0 0 0 0
+9 4 0 0 0 7
 D0
 ~
 ~
@@ -243,7 +243,7 @@ Near The Isle~
 appears to be nothing more than a short path that leads to the
 side of a hill.
 ~
-9 4 0 0 0 0
+9 4 0 0 0 7
 D1
 ~
 ~
@@ -260,7 +260,7 @@ will not hear you call here.  Hence they will not answer you.  To the
 south the path ends at a dark cave entrance.
 A sign has been posted beside the entrance.
 ~
-9 0 0 0 0 0
+9 0 0 0 0 1
 D0
 ~
 ~
@@ -282,7 +282,7 @@ The First Trial Of Minos~
 Minos loves to torture his people through these places.  He
 collects the monsters of the world and puts them here.
 ~
-9 9 0 0 0 0
+9 9 0 0 0 1
 D1
 ~
 ~
@@ -296,7 +296,7 @@ the next monster in my playground.  Or are you strong enough?'
    To the south is the entrance to the next challenge of Minos'
 stronghold.
 ~
-9 9 0 0 0 0
+9 9 0 0 0 1
 D2
 ~
 ~
@@ -387,7 +387,7 @@ Above, On The Beach~
 end of the island.  You could clamber down easy enough, but getting
 back up would be another story.
 ~
-9 0 0 0 0 0
+9 0 0 0 0 4
 D5
 ~
 ~

--- a/lib/world/wld/90.wld
+++ b/lib/world/wld/90.wld
@@ -5,7 +5,7 @@ life is the tracks you leave behind.  A gusting wind throws sand up into your
 face and makes you choke.  On the horizon you believe you can see a clump of
 trees.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -36,7 +36,7 @@ and slippery footing makes travel in this desert painful.  To the southeast you
 can make out a few trees and some small shrubbery.  A good sign of water.  You
 are thirsty.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -52,7 +52,7 @@ Between Sand Dunes~
 see nothing but desert stretching for miles in every direction.  You find it
 very hard, if not impossible, to remember which direction you are heading.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -78,7 +78,7 @@ landmark for miles around and it is from this landmark that many travellers
 find their way to the lost city and the south pass.  You can faintly make out a
 trail leading east and west.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -103,7 +103,7 @@ bearable and you can breathe without swallowing a handful of sand.  The desert
 is very peaceful here.  You notice some bleached white bones half-buried in the
 sand.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -128,7 +128,7 @@ seems to be the remains of a small stream that dried up years ago.  You have
 heard that you can follow a stream and it will eventually lead to civilization.
 Maybe this will lead to somewhere important.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -145,7 +145,7 @@ better.  The sand you walk on seems to be firming up slightly and you can see a
 few cactii further to the east as you work your way out of the harshest part of
 the desert.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D2
 ~
 ~
@@ -162,7 +162,7 @@ to trace your footsteps, but the wind has already covered them over.  You get
 an uneasy feeling in your stomach as you realize how easily one could get lost
 here.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -179,7 +179,7 @@ You try to cover your face but the sand still finds its way in.  You remember
 stories of lost travellers entering the desert and never returning.  Will you
 be next?    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -200,7 +200,7 @@ extreme heat during the day and frigid cold at night.  It is a wonder that any
 animal could survive out here, but some do.  Most animals living in the desert
 are scavengers who prey on lost souls, like your own!    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D2
 ~
 ~
@@ -217,7 +217,7 @@ travel between the lost city, south pass, and the Capital.  This is where the
 truly adventureous travelers roam in the search for fame and fortune.  Most
 never make it back.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -235,7 +235,7 @@ trickles through the center of the palms.  It is not very refreshing, but
 enough to support a flurry of plant and animal life.  From here paths continue
 north toward the Capital or the lost city, and south to the south pass.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -260,7 +260,7 @@ small trickle of water that never runs dry.  This oasis is a safe haven for
 many lost travellers.  From the oasis a lost traveller can usually find his way
 back to safety.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -277,7 +277,7 @@ somehow survive without water for months at a time.  Small animals that have
 adapted to the extreme weather in the desert scurry away as you pass.  Tales of
 deadly scorpions make you watch where you step.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -294,7 +294,7 @@ been washed away in this area making a small ditch where a good sized stream
 must have once flowed.  The ground around the ditch is packed sand with cracks
 running through it.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D2
 ~
 ~
@@ -311,7 +311,7 @@ climb to the top, expecting to get a better view of your surroundins, you only
 see more dunes.  The dry air makes you wish you had remembered to bring more
 water.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -328,7 +328,7 @@ not enough moisture in the desert to form any clouds.  The area around you is
 barren, just sand, no sign of any life.  To the northeast you can see what
 looks like some trees in the distance.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -344,7 +344,7 @@ The Desert~
 under your feet makes it difficult to even walk.  Just to the north is a small
 patch of palm trees.  A place of sanctuary in the middle of an ocean of sand.
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -361,7 +361,7 @@ bottom of what must have once been an impressive river.  Skeletons of fish are
 half buried in the rubble.  It appears this stream ran dry from an unnatural
 cause.  The banks of the river reach up to about eye level.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -378,7 +378,7 @@ your head, actually slanting towards you, making them impossible to climb.
 The rocky river bed makes an unsure footing and you stumble along, trying not
 to twist an ankle.  The river bed leads in an east west direction.
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -395,7 +395,7 @@ there was to begin with.  It feels as if the walls are closing in on you.  You
 begin to notice bones scattered among the rocks that don't look like fish
 bones.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D2
 ~
 ~
@@ -412,7 +412,7 @@ horizon.  Maybe it is just a mirage, or maybe it is something else.  The harder
 you look the more you begin to think that you might be reaching the southern
 end of the desert.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -428,7 +428,7 @@ A Dried Up River Bed~
 smooth from years of errosion from the river.  Now they are becoming pitted and
 cracked.  The river bed continues north and east.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -445,7 +445,7 @@ large river.  The banks reach up to just above your head, obscuring your view
 of what's above you.  The river bottom is layered in small round pebbles.  
 This would be a great place to set up an ambush for unwary travellers.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D3
 ~
 ~
@@ -457,7 +457,7 @@ The Desert~
 relentlessly.  You can make out what looks like a mountain range further to the
 south.  Perhaps this faded trail you are following leads to the south pass.  
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -474,7 +474,7 @@ north and west.  The remains of a trail being consumed by the desert sand.  To
 the south you can see somthing on the horizon.  Desert stretches as far as you
 can see in every other direction.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -491,7 +491,7 @@ far as you can see.  To the south a jagged mountain range stretches to the sky.
 The mountains are tall enough to be barren of trees and some are even snow
 capped.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -508,7 +508,7 @@ range are wild and undoubtedly false.  But one thing you know is true.  They
 are almost insurpassable unless you can find the south pass.  The trail leads
 east and west.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D1
 ~
 ~
@@ -524,7 +524,7 @@ A Faded Trail~
 desert sand.  Dunes of sand rise above you to the south and east.  The trail
 continues to the west.  This part of the desert is strangely quite and still.
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -540,7 +540,7 @@ Before the Mountains~
 west the mountains look insurpassable.  A small trail continues south towards
 the base of the mountains or north into the desert.    
 ~
-90 0 0 0 0 0
+90 0 0 0 0 2
 D0
 ~
 ~
@@ -558,7 +558,7 @@ to the north.  Anyone or anything could easily hide along the base of the
 mountains.  A small trail leads to the east.  An almost invisible trail leads
 south from here, toward the mountains.  
 ~
-90 4 0 0 0 0
+90 4 0 0 0 2
 D0
 ~
 ~

--- a/lib/world/wld/96.wld
+++ b/lib/world/wld/96.wld
@@ -46,7 +46,7 @@ their merry songs, voices intertangling into a mesh of sounds that faintly
 resembles a choir.  The path branches off to the west, but the main path
 continues north.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -71,7 +71,7 @@ decorated with strange runes, and animal skulls hang from the eaves.  The
 doorknob is fashioned from a human thigh bone.  Exits are back to the main
 path, or into the hut.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D1
 ~
 ~
@@ -107,7 +107,7 @@ The forest animals seem to take no heed of anyone, travelling along the path as
 any human would.  Squirrels, rabbits, hares, foxes, and other animals can be
 seen scurrying about.  The path continues north and south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -125,7 +125,7 @@ are far more active here, and the ground is littered with evidence on their
 passing.  A bird chirps gleefully from a hole in a nearby tree, soon followed
 by a chorus of her chicks.  The path here splits in four directions.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -152,7 +152,7 @@ which accountrs for the increase in noise.  The tree itself is covered in moss
 and lichen, with violets and wildflowers shooting from the rotted wood.  The
 only exit is back to the intersection.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D1
 ~
 ~
@@ -184,7 +184,7 @@ softer.  The air is beginning to take on an unpleasant odor, but it's not quite
 placeable.  The birdsong is as loud as ever, but the other animals seem to be
 strangely quiet.  The path turns south, or back west.    
 ~
-96 64 0 0 0 0
+96 64 0 0 0 3
 D2
 ~
 ~
@@ -201,7 +201,7 @@ A swampy pit~
 water and muck is in resting in the middle of the path.  The forest is silent,
 except the occasional bird chirping.  The only exit is back north.    
 ~
-96 65 0 0 0 0
+96 65 0 0 0 3
 D0
 ~
 ~
@@ -216,7 +216,7 @@ intertwines itself with the sounds of the animals going about their business.
 The moisture trapped by the trees coupled with the coolness of the air gives
 the forest a wet sheen.  The path continues north and south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -236,7 +236,7 @@ intertwines itself with the sounds of the animals going about their business.
 The moisture trapped by the trees coupled with the coolness of the air gives
 the forest a wet sheen.  The path continues north and south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -254,7 +254,7 @@ many places the path is interrupted by small collapses, due to ants tunneling
 under.  In the underbrush nearby, an animal has burrowed a rather deep hole to
 make it's home.  Exits are west or back to the south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D2
 ~
 ~
@@ -278,7 +278,7 @@ A three-way intersection~
 other hand, doesn't look like any animal uses it.  The path continues west and
 north, and back east.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -302,7 +302,7 @@ intertwines itself with the sounds of the animals going about their business.
 The moisture trapped by the trees coupled with the coolness of the air gives
 the forest a wet sheen.  The path continues north and south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -320,7 +320,7 @@ many places the path is interrupted by small collapses, due to ants tunneling
 under.  In the underbrush nearby, an animal has burrowed a rather deep hole to
 make it's home.  Exits are east or back to the south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D1
 ~
 ~
@@ -344,7 +344,7 @@ which accountrs for the increase in noise.  The tree itself is covered in moss
 and lichen, with violets and wildflowers shooting from the rotted wood.  The
 only exit is back west.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D3
 ~
 ~
@@ -360,7 +360,7 @@ intertwines itself with the sounds of the animals going about their business.
 The moisture trapped by the trees coupled with the coolness of the air gives
 the forest a wet sheen.  The path continues east and west.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D1
 ~
 ~
@@ -378,7 +378,7 @@ dense.  The trees are more spread apart, and flowers come less often.  The
 smaller and weaker animals seem to have disappeared, but the bigger ones seem
 to have grown more plentiful.  The path turns south, and continues back east.
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D1
 ~
 ~
@@ -398,7 +398,7 @@ of beauty about it.  Small animals scurry about, and birdsong can be heard even
 at the threshold of the forest.  Flowers line the path north into the forest,
 which is the only visible exit.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -422,7 +422,7 @@ someone wants an unobstructed view or someone's property line is near.  Far in
 the distance a cave makes a grey splotch on the horizon.  Exits are west or
 back north.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -440,7 +440,7 @@ the underbrush constantly, and the birdsong grows even fainter.  Loud roars
 come from the west, and the unmistakeable sound of an animal getting ripped in
 half.  The path continues west and east.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D1
 ~
 ~
@@ -458,7 +458,7 @@ seem to thrive in the silence.  The inhuman roars from the west grow louder,
 and the squelching of dead animals intensifies.  The smell of excrement floats
 through the air.  The path continues west and east.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D1
 ~
 ~
@@ -477,7 +477,7 @@ The shrieks of a dying creature can be heard nearby, and the roaring stops
 momentarily, replaced by a sickening squelch.  The path returns west, or
 continues north.    
 ~
-96 4 0 0 0 0
+96 4 0 0 0 3
 D0
 ~
 ~
@@ -495,7 +495,7 @@ excrement floats through the air, in enough potency to make one vomit.  A pair
 of red eyes peer out of the shroud of darkness in the cave.  The path continues
 north, into the cave west, or returns south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D0
 ~
 ~
@@ -516,7 +516,7 @@ in various stages of decomposition, and piles of animal excrement.  Whether
 it's from what lives in the cave or from the dead animals isn't known.  The
 only exit is back south.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 3
 D2
 ~
 ~
@@ -528,7 +528,7 @@ In the mouth of the cave~
 detected.  Roars from inside the cave signifies that the cave isn't exactly
 empty.  The rest of the cave lies west, and one can exit east.    
 ~
-96 8 0 0 0 0
+96 8 0 0 0 5
 D1
 ~
 ~
@@ -545,7 +545,7 @@ strewn about corpses and the fresh blood staining the walls.  Claw marks on the
 floor tell that the dead animals put up quite a struggle.  Exits in all
 directions.    
 ~
-96 9 0 0 0 0
+96 9 0 0 0 5
 D0
 ~
 ~
@@ -660,7 +660,7 @@ off of its hinges, and it lies on the ground near the entrance.  To the west
 and east are the stairways into the towers, and north lays the gate.  To the
 south a blue portal stretches between the walls.    
 ~
-96 0 0 0 0 0
+96 0 0 0 0 5
 D0
 ~
 ~
@@ -686,7 +686,7 @@ archers to fire through in case of an attack, and a murder-hole halfway up the
 stairs give soldiers something to pour burning oil or drip heavy objects
 through.  East lies the outer gate and the top of the small tower is upward.  
 ~
-96 0 0 0 0 0
+96 0 0 0 0 5
 D1
 ~
 ~
@@ -704,7 +704,7 @@ archers to fire through in case of an attack, and a murder-hole halfway up the
 stairs give soldiers something to pour burning oil or drip heavy objects
 through.  West lies the outer gate and the top of the small tower is upward.  
 ~
-96 0 0 0 0 0
+96 0 0 0 0 5
 D3
 ~
 ~


### PR DESCRIPTION
According to the original wld files many sector types are plainly set to zero (e.g. Midgard city is fully "inside"). I created a patch correcting all sector types in all wld files back to the ones from the original files (commit 3282b8fdc9959c194aa1412fa0a5a523576e023a).
The patch has been created by comparing every room existing today with a room in the original files and by changing the sector only, if the room exists in the original files and had a different sector type. Roughly 1/3 (4584/12468 to be precise) of all rooms are in scope of a sector type change.