### PR TITLE
DG Scripts bug fixes

### DIFF
--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -536,7 +536,7 @@ static void do_stat_room(struct char_data *ch, struct room_data *rm)
   sprinttype(rm->sector_type, sector_types, buf2, sizeof(buf2));
   send_to_char(ch, "Zone: [%3d], VNum: [%s%5d%s], RNum: [%5d], IDNum: [%5ld], Type: %s\r\n",
 	  zone_table[rm->zone].number, CCGRN(ch, C_NRM), rm->number,
-	  CCNRM(ch, C_NRM), real_room(rm->number), (long) rm->number + ROOM_ID_BASE, buf2);
+	  CCNRM(ch, C_NRM), real_room(rm->number), room_script_id(rm), buf2);
 
   sprintbitarray(rm->room_flags, room_bits, RF_ARRAY_MAX, buf2);
   send_to_char(ch, "SpecProc: %s, Flags: %s\r\n", rm->func == NULL ? "None" : get_spec_func_name(rm->func), buf2);
@@ -626,7 +626,7 @@ static void do_stat_object(struct char_data *ch, struct obj_data *j)
   vnum = GET_OBJ_VNUM(j);
   sprinttype(GET_OBJ_TYPE(j), item_types, buf, sizeof(buf));
   send_to_char(ch, "VNum: [%s%5d%s], RNum: [%5d], Idnum: [%5ld], Type: %s, SpecProc: %s\r\n",
-    CCGRN(ch, C_NRM), vnum, CCNRM(ch, C_NRM), GET_OBJ_RNUM(j), GET_ID(j), buf,
+    CCGRN(ch, C_NRM), vnum, CCNRM(ch, C_NRM), GET_OBJ_RNUM(j), obj_script_id(j), buf,
     GET_OBJ_SPEC(j) ? (get_spec_func_name(GET_OBJ_SPEC(j))) : "None");
 
   send_to_char(ch, "L-Desc: '%s%s%s'\r\n", CCYEL(ch, C_NRM),
@@ -772,7 +772,7 @@ static void do_stat_character(struct char_data *ch, struct char_data *k)
   sprinttype(GET_SEX(k), genders, buf, sizeof(buf));
   send_to_char(ch, "%s %s '%s'  IDNum: [%5ld], In room [%5d], Loadroom : [%5d]\r\n",
 	  buf, (!IS_NPC(k) ? "PC" : (!IS_MOB(k) ? "NPC" : "MOB")),
-	  GET_NAME(k), IS_NPC(k) ? GET_ID(k) : GET_IDNUM(k), GET_ROOM_VNUM(IN_ROOM(k)), IS_NPC(k) ? NOWHERE : GET_LOADROOM(k));
+	  GET_NAME(k), IS_NPC(k) ? char_script_id(k) : GET_IDNUM(k), GET_ROOM_VNUM(IN_ROOM(k)), IS_NPC(k) ? NOWHERE : GET_LOADROOM(k));
 
   if (IS_MOB(k)) {
     send_to_char(ch, "Keyword: %s, VNum: [%5d], RNum: [%5d]\r\n", k->player.name, GET_MOB_VNUM(k), GET_MOB_RNUM(k));

--- a/src/db.c
+++ b/src/db.c
@@ -2344,9 +2344,7 @@ struct char_data *create_char(void)
   ch->next = character_list;
   character_list = ch;
 
-  GET_ID(ch) = max_mob_id++;
-  /* find_char helper */
-  add_to_lookup_table(GET_ID(ch), (void *)ch);
+  ch->script_id = 0;	// set later by char_script_id
 
   return (ch);
 }
@@ -2397,10 +2395,7 @@ struct char_data *read_mobile(mob_vnum nr, int type) /* and mob_rnum */
 
   mob_index[i].number++;
 
-  GET_ID(mob) = max_mob_id++;
-  
-  /* find_char helper */
-  add_to_lookup_table(GET_ID(mob), (void *)mob);
+  mob->script_id = 0;	// this is set later by char_script_id
 
   copy_proto_script(&mob_proto[i], mob, MOB_TRIGGER);
   assign_triggers(mob, MOB_TRIGGER);
@@ -2420,9 +2415,7 @@ struct obj_data *create_obj(void)
   
   obj->events = NULL;
 
-  GET_ID(obj) = max_obj_id++;
-  /* find_obj helper */
-  add_to_lookup_table(GET_ID(obj), (void *)obj);
+  obj->script_id = 0;	// this is set later by obj_script_id
 
   return (obj);
 }
@@ -2448,9 +2441,7 @@ struct obj_data *read_object(obj_vnum nr, int type) /* and obj_rnum */
 
   obj_index[i].number++;
 
-  GET_ID(obj) = max_obj_id++;
-  /* find_obj helper */
-  add_to_lookup_table(GET_ID(obj), (void *)obj);
+  obj->script_id = 0;	// this is set later by obj_script_id
 
   copy_proto_script(&obj_proto[i], obj, OBJ_TRIGGER);
   assign_triggers(obj, OBJ_TRIGGER);
@@ -3245,8 +3236,9 @@ void free_char(struct char_data *ch)
 
   /* find_char helper, when free_char is called with a blank character struct,
    * ID is set to 0, and has not yet been added to the lookup table. */
-  if (GET_ID(ch) != 0)
-  remove_from_lookup_table(GET_ID(ch));
+  if (ch->script_id != 0) {
+    remove_from_lookup_table(ch->script_id);
+  }
 
   free(ch);
 }
@@ -3268,8 +3260,10 @@ void free_obj(struct obj_data *obj)
   if (SCRIPT(obj))
     extract_script(obj, OBJ_TRIGGER);
 
