### PR TITLE
Fix misleading indentation warnings on newer version of GCC

### DIFF
--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -1292,8 +1292,8 @@ ACMD(do_who)
         else if (PLR_FLAGGED(tch, PLR_WRITING))
           send_to_char(ch, " (writing)");
 
-      if (d->original)
-        send_to_char(ch, " (out of body)");
+        if (d->original)
+          send_to_char(ch, " (out of body)");
 
         if (d->connected == CON_OEDIT)
           send_to_char(ch, " (Object Edit)");
@@ -2057,10 +2057,10 @@ ACMD(do_toggle)
     if (!strncmp(arg, tog_messages[toggle].command, len))
       break;
 
-    if (*tog_messages[toggle].command == '\n' || tog_messages[toggle].min_level > GET_LEVEL(ch)) {
-      send_to_char(ch, "You can't toggle that!\r\n");
-      return;
-    }
+  if (*tog_messages[toggle].command == '\n' || tog_messages[toggle].min_level > GET_LEVEL(ch)) {
+    send_to_char(ch, "You can't toggle that!\r\n");
+    return;
+  }
 
   switch (toggle) {
   case SCMD_COLOR:
@@ -2169,7 +2169,7 @@ ACMD(do_toggle)
       send_to_char(ch, "Okay, your page length is now set to %d lines.", GET_PAGE_LENGTH(ch));
     } else
       send_to_char(ch, "Please specify a number of lines (5 - 255).");
-      break;
+    break;
   case SCMD_SCREENWIDTH:
     if (!*arg2)
       send_to_char(ch, "Your current screen width is set to %d characters.", GET_SCREEN_WIDTH(ch));
@@ -2178,7 +2178,7 @@ ACMD(do_toggle)
       send_to_char(ch, "Okay, your screen width is now set to %d characters.", GET_SCREEN_WIDTH(ch));
     } else
       send_to_char(ch, "Please specify a number of characters (40 - 200).");
-      break;
+    break;
   case SCMD_AUTOMAP:
     if (can_see_map(ch)) {
       if (!*arg2) {
@@ -2195,7 +2195,7 @@ ACMD(do_toggle)
       }
     } else
       send_to_char(ch, "Sorry, automap is currently disabled.\r\n");
-      break;
+    break;
   default:
     if (!*arg2) {
       TOGGLE_BIT_AR(PRF_FLAGS(ch), tog_messages[toggle].toggle);
@@ -2206,7 +2206,7 @@ ACMD(do_toggle)
     } else if (!strcmp(arg2, "off")) {
       REMOVE_BIT_AR(PRF_FLAGS(ch), tog_messages[toggle].toggle);
     } else {
-        send_to_char(ch, "Value for %s must either be 'on' or 'off'.\r\n", tog_messages[toggle].command);
+      send_to_char(ch, "Value for %s must either be 'on' or 'off'.\r\n", tog_messages[toggle].command);
       return;
     }
   }

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -3669,20 +3669,20 @@ ACMD (do_zcheck)
           len += snprintf(buf + len, sizeof(buf) - len,
                             "- SPEC flag needs to be removed.\r\n");
 
-          /* Additional mob checks.*/
-          if (found) {
-            send_to_char(ch,
-                    "%s[%5d]%s %-30s: %s\r\n",
-                    CCCYN(ch, C_NRM), GET_MOB_VNUM(mob),
-                    CCYEL(ch, C_NRM), GET_NAME(mob),
-                    CCNRM(ch, C_NRM));
-            send_to_char(ch, "%s", buf);
-          }
-          /* reset buffers and found flag */
-          strcpy(buf, "");
-          found = 0;
-          len = 0;
-        }   /* mob is in zone */
+        /* Additional mob checks.*/
+        if (found) {
+          send_to_char(ch,
+                  "%s[%5d]%s %-30s: %s\r\n",
+                  CCCYN(ch, C_NRM), GET_MOB_VNUM(mob),
+                  CCYEL(ch, C_NRM), GET_NAME(mob),
+                  CCNRM(ch, C_NRM));
+          send_to_char(ch, "%s", buf);
+        }
+        /* reset buffers and found flag */
+        strcpy(buf, "");
+        found = 0;
+        len = 0;
+      }   /* mob is in zone */
     }  /* check mobs */
 
  /* Check objects */
@@ -3988,15 +3988,15 @@ static void obj_checkload(struct char_data *ch, obj_vnum ovnum)
                              mob_proto[lastmob_r].player.short_descr,
                              mob_index[lastmob_r].vnum,
                              ZCMD2.arg2);
