### PR TITLE
Don't tell a followed person that an invisible immortal stopped following

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -535,7 +535,8 @@ void stop_follower(struct char_data *ch)
   } else {
     act("You stop following $N.", FALSE, ch, 0, ch->master, TO_CHAR);
     act("$n stops following $N.", TRUE, ch, 0, ch->master, TO_NOTVICT);
-    act("$n stops following you.", TRUE, ch, 0, ch->master, TO_VICT);
+    if (CAN_SEE(ch->master, ch))
+      act("$n stops following you.", TRUE, ch, 0, ch->master, TO_VICT);
   }
 
   if (ch->master->followers->follower == ch) {	/* Head of follower-list? */


### PR DESCRIPTION
This duplicates the CAN_SEE check from add_follower into stop_follower, and prevents "An immortal stops following you" from appearing when a followed user quits, or the immortal unfollows or follows someone else.