### PR TITLE
Remove extra spaces inside parens in a some expressions.

### DIFF
--- a/lib/world/trg/201.trg
+++ b/lib/world/trg/201.trg
@@ -2,7 +2,7 @@
 Seabreeze/Landbreeze - All Rooms~
 2 b 75
 ~
-if ( %time.hour% >=7 && %time.hour% <=19)
+if (%time.hour% >=7 && %time.hour% <=19)
   %echo% @WA seabreeze arrives from the south, bringing in the smell of salt.@n
   return 0
 else
@@ -21,7 +21,7 @@ return 0
 Seabreeze only - all~
 2 b 100
 ~
-if ( %time.hour% >=7 && %time.hour% <=19)
+if (%time.hour% >=7 && %time.hour% <=19)
   %echo% @WA seabreeze arrives from the south, bringing in the smell of salt.@n
   return 0
 end
@@ -99,7 +99,7 @@ in room 1233.
 the crabs sleep - 20101~
 0 b 100
 ~
-if ( %time.hour% <=7 || %time.hour% >=19)
+if (%time.hour% <=7 || %time.hour% >=19)
   eval line %random.5%
   switch %line%
     case 1
@@ -133,7 +133,7 @@ end
 seagull sleeps/wake - 20103~
 0 b 100
 ~
-if ( %time.hour% <=5 || %time.hour% >=18)
+if (%time.hour% <=5 || %time.hour% >=18)
   south
   %teleport% %self% 20110
   wait 2 secs
@@ -908,7 +908,7 @@ wait 5
 More effects - 20147~
 2 b 100
 ~
-if ( %time.hour% >=6 && %time.hour% <=17)
+if (%time.hour% >=6 && %time.hour% <=17)
   %echo% A bird sings from the nearby tree.
   return 0
 else

--- a/lib/world/trg/345.trg
+++ b/lib/world/trg/345.trg
@@ -80,7 +80,7 @@ end
 Quest 2 give obj. (mob 34502)~
 0 j 100
 ~
-if %object.vnum( 34502 )%
+if %object.vnum(34502)%
   wait 1 s
   say Thank you.
   say Now for your information

--- a/lib/world/trg/83.trg
+++ b/lib/world/trg/83.trg
@@ -441,7 +441,7 @@ emote clears his throat.
 wait 3s
 while %beers%
   eval beertens %beers% / 10
-  eval beerones %beers% - ( %beertens% * 10 )
+  eval beerones %beers% - (%beertens% * 10)
   switch %beerones%
     case 0
       unset alphabeers


### PR DESCRIPTION
Functionally, this is a non-change.
This just conforms a few odd cases to be the same as the rest.

`git show -w` shows nothing (this is a whitespace-only change).