-            break;
-          case 'R': /* rem obj from room */
-            lastroom_v = world[ZCMD2.arg1].number;
-            lastroom_r = ZCMD2.arg1;
-            if (ZCMD2.arg2 == ornum)
-              send_to_char(ch, "  [%5d] %s (Removed from room)\r\n",
-                               lastroom_v,
-                               world[lastroom_r].name);
-            break;
+          break;
+        case 'R': /* rem obj from room */
+          lastroom_v = world[ZCMD2.arg1].number;
+          lastroom_r = ZCMD2.arg1;
+          if (ZCMD2.arg2 == ornum)
+            send_to_char(ch, "  [%5d] %s (Removed from room)\r\n",
+                             lastroom_v,
+                             world[lastroom_r].name);
+          break;
       }/* switch */
     } /*for cmd_no......*/
   }  /*for zone...*/

--- a/src/aedit.c
+++ b/src/aedit.c
@@ -42,7 +42,7 @@ ACMD(do_oasis_aedit)
   if (IS_NPC(ch) || !ch->desc || STATE(ch->desc) != CON_PLAYING)
     return;
     
-    if (CONFIG_NEW_SOCIALS == 0) {
+  if (CONFIG_NEW_SOCIALS == 0) {
     send_to_char(ch, "Socials cannot be edited at the moment.\r\n");
     return;
   }

--- a/src/dg_olc.c
+++ b/src/dg_olc.c
@@ -499,50 +499,50 @@ void trigedit_parse(struct descriptor_data *d, char *arg)
            OLC_MODE(d) = TRIGEDIT_CONFIRM_SAVESTRING;
          } else
            cleanup_olc(d, CLEANUP_ALL);
-           return;
-         case '1':
-           OLC_MODE(d) = TRIGEDIT_NAME;
-           write_to_output(d, "Name: ");
-           break;
-         case '2':
-           OLC_MODE(d) = TRIGEDIT_INTENDED;
-           write_to_output(d, "0: Mobiles, 1: Objects, 2: Rooms: ");
-           break;
-         case '3':
-           OLC_MODE(d) = TRIGEDIT_TYPES;
-           trigedit_disp_types(d);
-           break;
-         case '4':
-           OLC_MODE(d) = TRIGEDIT_NARG;
-           write_to_output(d, "Numeric argument: ");
-           break;
-         case '5':
-           OLC_MODE(d) = TRIGEDIT_ARGUMENT;
-           write_to_output(d, "Argument: ");
-           break;
-         case '6':
-           OLC_MODE(d) = TRIGEDIT_COMMANDS;
-           write_to_output(d, "Enter trigger commands: (/s saves /h for help)\r\n\r\n");
-           d->backstr = NULL;
-           if (OLC_STORAGE(d)) {
-             clear_screen(d);
-             script_syntax_highlighting(d, OLC_STORAGE(d));
-             d->backstr = strdup(OLC_STORAGE(d));
-           }
-           d->str = &OLC_STORAGE(d);
-           d->max_str = MAX_CMD_LENGTH;
-           d->mail_to = 0;
-           OLC_VAL(d) = 1;
+         return;
+       case '1':
+         OLC_MODE(d) = TRIGEDIT_NAME;
+         write_to_output(d, "Name: ");
+         break;
+       case '2':
+         OLC_MODE(d) = TRIGEDIT_INTENDED;
+         write_to_output(d, "0: Mobiles, 1: Objects, 2: Rooms: ");
+         break;
+       case '3':
+         OLC_MODE(d) = TRIGEDIT_TYPES;
+         trigedit_disp_types(d);
+         break;
+       case '4':
+         OLC_MODE(d) = TRIGEDIT_NARG;
+         write_to_output(d, "Numeric argument: ");
+         break;
+       case '5':
+         OLC_MODE(d) = TRIGEDIT_ARGUMENT;
+         write_to_output(d, "Argument: ");
+         break;
+       case '6':
+         OLC_MODE(d) = TRIGEDIT_COMMANDS;
+         write_to_output(d, "Enter trigger commands: (/s saves /h for help)\r\n\r\n");
+         d->backstr = NULL;
+         if (OLC_STORAGE(d)) {
+           clear_screen(d);
+           script_syntax_highlighting(d, OLC_STORAGE(d));
+           d->backstr = strdup(OLC_STORAGE(d));
+         }
+         d->str = &OLC_STORAGE(d);
+         d->max_str = MAX_CMD_LENGTH;
+         d->mail_to = 0;
+         OLC_VAL(d) = 1;
 
