### PR TITLE
Normalize a few spell names.

### DIFF
--- a/lib/world/trg/130.trg
+++ b/lib/world/trg/130.trg
@@ -795,7 +795,7 @@ switch %random.7%
   case 3
     say Let's see how well you do if I pluck out your eyes!
     wait 1 sec
-    dg_cast 'blind' %actor%
+    dg_cast 'blindness' %actor%
   break
   case 4
     say I said to 'shut up'!!

--- a/lib/world/trg/14.trg
+++ b/lib/world/trg/14.trg
@@ -520,7 +520,7 @@ switch %random.3%
     dg_cast 'harm' %actor%
   break
   case 2
-    dg_cast 'magic missle' %actor%
+    dg_cast 'magic missile' %actor%
   break
   default
     say That wasn't right...

--- a/lib/world/trg/274.trg
+++ b/lib/world/trg/274.trg
@@ -7,7 +7,7 @@ say Blessings upon you this day, %actor.name%. The hand of God
 say be upon you always. Here let me heal and help you.
 dg_cast 'heal' %actor.name%
 wait 5
-dg_cast 'sanc' %actor.name%
+dg_cast 'sanctuary' %actor.name%
 wait 5
 dg_cast 'fly' %actor.name%
 wait 5

--- a/lib/world/trg/288.trg
+++ b/lib/world/trg/288.trg
@@ -75,7 +75,7 @@ switch %rand%
     dg_cast 'curse' %actor%
   break
   case 3
-    dg_cast 'blind' %actor%
+    dg_cast 'blindness' %actor%
   break
   case 4
     dg_cast 'earthquake'

--- a/lib/world/trg/3.trg
+++ b/lib/world/trg/3.trg
@@ -272,7 +272,7 @@ disarm %actor%
 Mob Fight - generic lightning bolt~
 0 k 10
 ~
-dg_cast 'lightning' %actor%
+dg_cast 'lightning bolt' %actor%
 ~
 #322
 Mob Fight - generic kick~

--- a/lib/world/trg/343.trg
+++ b/lib/world/trg/343.trg
@@ -201,7 +201,7 @@ say Blessings upon you this day, %actor.name%. The hand of God
 say be upon you always. Here let me heal and help you.
 dg_cast 'heal' %actor.name%
 wait 5
-dg_cast 'sanc' %actor.name%
+dg_cast 'sanctuary' %actor.name%
 wait 5
 dg_cast 'fly' %actor.name%
 wait 5


### PR DESCRIPTION
This just makes all dg_casts use the same name for the same spell.

Some of these are just short names, at least one seems to be a typo.