### PR TITLE
Fixes for w-format-truncation. Also, export of zones work again on linux

### DIFF
--- a/src/act.comm.c
+++ b/src/act.comm.c
@@ -144,7 +144,7 @@ static int is_tell_ok(struct char_data *ch, struct char_data *vict)
 ACMD(do_tell)
 {
   struct char_data *vict = NULL;
-  char buf[MAX_INPUT_LENGTH], buf2[MAX_INPUT_LENGTH];
+  char buf[MAX_INPUT_LENGTH + 25], buf2[MAX_INPUT_LENGTH];  // +25 to make room for constants
 
   half_chop(argument, buf, buf2);
 
@@ -397,7 +397,7 @@ ACMD(do_gen_comm)
 {
   struct descriptor_data *i;
   char color_on[24];
-  char buf1[MAX_INPUT_LENGTH], buf2[MAX_INPUT_LENGTH], *msg;
+  char buf1[MAX_INPUT_LENGTH], buf2[MAX_INPUT_LENGTH + 50], *msg;   // + 50 to make room for color codes
   bool emoting = FALSE;
 
   /* Array of flags which must _not_ be set in order for comm to be heard. */

--- a/src/boards.c
+++ b/src/boards.c
@@ -172,7 +172,7 @@ SPECIAL(gen_board)
 int board_write_message(int board_type, struct char_data *ch, char *arg, struct obj_data *board)
 {
   time_t ct;
-  char buf[MAX_INPUT_LENGTH], buf2[MAX_NAME_LENGTH + 3], tmstr[MAX_STRING_LENGTH];
+  char buf[MAX_INPUT_LENGTH], buf2[MAX_NAME_LENGTH + 3], tmstr[100];
 
   if (GET_LEVEL(ch) < WRITE_LVL(board_type)) {
     send_to_char(ch, "You are not holy enough to write on this board.\r\n");

--- a/src/db.c
+++ b/src/db.c
@@ -936,7 +936,7 @@ void index_boot(int mode)
   const char *index_filename, *prefix = NULL;	/* NULL or egcs 1.1 complains */
   FILE *db_index, *db_file;
   int line_number, rec_count = 0, size[2];
-  char buf2[PATH_MAX], buf1[MAX_STRING_LENGTH];
+  char buf2[PATH_MAX], buf1[PATH_MAX - 100];   // - 100 to make room for prefix
 
   switch (mode) {
   case DB_BOOT_WLD:
@@ -3900,7 +3900,7 @@ static void load_default_config( void )
 void load_config( void )
 {
   FILE *fl;
-  char line[MAX_STRING_LENGTH];
+  char line[READ_SIZE - 2]; // to make sure there's room for readding \r\n
   char tag[MAX_INPUT_LENGTH];
   int  num;
   char buf[MAX_INPUT_LENGTH];

--- a/src/dg_scripts.c
+++ b/src/dg_scripts.c
@@ -1968,7 +1968,7 @@ static void makeuid_var(void *go, struct script_data *sc, trig_data *trig,
 {
   char junk[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
   char arg[MAX_INPUT_LENGTH], name[MAX_INPUT_LENGTH];
-  char uid[MAX_INPUT_LENGTH];
+  char uid[MAX_INPUT_LENGTH + 1]; // to make room for UID_CHAR
 
   *uid = '\0';
   half_chop(cmd, junk, cmd);    /* makeuid */

--- a/src/dg_variables.c
+++ b/src/dg_variables.c
@@ -1628,7 +1628,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
 void var_subst(void *go, struct script_data *sc, trig_data *trig,
                int type, char *line, char *buf)
 {
-  char tmp[MAX_INPUT_LENGTH], repl_str[MAX_INPUT_LENGTH - 1];
+  char tmp[MAX_INPUT_LENGTH], repl_str[MAX_INPUT_LENGTH - 20]; // - 20 to make room for "eval tmpvr "
   char *var = NULL, *field = NULL, *p = NULL;
   char tmp2[MAX_INPUT_LENGTH];
   char *subfield_p, subfield[MAX_INPUT_LENGTH];

--- a/src/objsave.c
+++ b/src/objsave.c
@@ -1177,7 +1177,7 @@ obj_save_data *objsave_parse_objects(FILE *fl)
 
 static int Crash_load_objs(struct char_data *ch) {
   FILE *fl;
-  char filename[MAX_STRING_LENGTH];
+  char filename[PATH_MAX];
   char line[READ_SIZE];
   char buf[MAX_STRING_LENGTH];
   char str[64];

--- a/src/shop.c
+++ b/src/shop.c
@@ -474,7 +474,7 @@ static int sell_price(struct obj_data *obj, int shop_nr, struct char_data *keepe
 
 static void shopping_buy(char *arg, struct char_data *ch, struct char_data *keeper, int shop_nr)
 {
-  char tempstr[MAX_INPUT_LENGTH], tempbuf[MAX_INPUT_LENGTH];
+  char tempstr[MAX_INPUT_LENGTH - 10], tempbuf[MAX_INPUT_LENGTH];
   struct obj_data *obj, *last_obj = NULL;
   int goldamt = 0, buynum, bought = 0;
 
@@ -739,7 +739,7 @@ static void sort_keeper_objs(struct char_data *keeper, int shop_nr)
 
 static void shopping_sell(char *arg, struct char_data *ch, struct char_data *keeper, int shop_nr)
 {
-  char tempstr[MAX_INPUT_LENGTH], name[MAX_INPUT_LENGTH], tempbuf[MAX_INPUT_LENGTH];
+  char tempstr[MAX_INPUT_LENGTH - 10], name[MAX_INPUT_LENGTH], tempbuf[MAX_INPUT_LENGTH]; // - 10 to make room for constants in format
   struct obj_data *obj;
   int sellnum, sold = 0, goldamt = 0;
 


### PR DESCRIPTION
Fixes format truncation warnings from gcc-8, ref https://www.tbamud.com/forum/4-development/4517-new-gcc-7-warnings. 

Some time in the past, the export command seem to have been changed in a way so it didn't actually tar and zip the exported zone. It was also a hotspot with warnings about this truncation, so it's been recreated to support it.