### PR TITLE
Minor fixes for done/end markers in one script.

### DIFF
--- a/lib/world/trg/274.trg
+++ b/lib/world/trg/274.trg
@@ -106,8 +106,7 @@ switch %random.4%
        say its a mean old man!
       else
        say its a mean witch!
-       done
-      done
+      end
       %echo% the child starts crying!
     break
     case 2
@@ -122,7 +121,7 @@ switch %random.4%
       hug %actor.name%
       say Please be welcome here!
     break
-end
+done
 ~
 #27407
 Std greeting shop mobs~


### PR DESCRIPTION
I don't know dg_script well at all, so I could be mistaken.  But, I think these are just minor errors in this script.

I have a separately-implemented mud codebase that interprets the worlds from tbamud, and it flags these as errors, and some other issues I might chose to fix later, depending on how this PR goes.  :)

Of course, it's possible this is really a bug in my own codebase, and not in these scripts... but I don't think so - and the documentation I've managed to find seems to confirm my suspicion.