### PR TITLE
Multiple keyword support

### DIFF
--- a/src/handler.c
+++ b/src/handler.c
@@ -122,9 +122,14 @@ int isname (const char *str, const char *namelist)
     for (substr = strtok(strlist, KEYWORDJOIN); substr; substr = strtok (NULL, KEYWORDJOIN))
     {
         if (!substr) continue;
-        if (!isname_tok(substr, namelist)) return 0;
+        if (!isname_tok(substr, namelist)) 
+        {
+            free(strlist);
+            return 0;
+        }
     }
     /* If we didn't fail, assume we succeded because every token was matched */
+    free(strlist);
     return 1;
 }
 

--- a/src/handler.c
+++ b/src/handler.c
@@ -81,7 +81,8 @@ int is_name(const char *str, const char *namelist)
 
 /* allow abbreviations */
 #define WHITESPACE " \t"
-int isname(const char *str, const char *namelist)
+#define KEYWORDJOIN "_"
+int isname_tok(const char *str, const char *namelist)
 {
   char *newlist;
   char *curtok;
@@ -104,6 +105,29 @@ int isname(const char *str, const char *namelist)
   free(newlist);
   return 0;
 }
+
+
+int isname (const char *str, const char *namelist)
+{
+  char *strlist;
+  char *substr;
+
+  if (!str || !*str || !namelist || !*namelist)
+    return 0;
+
+  if (!strcmp (str, namelist))	/* the easy way */
+    return 1;
+
+    strlist = strdup(str);
+    for (substr = strtok(strlist, KEYWORDJOIN); substr; substr = strtok (NULL, KEYWORDJOIN))
+    {
+        if (!substr) continue;
+        if (!isname_tok(substr, namelist)) return 0;
+    }
+    /* If we didn't fail, assume we succeded because every token was matched */
+    return 1;
+}
+
 
 static void aff_apply_modify(struct char_data *ch, byte loc, sbyte mod, char *msg)
 {


### PR DESCRIPTION
This change will allow the player to use multiple keywords to narrowly target a single object from several similar ones.

For example, say I had the following items:

- Armor of Power (keywords "armor" and "power")
- Gloves of Power (keywords "gloves" and "power")
- Armor of Weakness (keywords "armor" and "weakness")

Currently, there's no unique way to identify the Armor of Power - the only way to definitely target it is to try `1.armor`, `2.armor`, etc until you hit on it.

With this patch, you can use multiple keywords separated by an underscore to target an item more accurately.  In this case, it'd be `take armor_power` to target only an item which had both "armor" and "power" as keywords.  The ordering doesn't matter, and abbreviations within a keyword should still work just fine.