-  /* find_obj helper */
-  remove_from_lookup_table(GET_ID(obj));
+  /* find_obj helper (0 is not-yet-added to the table) */
+  if (obj->script_id != 0) {
+    remove_from_lookup_table(obj->script_id);
+  }
 
   free(obj);
 }

--- a/src/dg_mobcmd.c
+++ b/src/dg_mobcmd.c
@@ -379,7 +379,7 @@ ACMD(do_mload)
       char_to_room(mob, rnum);
       if (SCRIPT(ch)) { /* It _should_ have, but it might be detached. */
         char buf[MAX_INPUT_LENGTH];
-        sprintf(buf, "%c%ld", UID_CHAR, GET_ID(mob));
+        sprintf(buf, "%c%ld", UID_CHAR, char_script_id(mob));
         add_var(&(SCRIPT(ch)->global_vars), "lastloaded", buf, 0);
       }
       load_mtrigger(mob);
@@ -392,7 +392,7 @@ ACMD(do_mload)
       }
       if (SCRIPT(ch)) { /* It _should_ have, but it might be detached. */
         char buf[MAX_INPUT_LENGTH];
-        sprintf(buf, "%c%ld", UID_CHAR, GET_ID(object));
+        sprintf(buf, "%c%ld", UID_CHAR, obj_script_id(object));
         add_var(&(SCRIPT(ch)->global_vars), "lastloaded", buf, 0);
       }
       /* special handling to make objects able to load on a person/in a container/worn etc. */
@@ -821,7 +821,7 @@ ACMD(do_mremember)
     }
 
     /* fill in the structure */
-    mem->id = GET_ID(victim);
+    mem->id = char_script_id(victim);
     if (argument && *argument) {
       mem->cmd = strdup(argument);
     }
