### PR TITLE
ignore installation files and player/object data created by individual servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,41 @@
 bin/*
-src/*.o
-src/util/*.o
+
+# ignore object code
+*.o
+
+# ignore player index, files, objects, vars
+**/plrfiles/index
+**/plrfiles/?-?
+**/plrobjs/?-?
+**/plrvars/?-?
+
+# ignore house files as well
+**/house
+
+# but keep the '00' placeholder files!
+!00
+
+#ignore etc, but keep badsites file
+/lib/etc
+!badsites
+
+# ignore world files, all changes presumed to be mud specific
+**/world
+
+# log files, status files
+*.log
+.fastboot
+.killscript
+
+# config and other files created during installation
+config.cache
+config.status
+src/.accepted
+src/Makefile
+src/conf.h
+src/depend
+src/util/Makefile
+src/util/depend
+
+# project files
+**/.idea


### PR DESCRIPTION
This should ignore files generated for a unique installation as well as anyone inadvertently submitting world  file updates that are customized.

Fixes to packaged world data can still be committed with a forced commit if someone wants to submit a pull request for a problem file.  Same goes with /etc where default info would be the norm unless you're explicitly changing the base world/config for new installations.