### PR TITLE
MSDP Plugin Sending Newline Fix

### DIFF
--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -1986,7 +1986,7 @@ void list_llog_entries(struct char_data *ch)
   strftime(timestr, sizeof(timestr), "%a %b %d %Y %H:%M:%S", localtime(&llast.time));
 
   while(!feof(fp)) {
-    send_to_char(ch, "%10s\t%d\t%s\t%s\r\n", llast.username, llast.punique,
+    send_to_char(ch, "%10s %d %s %s\r\n", llast.username, llast.punique,
         last_array[llast.close_type], timestr);
     i = fread(&llast, sizeof(struct last_entry), 1, fp);
   }

--- a/src/comm.c
+++ b/src/comm.c
@@ -1572,14 +1572,15 @@ static int process_output(struct descriptor_data *t)
 
   /* add the extra CRLF if the person isn't in compact mode */
   if (STATE(t) == CON_PLAYING && t->character && !IS_NPC(t->character) && !PRF_FLAGGED(t->character, PRF_COMPACT))
-    strcat(osb, "\r\n");	/* strcpy: OK (osb:MAX_SOCK_BUF-2 reserves space) */
+    if ( !t->pProtocol->WriteOOB )
+        strcat(osb, "\r\n");	/* strcpy: OK (osb:MAX_SOCK_BUF-2 reserves space) */
 
   if (!t->pProtocol->WriteOOB) /* add a prompt */
     strcat(i, make_prompt(t));	/* strcpy: OK (i:MAX_SOCK_BUF reserves space) */
 
   /* now, send the output.  If this is an 'interruption', use the prepended
    * CRLF, otherwise send the straight output sans CRLF. */
-  if (t->has_prompt) {
+  if (t->has_prompt && !t->pProtocol->WriteOOB) { 
     t->has_prompt = FALSE;
     result = write_to_descriptor(t->descriptor, i);
     if (result >= 2)
@@ -1844,13 +1845,18 @@ static int process_input(struct descriptor_data *t)
 
     /* Read # of "bytes_read" from socket, and if we have something, mark the sizeof data
      * in the read_buf array as NULL */
-    if ((bytes_read = perform_socket_read(t->descriptor, read_buf, space_left)) > 0)
-      read_buf[bytes_read] = '\0';
-
-    /* Since we have recieved atleast 1 byte of data from the socket, lets run it through
+    
+    bytes_read = perform_socket_read(t->descriptor, read_buf, MAX_PROTOCOL_BUFFER);
+    
+    /* Since we have recieved at least 0 byte of data from the socket, lets run it through
      * ProtocolInput() and rip out anything that is Out Of Band */ 
-    if ( bytes_read > 0 )
-      bytes_read = ProtocolInput( t, read_buf, bytes_read, t->inbuf );
+    
+    if ( bytes_read >= 0 )
+    {
+      read_buf[bytes_read] = '\0';
+      ProtocolInput( t, read_buf, bytes_read, read_point );
+      bytes_read = strlen(read_point);
+    }
 
     if (bytes_read < 0)	/* Error, disconnect them. */
       return (-1);

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -38,25 +38,27 @@ const char * RGBthree = "F555";
 
 static void Write( descriptor_t *apDescriptor, const char *apData )
 {
-   if ( apDescriptor != NULL)
+   if ( apDescriptor != NULL && apDescriptor->has_prompt )
    {
-      if ( apDescriptor->pProtocol->WriteOOB > 0)
+      if ( apDescriptor->pProtocol->WriteOOB > 0 || 
+          *(apDescriptor->output) == '\0' )
       {
          apDescriptor->pProtocol->WriteOOB = 2;
       }
    }
-   write_to_output( apDescriptor, apData, 0 );
+   write_to_output( apDescriptor, apData );
 }
 
 static void ReportBug( const char *apText )
 {
-   log( "%s", apText);
+   log( apText );
 }
 
 static void InfoMessage( descriptor_t *apDescriptor, const char *apData )
 {
    Write( apDescriptor, "\t[F210][\toINFO\t[F210]]\tn " );
    Write( apDescriptor, apData );
+   apDescriptor->pProtocol->WriteOOB = 0;
 }
 
 static void CompressStart( descriptor_t *apDescriptor )


### PR DESCRIPTION
Added missing changes for Kavir's MSDP plugin that was causing a blank newline to be sent to client after msdp_updates.

Source:
https://github.com/Xavious/MSDP_Protocol_Handler/blob/master/INSTALL_TBA.TXT

The changes to process_input are straight from the link and I hope are up to date, I've tested and haven't been able to fault it 