@@ -865,7 +865,7 @@ ACMD(do_mforget)
     mem = SCRIPT_MEM(ch);
     prev = NULL;
     while (mem) {
-      if (mem->id == GET_ID(victim)) {
+      if (mem->id == char_script_id(victim)) {
         if (mem->cmd) free(mem->cmd);
         if (prev==NULL) {
           SCRIPT_MEM(ch) = mem->next;
@@ -950,7 +950,7 @@ ACMD(do_mtransform)
     if(m->player.description)
       tmpmob.player.description = strdup(m->player.description);
 
-    tmpmob.id = ch->id;
+    tmpmob.script_id = ch->script_id;
     tmpmob.affected = ch->affected;
     tmpmob.carrying = ch->carrying;
     tmpmob.proto_script = ch->proto_script;

--- a/src/dg_objcmd.c
+++ b/src/dg_objcmd.c
@@ -330,7 +330,7 @@ static OCMD(do_otransform)
     tmpobj.worn_on = obj->worn_on;
     tmpobj.in_obj = obj->in_obj;
     tmpobj.contains = obj->contains;
-    tmpobj.id = obj->id;
+    tmpobj.script_id = obj->script_id;
     tmpobj.proto_script = obj->proto_script;
     tmpobj.script = obj->script;
     tmpobj.next_content = obj->next_content;
@@ -491,7 +491,7 @@ static OCMD(do_dgoload)
 
       if (SCRIPT(obj)) { /* It _should_ have, but it might be detached. */
         char buf[MAX_INPUT_LENGTH];
-        sprintf(buf, "%c%ld", UID_CHAR, GET_ID(mob));
+        sprintf(buf, "%c%ld", UID_CHAR, char_script_id(mob));
         add_var(&(SCRIPT(obj)->global_vars), "lastloaded", buf, 0);
       }
 
@@ -506,7 +506,7 @@ static OCMD(do_dgoload)
 
       if (SCRIPT(obj)) { /* It _should_ have, but it might be detached. */
         char buf[MAX_INPUT_LENGTH];
-        sprintf(buf, "%c%ld", UID_CHAR, GET_ID(object));
+        sprintf(buf, "%c%ld", UID_CHAR, obj_script_id(object));
         add_var(&(SCRIPT(obj)->global_vars), "lastloaded", buf, 0);
       }
 

--- a/src/dg_scripts.h
+++ b/src/dg_scripts.h
@@ -437,8 +437,18 @@ void wld_command_interpreter(room_data *room, char *argument);
 #define TRIGGER_CHECK(t, type)   (IS_SET(GET_TRIG_TYPE(t), type) && \
 				  !GET_TRIG_DEPTH(t))
 
-#define ADD_UID_VAR(buf, trig, go, name, context) do { \
-		         sprintf(buf, "%c%ld", UID_CHAR, GET_ID(go)); \
+
+/* This formerly used 'go' instead of 'id' and referenced 'go->id' but this is
+* no longer possible since script ids must be referenced with char_script_id()
+* and obj_script_id().
+*/
+#define ADD_UID_VAR(buf, trig, id, name, context) do { \
+		         sprintf(buf, "%c%ld", UID_CHAR, id); \
                          add_var(&GET_TRIG_VARS(trig), name, buf, context); } while (0)
+
+// id helpers
+extern long char_script_id(char_data *ch);
+extern long obj_script_id(obj_data *obj);
+#define room_script_id(room)  ((long)(room)->number + ROOM_ID_BASE)
 
 #endif /* _DG_SCRIPTS_H_ */

--- a/src/dg_scripts.h
+++ b/src/dg_scripts.h
@@ -420,9 +420,9 @@ void wld_command_interpreter(room_data *room, char *argument);
  * mob id's: MOB_ID_BASE to ROOM_ID_BASE - 1
  * room id's: ROOM_ID_BASE to OBJ_ID_BASE - 1
  * object id's: OBJ_ID_BASE and higher */
-#define MOB_ID_BASE	  50000  /* 50000 player IDNUMS should suffice */
-#define ROOM_ID_BASE    1050000 /* 1000000 Mobs */
-#define OBJ_ID_BASE     1300000 /* 250000 Rooms */
+#define MOB_ID_BASE	  10000000  /* 10000000 player IDNUMS should suffice */
+#define ROOM_ID_BASE    (10000000 + MOB_ID_BASE) /* 10000000 Mobs */
+#define OBJ_ID_BASE     (10000000 + ROOM_ID_BASE) /* 10000000 Rooms */
 
 #define SCRIPT(o)		  ((o)->script)
 #define SCRIPT_MEM(c)             ((c)->memory)

--- a/src/dg_triggers.c
+++ b/src/dg_triggers.c
@@ -136,7 +136,7 @@ void bribe_mtrigger(char_data *ch, char_data *actor, int amount)
     if (TRIGGER_CHECK(t, MTRIG_BRIBE) && (amount >= GET_TRIG_NARG(t))) {
       snprintf(buf, sizeof(buf), "%d", amount);
       add_var(&GET_TRIG_VARS(t), "amount", buf, 0);
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
       break;
     }
@@ -160,7 +160,7 @@ void greet_memory_mtrigger(char_data *actor)
       continue;
     /* find memory line with command only */
     for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); mem=mem->next) {
-      if (GET_ID(actor)!=mem->id) continue;
+      if (char_script_id(actor)!=mem->id) continue;
       if (mem->cmd) {
         command_interpreter(ch, mem->cmd); /* no script */
         command_performed = 1;
@@ -173,7 +173,7 @@ void greet_memory_mtrigger(char_data *actor)
               CAN_SEE(ch, actor) &&
               !GET_TRIG_DEPTH(t) &&
               rand_number(1, 100) <= GET_TRIG_NARG(t)) {
-              ADD_UID_VAR(buf, t, actor, "actor", 0);
+              ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
               script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
               break;
           }
@@ -222,7 +222,7 @@ int greet_mtrigger(char_data *actor, int dir)
           add_var(&GET_TRIG_VARS(t), "direction", dirs[rev_dir[dir]], 0);
         else
           add_var(&GET_TRIG_VARS(t), "direction", "none", 0);
-        ADD_UID_VAR(buf, t, actor, "actor", 0);
+        ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
         intermediate = script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
         if (!intermediate) final = FALSE;
         continue;
@@ -246,14 +246,14 @@ void entry_memory_mtrigger(char_data *ch)
        actor = actor->next_in_room) {
     if (actor!=ch && SCRIPT_MEM(ch)) {
       for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); mem = mem->next) {
-        if (GET_ID(actor)==mem->id) {
+        if (char_script_id(actor)==mem->id) {
           struct script_memory *prev;
           if (mem->cmd) command_interpreter(ch, mem->cmd);
           else {
             for (t = TRIGGERS(SCRIPT(ch)); t; t = t->next) {
               if (TRIGGER_CHECK(t, MTRIG_MEMORY) && (rand_number(1, 100) <=
                   GET_TRIG_NARG(t))){
-                ADD_UID_VAR(buf, t, actor, "actor", 0);
+                ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
                 script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
                 break;
               }
@@ -318,7 +318,7 @@ int command_mtrigger(char_data *actor, char *cmd, char *argument)
 
         if (*GET_TRIG_ARG(t)=='*' ||
             !strn_cmp(GET_TRIG_ARG(t), cmd, strlen(GET_TRIG_ARG(t)))) {
-          ADD_UID_VAR(buf, t, actor, "actor", 0);
+          ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
           skip_spaces(&argument);
           add_var(&GET_TRIG_VARS(t), "arg", argument, 0);
           skip_spaces(&cmd);
@@ -358,7 +358,7 @@ void speech_mtrigger(char_data *actor, char *str)
 
         if (((GET_TRIG_NARG(t) && word_check(str, GET_TRIG_ARG(t))) ||
              (!GET_TRIG_NARG(t) && is_substring(GET_TRIG_ARG(t), str)))) {
-          ADD_UID_VAR(buf, t, actor, "actor", 0);
+          ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
           add_var(&GET_TRIG_VARS(t), "speech", str, 0);
           script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
           break;
@@ -389,13 +389,13 @@ void act_mtrigger(const char_data *ch, char *str, char_data *actor,
       if (((GET_TRIG_NARG(t) && word_check(str, GET_TRIG_ARG(t))) ||
            (!GET_TRIG_NARG(t) && is_substring(GET_TRIG_ARG(t), str)))) {
         if (actor)
-          ADD_UID_VAR(buf, t, actor, "actor", 0);
+          ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
         if (victim)
-          ADD_UID_VAR(buf, t, victim, "victim", 0);
+          ADD_UID_VAR(buf, t, char_script_id(victim), "victim", 0);
         if (object)
-          ADD_UID_VAR(buf, t, object, "object", 0);
+          ADD_UID_VAR(buf, t, obj_script_id(object), "object", 0);
         if (target)
-          ADD_UID_VAR(buf, t, target, "target", 0);
+          ADD_UID_VAR(buf, t, obj_script_id(target), "target", 0);
         if (str) {
           /* we're guaranteed to have a string ending with \r\n\0 */
           char *nstr = strdup(str), *fstr = nstr, *p = strchr(nstr, '\r');
@@ -425,7 +425,7 @@ void fight_mtrigger(char_data *ch)
         (rand_number(1, 100) <= GET_TRIG_NARG(t))){
       actor = FIGHTING(ch);
       if (actor)
-        ADD_UID_VAR(buf, t, actor, "actor", 0);
+        ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       else
         add_var(&GET_TRIG_VARS(t), "actor", "nobody", 0);
 
@@ -450,7 +450,7 @@ void hitprcnt_mtrigger(char_data *ch)
         (((GET_HIT(ch) * 100) / GET_MAX_HIT(ch)) <= GET_TRIG_NARG(t))) {
 
       actor = FIGHTING(ch);
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
       break;
     }
@@ -470,8 +470,8 @@ int receive_mtrigger(char_data *ch, char_data *actor, obj_data *obj)
     if (TRIGGER_CHECK(t, MTRIG_RECEIVE) &&
         (rand_number(1, 100) <= GET_TRIG_NARG(t))){
 
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
-      ADD_UID_VAR(buf, t, obj, "object", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
+      ADD_UID_VAR(buf, t, obj_script_id(obj), "object", 0);
       ret_val = script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
       if (DEAD(actor) || DEAD(ch) || obj->carried_by != actor)
         return 0;
@@ -495,7 +495,7 @@ int death_mtrigger(char_data *ch, char_data *actor)
     if (TRIGGER_CHECK(t, MTRIG_DEATH) &&
         (rand_number(1, 100) <= GET_TRIG_NARG(t))){
       if (actor)
-        ADD_UID_VAR(buf, t, actor, "actor", 0);
+        ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       return script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
     }
   }
@@ -541,7 +541,7 @@ int cast_mtrigger(char_data *actor, char_data *ch, int spellnum)
   for (t = TRIGGERS(SCRIPT(ch)); t; t = t->next) {
     if (TRIGGER_CHECK(t, MTRIG_CAST) &&
         (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       sprintf(buf, "%d", spellnum);
       add_var(&GET_TRIG_VARS(t), "spell", buf, 0);
       add_var(&GET_TRIG_VARS(t), "spellname", skill_name(spellnum), 0);
@@ -574,7 +574,7 @@ int leave_mtrigger(char_data *actor, int dir)
           add_var(&GET_TRIG_VARS(t), "direction", dirs[dir], 0);
         else
           add_var(&GET_TRIG_VARS(t), "direction", "none", 0);
-        ADD_UID_VAR(buf, t, actor, "actor", 0);
+        ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
         return script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
       }
     }
@@ -602,7 +602,7 @@ int door_mtrigger(char_data *actor, int subcmd, int dir)
           add_var(&GET_TRIG_VARS(t), "direction", dirs[dir], 0);
         else
           add_var(&GET_TRIG_VARS(t), "direction", "none", 0);
-        ADD_UID_VAR(buf, t, actor, "actor", 0);
+        ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
         return script_driver(&ch, t, MOB_TRIGGER, TRIG_NEW);
       }
     }
@@ -673,7 +673,7 @@ int get_otrigger(obj_data *obj, char_data *actor)
 
   for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
     if (TRIGGER_CHECK(t, OTRIG_GET) && (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       ret_val = script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW);
       /* Don't allow a get to take place, if the actor is killed (the mud
        * would choke on obj_to_char) or the object is purged. */
@@ -710,7 +710,7 @@ int cmd_otrig(obj_data *obj, char_data *actor, char *cmd,
           (*GET_TRIG_ARG(t)=='*' ||
           !strn_cmp(GET_TRIG_ARG(t), cmd, strlen(GET_TRIG_ARG(t))))) {
 
-        ADD_UID_VAR(buf, t, actor, "actor", 0);
+        ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
         skip_spaces(&argument);
         add_var(&GET_TRIG_VARS(t), "arg", argument, 0);
         skip_spaces(&cmd);
@@ -760,7 +760,7 @@ int wear_otrigger(obj_data *obj, char_data *actor, int where)
 
   for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
     if (TRIGGER_CHECK(t, OTRIG_WEAR)) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       ret_val = script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW);
       /* Don't allow a wear to take place, if the object is purged. */
       if (!obj)
@@ -787,7 +787,7 @@ int remove_otrigger(obj_data *obj, char_data *actor)
 
   for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
     if (TRIGGER_CHECK(t, OTRIG_REMOVE)) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       ret_val = script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW);
       /* Don't allow a remove to take place, if the object is purged. */
       if (!obj)
@@ -811,7 +811,7 @@ int drop_otrigger(obj_data *obj, char_data *actor)
 
   for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
     if (TRIGGER_CHECK(t, OTRIG_DROP) && (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       ret_val = script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW);
       /* Don't allow a drop to take place, if the object is purged. */
       if (!obj)
@@ -835,8 +835,8 @@ int give_otrigger(obj_data *obj, char_data *actor, char_data *victim)
 
   for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
     if (TRIGGER_CHECK(t, OTRIG_GIVE) && (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
-      ADD_UID_VAR(buf, t, victim, "victim", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(victim), "victim", 0);
       ret_val = script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW);
       /* Don't allow a give to take place, if the object is purged or the
        * object is not carried by the giver. */
@@ -888,7 +888,7 @@ int cast_otrigger(char_data *actor, obj_data *obj, int spellnum)
   for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
     if (TRIGGER_CHECK(t, OTRIG_CAST) &&
         (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       sprintf(buf, "%d", spellnum);
       add_var(&GET_TRIG_VARS(t), "spell", buf, 0);
       add_var(&GET_TRIG_VARS(t), "spellname", skill_name(spellnum), 0);
@@ -921,7 +921,7 @@ int leave_otrigger(room_data *room, char_data *actor, int dir)
           add_var(&GET_TRIG_VARS(t), "direction", dirs[dir], 0);
         else
           add_var(&GET_TRIG_VARS(t), "direction", "none", 0);
-        ADD_UID_VAR(buf, t, actor, "actor", 0);
+        ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
         temp = script_driver(&obj, t, OBJ_TRIGGER, TRIG_NEW);
         if (temp == 0)
           final = 0;
@@ -943,7 +943,7 @@ int consume_otrigger(obj_data *obj, char_data *actor, int cmd)
 
   for (t = TRIGGERS(SCRIPT(obj)); t; t = t->next) {
     if (TRIGGER_CHECK(t, OTRIG_CONSUME)) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       switch (cmd) {
               case OCMD_EAT:
                 add_var(&GET_TRIG_VARS(t), "command", "eat", 0);
@@ -1034,7 +1034,7 @@ int enter_wtrigger(struct room_data *room, char_data *actor, int dir)
         add_var(&GET_TRIG_VARS(t), "direction", dirs[rev_dir[dir]], 0);
       else
         add_var(&GET_TRIG_VARS(t), "direction", "none", 0);
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       return script_driver(&room, t, WLD_TRIGGER, TRIG_NEW);
     }
   }
@@ -1068,7 +1068,7 @@ int command_wtrigger(char_data *actor, char *cmd, char *argument)
 
     if (*GET_TRIG_ARG(t)=='*' ||
         !strn_cmp(GET_TRIG_ARG(t), cmd, strlen(GET_TRIG_ARG(t)))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       skip_spaces(&argument);
       add_var(&GET_TRIG_VARS(t), "arg", argument, 0);
       skip_spaces(&cmd);
@@ -1104,7 +1104,7 @@ void speech_wtrigger(char_data *actor, char *str)
     if (*GET_TRIG_ARG(t)=='*' ||
        (GET_TRIG_NARG(t) && word_check(str, GET_TRIG_ARG(t))) ||
        (!GET_TRIG_NARG(t) && is_substring(GET_TRIG_ARG(t), str))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       add_var(&GET_TRIG_VARS(t), "speech", str, 0);
       script_driver(&room, t, WLD_TRIGGER, TRIG_NEW);
       break;
@@ -1126,8 +1126,8 @@ int drop_wtrigger(obj_data *obj, char_data *actor)
   for (t = TRIGGERS(SCRIPT(room)); t; t = t->next)
     if (TRIGGER_CHECK(t, WTRIG_DROP) &&
         (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
-      ADD_UID_VAR(buf, t, obj, "object", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
+      ADD_UID_VAR(buf, t, obj_script_id(obj), "object", 0);
       ret_val = script_driver(&room, t, WLD_TRIGGER, TRIG_NEW);
       if (obj->carried_by != actor)
         return 0;
@@ -1152,11 +1152,11 @@ int cast_wtrigger(char_data *actor, char_data *vict, obj_data *obj, int spellnum
     if (TRIGGER_CHECK(t, WTRIG_CAST) &&
         (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
 
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       if (vict)
-        ADD_UID_VAR(buf, t, vict, "victim", 0);
+        ADD_UID_VAR(buf, t, char_script_id(vict), "victim", 0);
       if (obj)
-        ADD_UID_VAR(buf, t, obj, "object", 0);
+        ADD_UID_VAR(buf, t, obj_script_id(obj), "object", 0);
       sprintf(buf, "%d", spellnum);
       add_var(&GET_TRIG_VARS(t), "spell", buf, 0);
       add_var(&GET_TRIG_VARS(t), "spellname", skill_name(spellnum), 0);
@@ -1185,7 +1185,7 @@ int leave_wtrigger(struct room_data *room, char_data *actor, int dir)
         add_var(&GET_TRIG_VARS(t), "direction", dirs[dir], 0);
       else
         add_var(&GET_TRIG_VARS(t), "direction", "none", 0);
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       return script_driver(&room, t, WLD_TRIGGER, TRIG_NEW);
     }
   }
@@ -1211,7 +1211,7 @@ int door_wtrigger(char_data *actor, int subcmd, int dir)
         add_var(&GET_TRIG_VARS(t), "direction", dirs[dir], 0);
       else
         add_var(&GET_TRIG_VARS(t), "direction", "none", 0);
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       return script_driver(&room, t, WLD_TRIGGER, TRIG_NEW);
     }
   }
@@ -1249,7 +1249,7 @@ int login_wtrigger(struct room_data *room, char_data *actor)
   for (t = TRIGGERS(SCRIPT(room)); t; t = t->next) {
     if (TRIGGER_CHECK(t, WTRIG_LOGIN) &&
         (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
-      ADD_UID_VAR(buf, t, actor, "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
       return script_driver(&room, t, WLD_TRIGGER, TRIG_NEW);
     }
   }

--- a/src/dg_variables.c
+++ b/src/dg_variables.c
@@ -92,7 +92,7 @@ int item_in_list(char *item, obj_data *list)
     long id = atol(item + 1);
 
     for (i = list; i; i = i->next_content) {
-      if (id == GET_ID(i))
+      if (id == i->script_id)
         count ++;
       if (GET_OBJ_TYPE(i) == ITEM_CONTAINER)
         count += item_in_list(item, i->contains);
@@ -299,13 +299,13 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
       if (!str_cmp(var, "self")) {
         switch (type) {
         case MOB_TRIGGER:
-          snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID((char_data *) go));
+          snprintf(str, slen, "%c%ld", UID_CHAR, char_script_id((char_data *) go));
           break;
         case OBJ_TRIGGER:
-          snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID((obj_data *) go));
+          snprintf(str, slen, "%c%ld", UID_CHAR, obj_script_id((obj_data *) go));
           break;
         case WLD_TRIGGER:
-          snprintf(str, slen, "%c%ld", UID_CHAR, (long) ((room_data *)go)->number + ROOM_ID_BASE);
+          snprintf(str, slen, "%c%ld", UID_CHAR, room_script_id((room_data *)go));
           break;
         }
       }
@@ -539,7 +539,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
           }
 
           if (rndm)
-            snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(rndm));
+            snprintf(str, slen, "%c%ld", UID_CHAR, char_script_id(rndm));
           else
             *str = '\0';
         }
@@ -704,7 +704,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
             } else if ((pos = find_eq_pos_script(subfield)) < 0 || !GET_EQ(c, pos))
               *str = '\0';
             else
-              snprintf(str, slen, "%c%ld",UID_CHAR, GET_ID(GET_EQ(c, pos)));
+              snprintf(str, slen, "%c%ld",UID_CHAR, obj_script_id(GET_EQ(c, pos)));
           }
           else if (!str_cmp(field, "exp")) {
             if (subfield && *subfield) {
@@ -718,7 +718,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
         case 'f':
           if (!str_cmp(field, "fighting")) {
             if (FIGHTING(c))
-              snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(FIGHTING(c)));
+              snprintf(str, slen, "%c%ld", UID_CHAR, char_script_id(FIGHTING(c)));
             else
               *str = '\0';
           }
@@ -726,7 +726,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
             if (!c->followers || !c->followers->follower)
               *str = '\0';
             else
-              snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(c->followers->follower));
+              snprintf(str, slen, "%c%ld", UID_CHAR, char_script_id(c->followers->follower));
           }
           break;
         case 'g':
@@ -784,7 +784,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
           break;
         case 'i':
           if (!str_cmp(field, "id"))
-            snprintf(str, slen, "%ld", GET_ID(c));
+            snprintf(str, slen, "%ld", char_script_id(c));
           /* new check for pc/npc status */
           else if (!str_cmp(field, "is_pc")) {
             if (IS_NPC(c))
@@ -806,7 +806,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
             if(subfield && *subfield) {
               for (obj = c->carrying;obj;obj=obj->next_content) {
                 if(GET_OBJ_VNUM(obj)==atoi(subfield)) {
-                  snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(obj)); /* arg given, found */
+                  snprintf(str, slen, "%c%ld", UID_CHAR, obj_script_id(obj)); /* arg given, found */
                   return;
                 }
               }
@@ -814,7 +814,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
                 *str = '\0'; /* arg given, not found */
             } else { /* no arg given */
               if (c->carrying) {
-                snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(c->carrying));
+                snprintf(str, slen, "%c%ld", UID_CHAR, obj_script_id(c->carrying));
               } else {
                 *str = '\0';
               }
@@ -866,7 +866,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
             if (!c->master)
               *str = '\0';
             else
-              snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(c->master));
+              snprintf(str, slen, "%c%ld", UID_CHAR, char_script_id(c->master));
           }
           else if (!str_cmp(field, "maxhitp")) {
             if (subfield && *subfield) {
@@ -903,7 +903,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
 
           else if (!str_cmp(field, "next_in_room")) {
             if (c->next_in_room)
-              snprintf(str, slen,"%c%ld",UID_CHAR, GET_ID(c->next_in_room));
+              snprintf(str, slen,"%c%ld",UID_CHAR, char_script_id(c->next_in_room));
             else
               *str = '\0';
           }
@@ -976,7 +976,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
 /* see note in dg_scripts.h */
 #ifdef ACTOR_ROOM_IS_UID
             snprintf(str, slen, "%c%ld",UID_CHAR,
-               (IN_ROOM(c)!= NOWHERE) ? (long) world[IN_ROOM(c)].number + ROOM_ID_BASE : ROOM_ID_BASE);
+               (IN_ROOM(c)!= NOWHERE) ? room_script_id(world + IN_ROOM(c)) : ROOM_ID_BASE);
 #else
             snprintf(str, slen, "%d", (IN_ROOM(c)!= NOWHERE) ? world[IN_ROOM(c)].number : 0);
 #endif
@@ -1182,14 +1182,14 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
 
           else if (!str_cmp(field, "carried_by")) {
             if (o->carried_by)
-              snprintf(str, slen,"%c%ld",UID_CHAR, GET_ID(o->carried_by));
+              snprintf(str, slen,"%c%ld",UID_CHAR, char_script_id(o->carried_by));
             else
               *str = '\0';
           }
 
           else if (!str_cmp(field, "contents")) {
             if (o->contains)
-              snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(o->contains));
+              snprintf(str, slen, "%c%ld", UID_CHAR, obj_script_id(o->contains));
             else
               *str = '\0';
           }
@@ -1234,11 +1234,11 @@ o->contains) ? "1" : "0"));
           break;
         case 'i':
           if (!str_cmp(field, "id"))
-            snprintf(str, slen, "%ld", GET_ID(o));
+            snprintf(str, slen, "%ld", obj_script_id(o));
 
           else if (!str_cmp(field, "is_inroom")) {
             if (IN_ROOM(o) != NOWHERE)
-              snprintf(str, slen,"%c%ld",UID_CHAR, (long) world[IN_ROOM(o)].number + ROOM_ID_BASE);
+              snprintf(str, slen,"%c%ld",UID_CHAR, room_script_id(world + IN_ROOM(o)));
             else
               *str = '\0';
           }
@@ -1252,7 +1252,7 @@ o->contains) ? "1" : "0"));
 
           else if (!str_cmp(field, "next_in_list")) {
             if (o->next_content)
-              snprintf(str, slen,"%c%ld",UID_CHAR, GET_ID(o->next_content));
+              snprintf(str, slen,"%c%ld",UID_CHAR, obj_script_id(o->next_content));
             else
               *str = '\0';
           }
@@ -1270,7 +1270,7 @@ o->contains) ? "1" : "0"));
         case 'r':
           if (!str_cmp(field, "room")) {
             if (obj_room(o) != NOWHERE)
-              snprintf(str, slen,"%c%ld",UID_CHAR, (long)world[obj_room(o)].number + ROOM_ID_BASE);
+              snprintf(str, slen,"%c%ld",UID_CHAR, room_script_id(world + obj_room(o)));
             else
               *str = '\0';
           }
@@ -1326,7 +1326,7 @@ o->contains) ? "1" : "0"));
 
           else if (!str_cmp(field, "worn_by")) {
             if (o->worn_by)
-              snprintf(str, slen,"%c%ld",UID_CHAR, GET_ID(o->worn_by));
+              snprintf(str, slen,"%c%ld",UID_CHAR, char_script_id(o->worn_by));
             else
               *str = '\0';
           }
