### PR TITLE
Make sure all followers are free'd before freeing the character list

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -501,15 +501,22 @@ static void free_extra_descriptions(struct extra_descr_data *edesc)
 void destroy_db(void)
 {
   ssize_t cnt, itr;
-  struct char_data *chtmp;
+  struct char_data *chtmp, *i = character_list;
   struct obj_data *objtmp;
 
   /* Active Mobiles & Players */
+  while (i) {
+    chtmp = i;
+    i = i->next;
+
+    if (chtmp->master)
+      stop_follower(chtmp);
+  }
+
   while (character_list) {
     chtmp = character_list;
     character_list = character_list->next;
-    if (chtmp->master)
-      stop_follower(chtmp);
+
     free_char(chtmp);
   }
 


### PR DESCRIPTION
Otherwise, the followers structs will point to free'd memory and
the stop_follower call will attempt to dereference a free'd
characters' followers list.