### PR TITLE
Get/Take Extra Description Message

### DIFF
--- a/src/act.item.c
+++ b/src/act.item.c
@@ -284,12 +284,21 @@ static void get_from_room(struct char_data *ch, char *arg, int howmany)
 {
   struct obj_data *obj, *next_obj;
   int dotmode, found = 0;
-
+  
   dotmode = find_all_dots(arg);
 
   if (dotmode == FIND_INDIV) {
     if (!(obj = get_obj_in_list_vis(ch, arg, NULL, world[IN_ROOM(ch)].contents)))
+    {
+        /* Are they trying to take something in a room extra description? */
+        if (find_exdesc(arg, world[IN_ROOM(ch)].ex_description) != NULL) 
+        {
+            send_to_char(ch, "You can't take %s %s.\r\n", AN(arg), arg);
+            return;
+        }
       send_to_char(ch, "You don't see %s %s here.\r\n", AN(arg), arg);
+    }
+    
     else {
       struct obj_data *obj_next;
       while(obj && howmany--) {


### PR DESCRIPTION
Changes the message from 'You don't see that' to 'You cant take <xyz>'
when a player tries to take something in a room extra description