@@ -1390,7 +1390,7 @@ o->contains) ? "1" : "0"));
           for (obj = r->contents; obj; obj = obj->next_content) {
             if (GET_OBJ_VNUM(obj) == atoi(subfield)) {
               /* arg given, found */
-              snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(obj));
+              snprintf(str, slen, "%c%ld", UID_CHAR, obj_script_id(obj));
               return;
             }
           }
@@ -1398,7 +1398,7 @@ o->contains) ? "1" : "0"));
             *str = '\0'; /* arg given, not found */
         } else { /* no arg given */
           if (r->contents) {
-            snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(r->contents));
+            snprintf(str, slen, "%c%ld", UID_CHAR, obj_script_id(r->contents));
           } else {
             *str = '\0';
           }
@@ -1407,14 +1407,14 @@ o->contains) ? "1" : "0"));
 
       else if (!str_cmp(field, "people")) {
         if (r->people)
-          snprintf(str, slen, "%c%ld", UID_CHAR, GET_ID(r->people));
+          snprintf(str, slen, "%c%ld", UID_CHAR, char_script_id(r->people));
         else
           *str = '\0';
       }
       else if (!str_cmp(field, "id")) {
         room_rnum rnum = real_room(r->number);
         if (rnum != NOWHERE)
-          snprintf(str, slen, "%ld", (long) world[rnum].number + ROOM_ID_BASE);
+          snprintf(str, slen, "%ld", room_script_id(world + rnum));
         else
           *str = '\0';
       }