-           break;
-         case 'w':
-         case 'W':
-           write_to_output(d, "Copy what trigger? ");
-           OLC_MODE(d) = TRIGEDIT_COPY;
-           break;
-         default:
-           trigedit_disp_menu(d);
-           return;
+         break;
+       case 'w':
+       case 'W':
+         write_to_output(d, "Copy what trigger? ");
+         OLC_MODE(d) = TRIGEDIT_COPY;
+         break;
+       default:
+         trigedit_disp_menu(d);
+         return;
      }
      return;
 

--- a/src/dg_scripts.c
+++ b/src/dg_scripts.c
@@ -793,10 +793,11 @@ static void do_stat_trigger(struct char_data *ch, trig_data *trig)
       if (cmd_list->cmd)
         len += snprintf(sb + len, sizeof(sb)-len, "%s\r\n", cmd_list->cmd);
 
-        if (len>MAX_STRING_LENGTH-80) {
-          len += snprintf(sb + len, sizeof(sb)-len, "*** Overflow - script too long! ***\r\n");
-          break;
-        }
+      if (len>MAX_STRING_LENGTH-80) {
+        len += snprintf(sb + len, sizeof(sb)-len, "*** Overflow - script too long! ***\r\n");
+        break;
+      }
+      
       cmd_list = cmd_list->next;
     }
 

--- a/src/modify.c
+++ b/src/modify.c
@@ -253,17 +253,18 @@ static void playing_string_cleanup(struct descriptor_data *d, int action)
       notify_if_playing(d->character, d->mail_to);
     } else
       write_to_output(d, "Mail aborted.\r\n");
-      free(*d->str);
-      free(d->str);
-    }
+    
+    free(*d->str);
+    free(d->str);
+  }
 
-  /* We have no way of knowing which slot the post was sent to so we can only
-   * give the message.   */
-    if (d->mail_to >= BOARD_MAGIC) {
-      board_save_board(d->mail_to - BOARD_MAGIC);
-      if (action == STRINGADD_ABORT)
-        write_to_output(d, "Post not aborted, use REMOVE <post #>.\r\n");
-    }
+/* We have no way of knowing which slot the post was sent to so we can only
+ * give the message.   */
+  if (d->mail_to >= BOARD_MAGIC) {
+    board_save_board(d->mail_to - BOARD_MAGIC);
+    if (action == STRINGADD_ABORT)
+      write_to_output(d, "Post not aborted, use REMOVE <post #>.\r\n");
+  }
   if (PLR_FLAGGED(d->character, PLR_IDEA)) {
     if (action == STRINGADD_SAVE && *d->str){
       write_to_output(d, "Idea saved!\r\n");

--- a/src/prefedit.c
+++ b/src/prefedit.c
@@ -958,7 +958,7 @@ ACMD(do_oasis_prefedit)
           send_to_char(ch, "Your preferences are currently being edited by %s.\r\n", PERS(d->character, ch));
         else
           sprintf(buf, "$S$u preferences are currently being edited by %s.", PERS(d->character, ch));
-          act(buf, FALSE, ch, 0, vict, TO_CHAR);
+        act(buf, FALSE, ch, 0, vict, TO_CHAR);
         return;
       }
     }

--- a/src/sedit.c
+++ b/src/sedit.c
@@ -744,7 +744,7 @@ void sedit_parse(struct descriptor_data *d, char *arg)
       }
     if (i >= 0)
       add_shop_to_int_list(&(S_ROOMS(OLC_SHOP(d))), atoi(arg));
-      sedit_rooms_menu(d);
+    sedit_rooms_menu(d);
     return;
   case SEDIT_DELETE_ROOM:
     remove_shop_from_int_list(&(S_ROOMS(OLC_SHOP(d))), atoi(arg));

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -404,8 +404,8 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
   case ITEM_POTION:
     tch = ch;
 
-  if (!consume_otrigger(obj, ch, OCMD_QUAFF))  /* check trigger */
-    return;
+    if (!consume_otrigger(obj, ch, OCMD_QUAFF))  /* check trigger */
+      return;
 
     act("You quaff $p.", FALSE, ch, obj, NULL, TO_CHAR);
     if (obj->action_description)


### PR DESCRIPTION
All whitespace changes.  These were causing compiler warnings on newer versions of GCC.