@@ -1464,7 +1464,7 @@ o->contains) ? "1" : "0"));
               sprintbit(R_EXIT(r, NORTH)->exit_info ,exit_bits, str, slen);
             else if (!str_cmp(subfield, "room")) {
               if (R_EXIT(r, NORTH)->to_room != NOWHERE)
-                snprintf(str, slen, "%c%ld", UID_CHAR, (long) world[R_EXIT(r, NORTH)->to_room].number + ROOM_ID_BASE);
+                snprintf(str, slen, "%c%ld", UID_CHAR, room_script_id(world + R_EXIT(r, NORTH)->to_room));
               else
                 *str = '\0';
             }
@@ -1484,7 +1484,7 @@ o->contains) ? "1" : "0"));
               sprintbit(R_EXIT(r, EAST)->exit_info ,exit_bits, str, slen);
             else if (!str_cmp(subfield, "room")) {
               if (R_EXIT(r, EAST)->to_room != NOWHERE)
-                snprintf(str, slen, "%c%ld", UID_CHAR, (long) world[R_EXIT(r, EAST)->to_room].number + ROOM_ID_BASE);
+                snprintf(str, slen, "%c%ld", UID_CHAR, room_script_id(world + R_EXIT(r, EAST)->to_room));
               else
                 *str = '\0';
             }
@@ -1504,7 +1504,7 @@ o->contains) ? "1" : "0"));
               sprintbit(R_EXIT(r, SOUTH)->exit_info ,exit_bits, str, slen);
             else if (!str_cmp(subfield, "room")) {
               if (R_EXIT(r, SOUTH)->to_room != NOWHERE)
-                snprintf(str, slen, "%c%ld", UID_CHAR, (long) world[R_EXIT(r, SOUTH)->to_room].number + ROOM_ID_BASE);
+                snprintf(str, slen, "%c%ld", UID_CHAR, room_script_id(world + R_EXIT(r, SOUTH)->to_room));
               else
                 *str = '\0';
             }
@@ -1524,7 +1524,7 @@ o->contains) ? "1" : "0"));
               sprintbit(R_EXIT(r, WEST)->exit_info ,exit_bits, str, slen);
             else if (!str_cmp(subfield, "room")) {
               if (R_EXIT(r, WEST)->to_room != NOWHERE)
-                snprintf(str, slen, "%c%ld", UID_CHAR, (long) world[R_EXIT(r, WEST)->to_room].number + ROOM_ID_BASE);
+                snprintf(str, slen, "%c%ld", UID_CHAR, room_script_id(world + R_EXIT(r, WEST)->to_room));
               else
                 *str = '\0';
             }
@@ -1544,7 +1544,7 @@ o->contains) ? "1" : "0"));
               sprintbit(R_EXIT(r, UP)->exit_info ,exit_bits, str, slen);
             else if (!str_cmp(subfield, "room")) {
               if (R_EXIT(r, UP)->to_room != NOWHERE)
-                snprintf(str, slen, "%c%ld", UID_CHAR, (long) world[R_EXIT(r, UP)->to_room].number + ROOM_ID_BASE);
+                snprintf(str, slen, "%c%ld", UID_CHAR, room_script_id(world + R_EXIT(r, UP)->to_room));
               else
                 *str = '\0';
             }
@@ -1564,7 +1564,7 @@ o->contains) ? "1" : "0"));
               sprintbit(R_EXIT(r, DOWN)->exit_info ,exit_bits, str, slen);
             else if (!str_cmp(subfield, "room")) {
               if (R_EXIT(r, DOWN)->to_room != NOWHERE)
-                snprintf(str, slen, "%c%ld", UID_CHAR, (long) world[R_EXIT(r, DOWN)->to_room].number + ROOM_ID_BASE);
+                snprintf(str, slen, "%c%ld", UID_CHAR, room_script_id(world + R_EXIT(r, DOWN)->to_room));
               else
                 *str = '\0';
             }

--- a/src/dg_wldcmd.c
+++ b/src/dg_wldcmd.c
@@ -468,7 +468,7 @@ WCMD(do_wload)
       char_to_room(mob, rnum);
       if (SCRIPT(room)) { /* It _should_ have, but it might be detached. */
         char buf[MAX_INPUT_LENGTH];
-        sprintf(buf, "%c%ld", UID_CHAR, GET_ID(mob));
+        sprintf(buf, "%c%ld", UID_CHAR, char_script_id(mob));
         add_var(&(SCRIPT(room)->global_vars), "lastloaded", buf, 0);
       }
       load_mtrigger(mob);
@@ -484,7 +484,7 @@ WCMD(do_wload)
         obj_to_room(object, real_room(room->number));
         if (SCRIPT(room)) { /* It _should_ have, but it might be detached. */
           char buf[MAX_INPUT_LENGTH];
-          sprintf(buf, "%c%ld", UID_CHAR, GET_ID(object));
+          sprintf(buf, "%c%ld", UID_CHAR, obj_script_id(object));
           add_var(&(SCRIPT(room)->global_vars), "lastloaded", buf, 0);
         }
         load_otrigger(object);

--- a/src/genobj.c
+++ b/src/genobj.c
@@ -64,7 +64,7 @@ static int update_all_objects(struct obj_data *refobj)
     *obj = *refobj;
 
     /* Copy game-time dependent variables over. */
-    GET_ID(obj) = swap.id;
+    obj->script_id = swap.script_id;
     IN_ROOM(obj) = swap.in_room;
     obj->carried_by = swap.carried_by;
     obj->worn_by = swap.worn_by;

--- a/src/handler.c
+++ b/src/handler.c
@@ -990,18 +990,24 @@ void extract_char_final(struct char_data *ch)
  * trivial workaround of 'vict = next_vict' doesn't work if the _next_ person
  * in the list gets killed, for example, by an area spell. Why do we leave them
  * on the character_list? Because code doing 'vict = vict->next' would get
- * really confused otherwise. */
+ * really confused otherwise.
+ *
+ * Fixed a bug where it would over-count extractions if you try to extract the
+ * same character twice (e.g. double-purging in a script) -khufu / EmpireMUD
+ */
 void extract_char(struct char_data *ch)
 {
   char_from_furniture(ch);
   clear_char_event_list(ch);
 
-  if (IS_NPC(ch))
+  if (IS_NPC(ch) && !MOB_FLAGGED(ch, MOB_NOTDEADYET)) {
     SET_BIT_AR(MOB_FLAGS(ch), MOB_NOTDEADYET);
-  else
+    ++extractions_pending;
+  }
+  else if (!IS_NPC(ch) && !PLR_FLAGGED(ch, PLR_NOTDEADYET)) {
     SET_BIT_AR(PLR_FLAGS(ch), PLR_NOTDEADYET);
-
-  extractions_pending++;
+    ++extractions_pending;
+  }
 }
 
 /* I'm not particularly pleased with the MOB/PLR hoops that have to be jumped

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1253,9 +1253,9 @@ int enter_player_game (struct descriptor_data *d)
     load_room = r_frozen_start_room;
 
   /* copyover */
-  GET_ID(d->character) = GET_IDNUM(d->character);
+  d->character->script_id = GET_IDNUM(d->character);
   /* find_char helper */
-  add_to_lookup_table(GET_ID(d->character), (void *)d->character);
+  add_to_lookup_table(d->character->script_id, (void *)d->character);
 
   /* After moving saving of variables to the player file, this should only
    * be called in case nothing was found in the pfile. If something was

--- a/src/structs.h
+++ b/src/structs.h
@@ -716,7 +716,7 @@ struct obj_data
   struct obj_data *in_obj; /**< Points to carrying object, or NULL */
   struct obj_data *contains; /**< List of objects being carried, or NULL */
 
-  long id; /**< used by DG triggers - unique id  */
+  long script_id; /**< used by DG triggers - fetch only with obj_script_id()  */
   struct trig_proto_list *proto_script; /**< list of default triggers  */
   struct script_data *script;           /**< script info for the object */
 
@@ -1032,7 +1032,7 @@ struct char_data
   struct obj_data *carrying;    /**< List head for objects in inventory */
   struct descriptor_data *desc; /**< Descriptor/connection info; NPCs = NULL */
 
-  long id; /**< used by DG triggers - unique id */
+  long script_id; /**< used by DG triggers - fetch only with char_script_id() */
   struct trig_proto_list *proto_script; /**< list of default triggers */
   struct script_data *script;           /**< script info for the object */
   struct script_memory *memory;         /**< for mob memory triggers */

--- a/src/utils.h
+++ b/src/utils.h
@@ -537,7 +537,8 @@ do                                                              \
 /** Unique ID of ch. */
 #define GET_IDNUM(ch)	  ((ch)->char_specials.saved.idnum)
 /** Returns contents of id field from x. */
-#define GET_ID(x)         ((x)->id)
+/** Warning: GET_ID is deprecated and you should use char_script_id, obj_script_id, room_script_id */
+/** #define GET_ID(x)         ((x)->id) */
 /** Weight carried by ch. */
 #define IS_CARRYING_W(ch) ((ch)->char_specials.carry_weight)
 /** Number of items carried by ch. */


### PR DESCRIPTION
This fixes 3 bugs in its 3 commits:
- Extractions are over-counted, leading to a meaningless SYSERR
- Scripts run out of ID space too soon: raised ID space for mobs and rooms (objects are not limited anyway)
- Scripts run out of ID space part 2: mobs and objects are no longer assigned script ids until they are requested, preventing wasted ids if the mob/obj is never targeted by a script