### PR TITLE
Gcc 9.2.1 warnings

### DIFF
--- a/src/act.item.c
+++ b/src/act.item.c
@@ -770,7 +770,7 @@ void name_from_drinkcon(struct obj_data *obj)
 {
   char *new_name, *cur_name, *next;
   const char *liqname;
-  int liqlen, cpylen;
+  int liqlen, cpylen, maxlen;
 
   if (!obj || (GET_OBJ_TYPE(obj) != ITEM_DRINKCON && GET_OBJ_TYPE(obj) != ITEM_FOUNTAIN))
     return;
@@ -785,7 +785,8 @@ void name_from_drinkcon(struct obj_data *obj)
   }
 
   liqlen = strlen(liqname);
-  CREATE(new_name, char, strlen(obj->name) - strlen(liqname)); /* +1 for NUL, -1 for space */
+  maxlen = strlen(obj->name) - strlen(liqname); /* +1 for NUL, -1 for space */
+  CREATE(new_name, char, maxlen);
 
   for (cur_name = obj->name; cur_name; cur_name = next) {
     if (*cur_name == ' ')
@@ -799,9 +800,13 @@ void name_from_drinkcon(struct obj_data *obj)
     if (!strn_cmp(cur_name, liqname, liqlen))
       continue;
 
-    if (*new_name)
+    if (*new_name) {
       strcat(new_name, " "); /* strcat: OK (size precalculated) */
-    strncat(new_name, cur_name, cpylen); /* strncat: OK (size precalculated) */
+      maxlen--;
+    }
+
+    strncat(new_name, cur_name, maxlen); /* strncat: OK (size precalculated) */
+    maxlen -= cpylen;
   }
 
   if (GET_OBJ_RNUM(obj) == NOTHING || obj->name != obj_proto[GET_OBJ_RNUM(obj)].name)

--- a/src/db.c
+++ b/src/db.c
@@ -501,15 +501,22 @@ static void free_extra_descriptions(struct extra_descr_data *edesc)
 void destroy_db(void)
 {
   ssize_t cnt, itr;
-  struct char_data *chtmp;
+  struct char_data *chtmp, *i = character_list;
   struct obj_data *objtmp;
 
   /* Active Mobiles & Players */
+  while (i) {
+    chtmp = i;
+    i = i->next;
+
+    if (chtmp->master)
+      stop_follower(chtmp);
+  }
+
   while (character_list) {
     chtmp = character_list;
     character_list = character_list->next;
-    if (chtmp->master)
-      stop_follower(chtmp);
+
     free_char(chtmp);
   }
 

--- a/src/spell_parser.c
+++ b/src/spell_parser.c
@@ -1,12 +1,12 @@
 /**************************************************************************
-*  File: spell_parser.c                                    Part of tbaMUD *
-*  Usage: Top-level magic routines; outside points of entry to magic sys. *
-*                                                                         *
-*  All rights reserved.  See license for complete information.            *
-*                                                                         *
-*  Copyright (C) 1993, 94 by the Trustees of the Johns Hopkins University *
-*  CircleMUD is based on DikuMUD, Copyright (C) 1990, 1991.               *
-**************************************************************************/
+ *  File: spell_parser.c                                    Part of tbaMUD *
+ *  Usage: Top-level magic routines; outside points of entry to magic sys. *
+ *                                                                         *
+ *  All rights reserved.  See license for complete information.            *
+ *                                                                         *
+ *  Copyright (C) 1993, 94 by the Trustees of the Johns Hopkins University *
+ *  CircleMUD is based on DikuMUD, Copyright (C) 1990, 1991.               *
+ **************************************************************************/
 
 #include "conf.h"
 #include "sysdep.h"
@@ -28,8 +28,11 @@ char cast_arg2[MAX_INPUT_LENGTH];
 const char *unused_spellname = "!UNUSED!"; /* So we can get &unused_spellname */
 
 /* Local (File Scope) Function Prototypes */
-static void say_spell(struct char_data *ch, int spellnum, struct char_data *tch, struct obj_data *tobj);
-static void spello(int spl, const char *name, int max_mana, int min_mana, int mana_change, int minpos, int targets, int violent, int routines, const char *wearoff);
+static void say_spell(struct char_data *ch, int spellnum, struct char_data *tch,
+    struct obj_data *tobj);
+static void spello(int spl, const char *name, int max_mana, int min_mana,
+    int mana_change, int minpos, int targets, int violent, int routines,
+    const char *wearoff);
 static int mag_manacost(struct char_data *ch, int spellnum);
 
 /* Local (File Scope) Variables */
@@ -37,54 +40,30 @@ struct syllable {
   const char *org;
   const char *news;
 };
-static struct syllable syls[] = {
-  {" ", " "},
-  {"ar", "abra"},
-  {"ate", "i"},
-  {"cau", "kada"},
-  {"blind", "nose"},
-  {"bur", "mosa"},
-  {"cu", "judi"},
-  {"de", "oculo"},
-  {"dis", "mar"},
-  {"ect", "kamina"},
-  {"en", "uns"},
-  {"gro", "cra"},
-  {"light", "dies"},
-  {"lo", "hi"},
-  {"magi", "kari"},
-  {"mon", "bar"},
-  {"mor", "zak"},
-  {"move", "sido"},
-  {"ness", "lacri"},
-  {"ning", "illa"},
-  {"per", "duda"},
-  {"ra", "gru"},
-  {"re", "candus"},
-  {"son", "sabru"},
-  {"tect", "infra"},
-  {"tri", "cula"},
-  {"ven", "nofo"},
-  {"word of", "inset"},
-  {"a", "i"}, {"b", "v"}, {"c", "q"}, {"d", "m"}, {"e", "o"}, {"f", "y"}, {"g", "t"},
-  {"h", "p"}, {"i", "u"}, {"j", "y"}, {"k", "t"}, {"l", "r"}, {"m", "w"}, {"n", "b"},
-  {"o", "a"}, {"p", "s"}, {"q", "d"}, {"r", "f"}, {"s", "g"}, {"t", "h"}, {"u", "e"},
-  {"v", "z"}, {"w", "x"}, {"x", "n"}, {"y", "l"}, {"z", "k"}, {"", ""}
-};
+static struct syllable syls[] = { { " ", " " }, { "ar", "abra" },
+    { "ate", "i" }, { "cau", "kada" }, { "blind", "nose" }, { "bur", "mosa" }, {
+        "cu", "judi" }, { "de", "oculo" }, { "dis", "mar" },
+    { "ect", "kamina" }, { "en", "uns" }, { "gro", "cra" }, { "light", "dies" },
+    { "lo", "hi" }, { "magi", "kari" }, { "mon", "bar" }, { "mor", "zak" }, {
+        "move", "sido" }, { "ness", "lacri" }, { "ning", "illa" }, { "per",
+        "duda" }, { "ra", "gru" }, { "re", "candus" }, { "son", "sabru" }, {
+        "tect", "infra" }, { "tri", "cula" }, { "ven", "nofo" }, { "word of",
+        "inset" }, { "a", "i" }, { "b", "v" }, { "c", "q" }, { "d", "m" }, {
+        "e", "o" }, { "f", "y" }, { "g", "t" }, { "h", "p" }, { "i", "u" }, {
+        "j", "y" }, { "k", "t" }, { "l", "r" }, { "m", "w" }, { "n", "b" }, {
+        "o", "a" }, { "p", "s" }, { "q", "d" }, { "r", "f" }, { "s", "g" }, {
+        "t", "h" }, { "u", "e" }, { "v", "z" }, { "w", "x" }, { "x", "n" }, {
+        "y", "l" }, { "z", "k" }, { "", "" } };
 
-
-
-static int mag_manacost(struct char_data *ch, int spellnum)
-{
+static int mag_manacost(struct char_data *ch, int spellnum) {
   return MAX(SINFO.mana_max - (SINFO.mana_change *
-		    (GET_LEVEL(ch) - SINFO.min_level[(int) GET_CLASS(ch)])),
-	     SINFO.mana_min);
+      (GET_LEVEL(ch) - SINFO.min_level[(int) GET_CLASS(ch)])),
+  SINFO.mana_min);
 }
 
 static void say_spell(struct char_data *ch, int spellnum, struct char_data *tch,
-	            struct obj_data *tobj)
-{
-  char lbuf[256], buf[256], buf1[256], buf2[256];	/* FIXME */
+    struct obj_data *tobj) {
+  char lbuf[256], buf[256], buf1[256], buf2[256]; /* FIXME */
   const char *format;
 
   struct char_data *i;
@@ -96,8 +75,8 @@ static void say_spell(struct char_data *ch, int spellnum, struct char_data *tch,
   while (lbuf[ofs]) {
     for (j = 0; *(syls[j].org); j++) {
       if (!strncmp(syls[j].org, lbuf + ofs, strlen(syls[j].org))) {
-	strcat(buf, syls[j].news);	/* strcat: BAD */
-	ofs += strlen(syls[j].org);
+        strcat(buf, syls[j].news); /* strcat: BAD */
+        ofs += strlen(syls[j].org);
         break;
       }
     }
@@ -113,8 +92,8 @@ static void say_spell(struct char_data *ch, int spellnum, struct char_data *tch,
       format = "$n closes $s eyes and utters the words, '%s'.";
     else
       format = "$n stares at $N and utters the words, '%s'.";
-  } else if (tobj != NULL &&
-	     ((IN_ROOM(tobj) == IN_ROOM(ch)) || (tobj->carried_by == ch)))
+  } else if (tobj != NULL
+      && ((IN_ROOM(tobj) == IN_ROOM(ch)) || (tobj->carried_by == ch)))
     format = "$n stares at $p and utters the words, '%s'.";
   else
     format = "$n utters the words, '%s'.";
@@ -133,7 +112,7 @@ static void say_spell(struct char_data *ch, int spellnum, struct char_data *tch,
 
   if (tch != NULL && tch != ch && IN_ROOM(tch) == IN_ROOM(ch)) {
     snprintf(buf1, sizeof(buf1), "$n stares at you and utters the words, '%s'.",
-	    GET_CLASS(ch) == GET_CLASS(tch) ? skill_name(spellnum) : buf);
+    GET_CLASS(ch) == GET_CLASS(tch) ? skill_name(spellnum) : buf);
     act(buf1, FALSE, ch, NULL, tch, TO_VICT);
   }
 }
@@ -141,8 +120,7 @@ static void say_spell(struct char_data *ch, int spellnum, struct char_data *tch,
 /* This function should be used anytime you are not 100% sure that you have
  * a valid spell/skill number.  A typical for() loop would not need to use
  * this because you can guarantee > 0 and <= TOP_SPELL_DEFINE. */
-const char *skill_name(int num)
-{
+const char *skill_name(int num) {
   if (num > 0 && num <= TOP_SPELL_DEFINE)
     return (spell_info[num].name);
   else if (num == -1)
@@ -151,8 +129,7 @@ const char *skill_name(int num)
     return ("UNDEFINED");
 }
 
-int find_skill_num(char *name)
-{
+int find_skill_num(char *name) {
   int skindex, ok;
   char *temp, *temp2;
   char first[256], first2[256], tempbuf[256];
@@ -162,12 +139,12 @@ int find_skill_num(char *name)
       return (skindex);
 
     ok = TRUE;
-    strlcpy(tempbuf, spell_info[skindex].name, sizeof(tempbuf));	/* strlcpy: OK */
+    strlcpy(tempbuf, spell_info[skindex].name, sizeof(tempbuf)); /* strlcpy: OK */
     temp = any_one_arg(tempbuf, first);
     temp2 = any_one_arg(name, first2);
     while (*first && *first2 && ok) {
       if (!is_abbrev(first2, first))
-	ok = FALSE;
+        ok = FALSE;
       temp = any_one_arg(temp, first);
       temp2 = any_one_arg(temp2, first2);
     }
@@ -185,8 +162,7 @@ int find_skill_num(char *name)
  * point for non-spoken or unrestricted spells. Spellnum 0 is legal but silently
  * ignored here, to make callers simpler. */
 int call_magic(struct char_data *caster, struct char_data *cvict,
-	     struct obj_data *ovict, int spellnum, int level, int casttype)
-{
+    struct obj_data *ovict, int spellnum, int level, int casttype) {
   int savetype;
 
   if (spellnum < 1 || spellnum > TOP_SPELL_DEFINE)
@@ -204,8 +180,7 @@ int call_magic(struct char_data *caster, struct char_data *cvict,
     act("$n's magic fizzles out and dies.", FALSE, caster, 0, 0, TO_ROOM);
     return (0);
   }
-  if (ROOM_FLAGGED(IN_ROOM(caster), ROOM_PEACEFUL) &&
-      (SINFO.violent || IS_SET(SINFO.routines, MAG_DAMAGE))) {
+  if (ROOM_FLAGGED(IN_ROOM(caster), ROOM_PEACEFUL) && (SINFO.violent || IS_SET(SINFO.routines, MAG_DAMAGE))) {
     send_to_char(caster, "A flash of white light fills the room, dispelling your violent magic!\r\n");
     act("White light from no particular source suddenly fills the room, then vanishes.", FALSE, caster, 0, 0, TO_ROOM);
     return (0);
@@ -232,7 +207,7 @@ int call_magic(struct char_data *caster, struct char_data *cvict,
 
   if (IS_SET(SINFO.routines, MAG_DAMAGE))
     if (mag_damage(level, caster, cvict, spellnum, savetype) == -1)
-      return (-1);	/* Successful and target died, don't cast again. */
+      return (-1); /* Successful and target died, don't cast again. */
 
   if (IS_SET(SINFO.routines, MAG_AFFECTS))
     mag_affects(level, caster, cvict, spellnum, savetype);
@@ -266,15 +241,42 @@ int call_magic(struct char_data *caster, struct char_data *cvict,
 
   if (IS_SET(SINFO.routines, MAG_MANUAL))
     switch (spellnum) {
-    case SPELL_CHARM:		MANUAL_SPELL(spell_charm); break;
-    case SPELL_CREATE_WATER:	MANUAL_SPELL(spell_create_water); break;
-    case SPELL_DETECT_POISON:	MANUAL_SPELL(spell_detect_poison); break;
-    case SPELL_ENCHANT_WEAPON:  MANUAL_SPELL(spell_enchant_weapon); break;
-    case SPELL_IDENTIFY:	MANUAL_SPELL(spell_identify); break;
-    case SPELL_LOCATE_OBJECT:   MANUAL_SPELL(spell_locate_object); break;
-    case SPELL_SUMMON:		MANUAL_SPELL(spell_summon); break;
-    case SPELL_WORD_OF_RECALL:  MANUAL_SPELL(spell_recall); break;
-    case SPELL_TELEPORT:	MANUAL_SPELL(spell_teleport); break;
+    case SPELL_CHARM:
+      MANUAL_SPELL(spell_charm)
+      ;
+      break;
+    case SPELL_CREATE_WATER:
+      MANUAL_SPELL(spell_create_water)
+      ;
+      break;
+    case SPELL_DETECT_POISON:
+      MANUAL_SPELL(spell_detect_poison)
+      ;
+      break;
+    case SPELL_ENCHANT_WEAPON:
+      MANUAL_SPELL(spell_enchant_weapon)
+      ;
+      break;
+    case SPELL_IDENTIFY:
+      MANUAL_SPELL(spell_identify)
+      ;
+      break;
+    case SPELL_LOCATE_OBJECT:
+      MANUAL_SPELL(spell_locate_object)
+      ;
+      break;
+    case SPELL_SUMMON:
+      MANUAL_SPELL(spell_summon)
+      ;
+      break;
+    case SPELL_WORD_OF_RECALL:
+      MANUAL_SPELL(spell_recall)
+      ;
+      break;
+    case SPELL_TELEPORT:
+      MANUAL_SPELL(spell_teleport)
+      ;
+      break;
     }
 
   return (1);
@@ -289,9 +291,7 @@ int call_magic(struct char_data *caster, struct char_data *cvict,
  * potion - [0] level	[1] spell num	[2] spell num	[3] spell num
  * Staves and wands will default to level 14 if the level is not specified; the
  * DikuMUD format did not specify staff and wand levels in the world files */
-void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
-		          char *argument)
-{
+void mag_objectmagic(struct char_data *ch, struct obj_data *obj, char *argument) {
   char arg[MAX_INPUT_LENGTH];
   int i, k;
   struct char_data *tch = NULL, *next_tch;
@@ -300,7 +300,7 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
   one_argument(argument, arg);
 
   k = generic_find(arg, FIND_CHAR_ROOM | FIND_OBJ_INV | FIND_OBJ_ROOM |
-		   FIND_OBJ_EQUIP, ch, &tch, &tobj);
+  FIND_OBJ_EQUIP, ch, &tch, &tobj);
 
   switch (GET_OBJ_TYPE(obj)) {
   case ITEM_STAFF:
@@ -322,38 +322,40 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
       /* Area/mass spells on staves can cause crashes. So we use special cases
        * for those spells spells here. */
       if (HAS_SPELL_ROUTINE(GET_OBJ_VAL(obj, 3), MAG_MASSES | MAG_AREAS)) {
-        for (i = 0, tch = world[IN_ROOM(ch)].people; tch; tch = tch->next_in_room)
-	  i++;
-	while (i-- > 0)
-	  call_magic(ch, NULL, NULL, GET_OBJ_VAL(obj, 3), k, CAST_STAFF);
+        for (i = 0, tch = world[IN_ROOM(ch)].people; tch;
+            tch = tch->next_in_room)
+          i++;
+        while (i-- > 0)
+          call_magic(ch, NULL, NULL, GET_OBJ_VAL(obj, 3), k, CAST_STAFF);
       } else {
-	for (tch = world[IN_ROOM(ch)].people; tch; tch = next_tch) {
-	  next_tch = tch->next_in_room;
-	  if (ch != tch)
-	    call_magic(ch, tch, NULL, GET_OBJ_VAL(obj, 3), k, CAST_STAFF);
-	}
+        for (tch = world[IN_ROOM(ch)].people; tch; tch = next_tch) {
+          next_tch = tch->next_in_room;
+          if (ch != tch)
+            call_magic(ch, tch, NULL, GET_OBJ_VAL(obj, 3), k, CAST_STAFF);
+        }
       }
     }
     break;
   case ITEM_WAND:
     if (k == FIND_CHAR_ROOM) {
       if (tch == ch) {
-	act("You point $p at yourself.", FALSE, ch, obj, 0, TO_CHAR);
-	act("$n points $p at $mself.", FALSE, ch, obj, 0, TO_ROOM);
+        act("You point $p at yourself.", FALSE, ch, obj, 0, TO_CHAR);
+        act("$n points $p at $mself.", FALSE, ch, obj, 0, TO_ROOM);
       } else {
-	act("You point $p at $N.", FALSE, ch, obj, tch, TO_CHAR);
-	if (obj->action_description)
-	  act(obj->action_description, FALSE, ch, obj, tch, TO_ROOM);
-	else
-	  act("$n points $p at $N.", TRUE, ch, obj, tch, TO_ROOM);
+        act("You point $p at $N.", FALSE, ch, obj, tch, TO_CHAR);
+        if (obj->action_description)
+          act(obj->action_description, FALSE, ch, obj, tch, TO_ROOM);
+        else
+          act("$n points $p at $N.", TRUE, ch, obj, tch, TO_ROOM);
       }
     } else if (tobj != NULL) {
       act("You point $p at $P.", FALSE, ch, obj, tobj, TO_CHAR);
       if (obj->action_description)
-	act(obj->action_description, FALSE, ch, obj, tobj, TO_ROOM);
+        act(obj->action_description, FALSE, ch, obj, tobj, TO_ROOM);
       else
-	act("$n points $p at $P.", TRUE, ch, obj, tobj, TO_ROOM);
-    } else if (IS_SET(spell_info[GET_OBJ_VAL(obj, 3)].routines, MAG_AREAS | MAG_MASSES)) {
+        act("$n points $p at $P.", TRUE, ch, obj, tobj, TO_ROOM);
+    } else if (IS_SET(spell_info[GET_OBJ_VAL(obj, 3)].routines,
+        MAG_AREAS | MAG_MASSES)) {
       /* Wands with area spells don't need to be pointed. */
       act("You point $p outward.", FALSE, ch, obj, NULL, TO_CHAR);
       act("$n points $p outward.", TRUE, ch, obj, NULL, TO_ROOM);
@@ -370,18 +372,18 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
     GET_OBJ_VAL(obj, 2)--;
     WAIT_STATE(ch, PULSE_VIOLENCE);
     if (GET_OBJ_VAL(obj, 0))
-      call_magic(ch, tch, tobj, GET_OBJ_VAL(obj, 3),
-		 GET_OBJ_VAL(obj, 0), CAST_WAND);
+      call_magic(ch, tch, tobj, GET_OBJ_VAL(obj, 3), GET_OBJ_VAL(obj, 0),
+          CAST_WAND);
     else
       call_magic(ch, tch, tobj, GET_OBJ_VAL(obj, 3),
-		 DEFAULT_WAND_LVL, CAST_WAND);
+      DEFAULT_WAND_LVL, CAST_WAND);
     break;
   case ITEM_SCROLL:
     if (*arg) {
       if (!k) {
-	act("There is nothing to here to affect with $p.", FALSE,
-	    ch, obj, NULL, TO_CHAR);
-	return;
+        act("There is nothing to here to affect with $p.", FALSE, ch, obj, NULL,
+            TO_CHAR);
+        return;
       }
     } else
       tch = ch;
@@ -394,9 +396,9 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
 
     WAIT_STATE(ch, PULSE_VIOLENCE);
     for (i = 1; i <= 3; i++)
-      if (call_magic(ch, tch, tobj, GET_OBJ_VAL(obj, i),
-		       GET_OBJ_VAL(obj, 0), CAST_SCROLL) <= 0)
-	break;
+      if (call_magic(ch, tch, tobj, GET_OBJ_VAL(obj, i), GET_OBJ_VAL(obj, 0),
+          CAST_SCROLL) <= 0)
+        break;
 
     if (obj != NULL)
       extract_obj(obj);
@@ -404,7 +406,7 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
   case ITEM_POTION:
     tch = ch;
 
-    if (!consume_otrigger(obj, ch, OCMD_QUAFF))  /* check trigger */
+    if (!consume_otrigger(obj, ch, OCMD_QUAFF)) /* check trigger */
       return;
 
     act("You quaff $p.", FALSE, ch, obj, NULL, TO_CHAR);
@@ -415,16 +417,16 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
 
     WAIT_STATE(ch, PULSE_VIOLENCE);
     for (i = 1; i <= 3; i++)
-      if (call_magic(ch, ch, NULL, GET_OBJ_VAL(obj, i),
-		       GET_OBJ_VAL(obj, 0), CAST_POTION) <= 0)
-	break;
+      if (call_magic(ch, ch, NULL, GET_OBJ_VAL(obj, i), GET_OBJ_VAL(obj, 0),
+          CAST_POTION) <= 0)
+        break;
 
     if (obj != NULL)
       extract_obj(obj);
     break;
   default:
     log("SYSERR: Unknown object_type %d in mag_objectmagic.",
-	GET_OBJ_TYPE(obj));
+        GET_OBJ_TYPE(obj));
     break;
   }
 }
@@ -434,31 +436,30 @@ void mag_objectmagic(struct char_data *ch, struct obj_data *obj,
  * prints the words, etc. Entry point for NPC casts.  Recommended entry point
  * for spells cast by NPCs via specprocs. */
 int cast_spell(struct char_data *ch, struct char_data *tch,
-	           struct obj_data *tobj, int spellnum)
-{
+    struct obj_data *tobj, int spellnum) {
   if (spellnum < 0 || spellnum > TOP_SPELL_DEFINE) {
     log("SYSERR: cast_spell trying to call spellnum %d/%d.", spellnum,
-	TOP_SPELL_DEFINE);
+    TOP_SPELL_DEFINE);
     return (0);
   }
 
   if (GET_POS(ch) < SINFO.min_position) {
     switch (GET_POS(ch)) {
       case POS_SLEEPING:
-      send_to_char(ch, "You dream about great magical powers.\r\n");
-      break;
-    case POS_RESTING:
-      send_to_char(ch, "You cannot concentrate while resting.\r\n");
-      break;
-    case POS_SITTING:
-      send_to_char(ch, "You can't do this sitting!\r\n");
-      break;
-    case POS_FIGHTING:
-      send_to_char(ch, "Impossible!  You can't concentrate enough!\r\n");
-      break;
-    default:
-      send_to_char(ch, "You can't do much of anything like this!\r\n");
-      break;
+        send_to_char(ch, "You dream about great magical powers.\r\n");
+        break;
+      case POS_RESTING:
+        send_to_char(ch, "You cannot concentrate while resting.\r\n");
+        break;
+      case POS_SITTING:
+        send_to_char(ch, "You can't do this sitting!\r\n");
+        break;
+      case POS_FIGHTING:
+        send_to_char(ch, "Impossible!  You can't concentrate enough!\r\n");
+        break;
+      default:
+        send_to_char(ch, "You can't do much of anything like this!\r\n");
+        break;
     }
     return (0);
   }
@@ -488,8 +489,7 @@ int cast_spell(struct char_data *ch, struct char_data *tch,
  * determines the spell number and finds a target, throws the die to see if
  * the spell can be cast, checks for sufficient mana and subtracts it, and
  * passes control to cast_spell(). */
-ACMD(do_cast)
-{
+ACMD(do_cast) {
   struct char_data *tch = NULL;
   struct obj_data *tobj = NULL;
   char *s, *t;
@@ -507,7 +507,8 @@ ACMD(do_cast)
   }
   s = strtok(NULL, "'");
   if (s == NULL) {
-    send_to_char(ch, "Spell names must be enclosed in the Holy Magic Symbols: '\r\n");
+    send_to_char(ch,
+        "Spell names must be enclosed in the Holy Magic Symbols: '\r\n");
     return;
   }
   t = strtok(NULL, "\0");
@@ -546,51 +547,52 @@ ACMD(do_cast)
     number = get_number(&t);
     if (!target && (IS_SET(SINFO.targets, TAR_CHAR_ROOM))) {
       if ((tch = get_char_vis(ch, t, &number, FIND_CHAR_ROOM)) != NULL)
-	target = TRUE;
+        target = TRUE;
     }
     if (!target && IS_SET(SINFO.targets, TAR_CHAR_WORLD))
       if ((tch = get_char_vis(ch, t, &number, FIND_CHAR_WORLD)) != NULL)
-	target = TRUE;
+        target = TRUE;
 
     if (!target && IS_SET(SINFO.targets, TAR_OBJ_INV))
       if ((tobj = get_obj_in_list_vis(ch, t, &number, ch->carrying)) != NULL)
-	target = TRUE;
+        target = TRUE;
 
     if (!target && IS_SET(SINFO.targets, TAR_OBJ_EQUIP)) {
       for (i = 0; !target && i < NUM_WEARS; i++)
-	if (GET_EQ(ch, i) && isname(t, GET_EQ(ch, i)->name)) {
-	  tobj = GET_EQ(ch, i);
-	  target = TRUE;
-	}
+        if (GET_EQ(ch, i) && isname(t, GET_EQ(ch, i)->name)) {
+          tobj = GET_EQ(ch, i);
+          target = TRUE;
+        }
     }
     if (!target && IS_SET(SINFO.targets, TAR_OBJ_ROOM))
-      if ((tobj = get_obj_in_list_vis(ch, t, &number, world[IN_ROOM(ch)].contents)) != NULL)
-	target = TRUE;
+      if ((tobj = get_obj_in_list_vis(ch, t, &number,
+          world[IN_ROOM(ch)].contents)) != NULL)
+        target = TRUE;
 
     if (!target && IS_SET(SINFO.targets, TAR_OBJ_WORLD))
       if ((tobj = get_obj_vis(ch, t, &number)) != NULL)
-	target = TRUE;
+        target = TRUE;
 
-  } else {			/* if target string is empty */
+  } else { /* if target string is empty */
     if (!target && IS_SET(SINFO.targets, TAR_FIGHT_SELF))
       if (FIGHTING(ch) != NULL) {
-	tch = ch;
-	target = TRUE;
+        tch = ch;
+        target = TRUE;
       }
     if (!target && IS_SET(SINFO.targets, TAR_FIGHT_VICT))
       if (FIGHTING(ch) != NULL) {
-	tch = FIGHTING(ch);
-	target = TRUE;
+        tch = FIGHTING(ch);
+        target = TRUE;
       }
     /* if no target specified, and the spell isn't violent, default to self */
-    if (!target && IS_SET(SINFO.targets, TAR_CHAR_ROOM) &&
-	!SINFO.violent) {
+    if (!target && IS_SET(SINFO.targets, TAR_CHAR_ROOM) && !SINFO.violent) {
       tch = ch;
       target = TRUE;
     }
     if (!target) {
       send_to_char(ch, "Upon %s should the spell be cast?\r\n",
-		IS_SET(SINFO.targets, TAR_OBJ_ROOM | TAR_OBJ_INV | TAR_OBJ_WORLD | TAR_OBJ_EQUIP) ? "what" : "who");
+          IS_SET(SINFO.targets, TAR_OBJ_ROOM | TAR_OBJ_INV | TAR_OBJ_WORLD | TAR_OBJ_EQUIP) ?
+              "what" : "who");
       return;
     }
   }
@@ -617,34 +619,34 @@ ACMD(do_cast)
     if (mana > 0)
       GET_MANA(ch) = MAX(0, MIN(GET_MAX_MANA(ch), GET_MANA(ch) - (mana / 2)));
     if (SINFO.violent && tch && IS_NPC(tch))
-      hit(tch, ch, TYPE_UNDEFINED);
+    hit(tch, ch, TYPE_UNDEFINED);
   } else { /* cast spell returns 1 on success; subtract mana & set waitstate */
     if (cast_spell(ch, tch, tobj, spellnum)) {
       WAIT_STATE(ch, PULSE_VIOLENCE);
       if (mana > 0)
-	GET_MANA(ch) = MAX(0, MIN(GET_MAX_MANA(ch), GET_MANA(ch) - mana));
+        GET_MANA(ch) = MAX(0, MIN(GET_MAX_MANA(ch), GET_MANA(ch) - mana));
     }
   }
 }
 
-void spell_level(int spell, int chclass, int level)
-{
+void spell_level(int spell, int chclass, int level) {
   int bad = 0;
 
   if (spell < 0 || spell > TOP_SPELL_DEFINE) {
-    log("SYSERR: attempting assign to illegal spellnum %d/%d", spell, TOP_SPELL_DEFINE);
+    log("SYSERR: attempting assign to illegal spellnum %d/%d", spell,
+        TOP_SPELL_DEFINE);
     return;
   }
 
   if (chclass < 0 || chclass >= NUM_CLASSES) {
     log("SYSERR: assigning '%s' to illegal class %d/%d.", skill_name(spell),
-		chclass, NUM_CLASSES - 1);
+        chclass, NUM_CLASSES - 1);
     bad = 1;
   }
 
   if (level < 1 || level > LVL_IMPL) {
     log("SYSERR: assigning '%s' to illegal level %d/%d.", skill_name(spell),
-		level, LVL_IMPL);
+        level, LVL_IMPL);
     bad = 1;
   }
 
@@ -652,11 +654,10 @@ void spell_level(int spell, int chclass, int level)
     spell_info[spell].min_level[chclass] = level;
 }
 
-
 /* Assign the spells on boot up */
 static void spello(int spl, const char *name, int max_mana, int min_mana,
-	int mana_change, int minpos, int targets, int violent, int routines, const char *wearoff)
-{
+    int mana_change, int minpos, int targets, int violent, int routines,
+    const char *wearoff) {
   int i;
 
   for (i = 0; i < NUM_CLASSES; i++)
@@ -672,8 +673,7 @@ static void spello(int spl, const char *name, int max_mana, int min_mana,
   spell_info[spl].wear_off_msg = wearoff;
 }
 
-void unused_spell(int spl)
-{
+void unused_spell(int spl) {
   int i;
 
   for (i = 0; i < NUM_CLASSES; i++)
@@ -713,8 +713,7 @@ void unused_spell(int spl)
  * See the documentation for a more detailed description of these fields. You
  * only need a spello() call to define a new spell; to decide who gets to use
  * a spell or skill, look in class.c.  -JE */
-void mag_assign_spells(void)
-{
+void mag_assign_spells(void) {
   int i;
 
   /* Do not change the loop below. */
@@ -723,225 +722,183 @@ void mag_assign_spells(void)
   /* Do not change the loop above. */
 
   spello(SPELL_ANIMATE_DEAD, "animate dead", 35, 10, 3, POS_STANDING,
-	TAR_OBJ_ROOM, FALSE, MAG_SUMMONS,
-	NULL);
+  TAR_OBJ_ROOM, FALSE, MAG_SUMMONS, NULL);
 
   spello(SPELL_ARMOR, "armor", 30, 15, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM, FALSE, MAG_AFFECTS,
-	"You feel less protected.");
+  TAR_CHAR_ROOM, FALSE, MAG_AFFECTS, "You feel less protected.");
 
   spello(SPELL_BLESS, "bless", 35, 5, 3, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_OBJ_INV, FALSE, MAG_AFFECTS | MAG_ALTER_OBJS,
-	"You feel less righteous.");
+  TAR_CHAR_ROOM | TAR_OBJ_INV, FALSE, MAG_AFFECTS | MAG_ALTER_OBJS,
+      "You feel less righteous.");
 
   spello(SPELL_BLINDNESS, "blindness", 35, 25, 1, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_NOT_SELF, FALSE, MAG_AFFECTS,
-	"You feel a cloak of blindness dissolve.");
+  TAR_CHAR_ROOM | TAR_NOT_SELF, FALSE, MAG_AFFECTS,
+      "You feel a cloak of blindness dissolve.");
 
   spello(SPELL_BURNING_HANDS, "burning hands", 30, 10, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_CALL_LIGHTNING, "call lightning", 40, 25, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_CHARM, "charm person", 75, 50, 2, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_NOT_SELF, TRUE, MAG_MANUAL,
-	"You feel more self-confident.");
+  TAR_CHAR_ROOM | TAR_NOT_SELF, TRUE, MAG_MANUAL,
+      "You feel more self-confident.");
 
   spello(SPELL_CHILL_TOUCH, "chill touch", 30, 10, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE | MAG_AFFECTS,
-	"You feel your strength return.");
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE | MAG_AFFECTS,
+      "You feel your strength return.");
 
   spello(SPELL_CLONE, "clone", 80, 65, 5, POS_STANDING,
-	TAR_IGNORE, FALSE, MAG_SUMMONS,
-	NULL);
+  TAR_IGNORE, FALSE, MAG_SUMMONS, NULL);
 
   spello(SPELL_COLOR_SPRAY, "color spray", 30, 15, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_CONTROL_WEATHER, "control weather", 75, 25, 5, POS_STANDING,
-	TAR_IGNORE, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_IGNORE, FALSE, MAG_MANUAL, NULL);
 
   spello(SPELL_CREATE_FOOD, "create food", 30, 5, 4, POS_STANDING,
-	TAR_IGNORE, FALSE, MAG_CREATIONS,
-	NULL);
+  TAR_IGNORE, FALSE, MAG_CREATIONS, NULL);
 
   spello(SPELL_CREATE_WATER, "create water", 30, 5, 4, POS_STANDING,
-	TAR_OBJ_INV | TAR_OBJ_EQUIP, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_OBJ_INV | TAR_OBJ_EQUIP, FALSE, MAG_MANUAL, NULL);
 
   spello(SPELL_CURE_BLIND, "cure blind", 30, 5, 2, POS_STANDING,
-	TAR_CHAR_ROOM, FALSE, MAG_UNAFFECTS,
-	NULL);
+  TAR_CHAR_ROOM, FALSE, MAG_UNAFFECTS, NULL);
 
   spello(SPELL_CURE_CRITIC, "cure critic", 30, 10, 2, POS_FIGHTING,
-	TAR_CHAR_ROOM, FALSE, MAG_POINTS,
-	NULL);
+  TAR_CHAR_ROOM, FALSE, MAG_POINTS, NULL);
 
   spello(SPELL_CURE_LIGHT, "cure light", 30, 10, 2, POS_FIGHTING,
-	TAR_CHAR_ROOM, FALSE, MAG_POINTS,
-	NULL);
+  TAR_CHAR_ROOM, FALSE, MAG_POINTS, NULL);
 
   spello(SPELL_CURSE, "curse", 80, 50, 2, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_OBJ_INV, TRUE, MAG_AFFECTS | MAG_ALTER_OBJS,
-	"You feel more optimistic.");
+  TAR_CHAR_ROOM | TAR_OBJ_INV, TRUE, MAG_AFFECTS | MAG_ALTER_OBJS,
+      "You feel more optimistic.");
 
   spello(SPELL_DARKNESS, "darkness", 30, 5, 4, POS_STANDING,
-	TAR_IGNORE, FALSE, MAG_ROOMS,
-	NULL);
+  TAR_IGNORE, FALSE, MAG_ROOMS, NULL);
 
   spello(SPELL_DETECT_ALIGN, "detect alignment", 20, 10, 2, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
-	"You feel less aware.");
+  TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS, "You feel less aware.");
 
   spello(SPELL_DETECT_INVIS, "detect invisibility", 20, 10, 2, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
-	"Your eyes stop tingling.");
+  TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
+      "Your eyes stop tingling.");
 
   spello(SPELL_DETECT_MAGIC, "detect magic", 20, 10, 2, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
-	"The detect magic wears off.");
+  TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
+      "The detect magic wears off.");
 
   spello(SPELL_DETECT_POISON, "detect poison", 15, 5, 1, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_MANUAL,
-	"The detect poison wears off.");
+  TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_MANUAL,
+      "The detect poison wears off.");
 
   spello(SPELL_DISPEL_EVIL, "dispel evil", 40, 25, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_DISPEL_GOOD, "dispel good", 40, 25, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_EARTHQUAKE, "earthquake", 40, 25, 3, POS_FIGHTING,
-	TAR_IGNORE, TRUE, MAG_AREAS,
-	NULL);
+  TAR_IGNORE, TRUE, MAG_AREAS, NULL);
 
   spello(SPELL_ENCHANT_WEAPON, "enchant weapon", 150, 100, 10, POS_STANDING,
-	TAR_OBJ_INV, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_OBJ_INV, FALSE, MAG_MANUAL, NULL);
 
   spello(SPELL_ENERGY_DRAIN, "energy drain", 40, 25, 1, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE | MAG_MANUAL,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE | MAG_MANUAL, NULL);
 
   spello(SPELL_GROUP_ARMOR, "group armor", 50, 30, 2, POS_STANDING,
-	TAR_IGNORE, FALSE, MAG_GROUPS,
-	NULL);
+  TAR_IGNORE, FALSE, MAG_GROUPS, NULL);
 
   spello(SPELL_FIREBALL, "fireball", 40, 30, 2, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_FLY, "fly", 40, 20, 2, POS_FIGHTING,
-	TAR_CHAR_ROOM, FALSE, MAG_AFFECTS,
-	"You drift slowly to the ground.");
+  TAR_CHAR_ROOM, FALSE, MAG_AFFECTS, "You drift slowly to the ground.");
 
   spello(SPELL_GROUP_HEAL, "group heal", 80, 60, 5, POS_STANDING,
-	TAR_IGNORE, FALSE, MAG_GROUPS,
-	NULL);
+  TAR_IGNORE, FALSE, MAG_GROUPS, NULL);
 
   spello(SPELL_HARM, "harm", 75, 45, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_HEAL, "heal", 60, 40, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM, FALSE, MAG_POINTS | MAG_UNAFFECTS,
-	NULL);
+  TAR_CHAR_ROOM, FALSE, MAG_POINTS | MAG_UNAFFECTS, NULL);
 
   spello(SPELL_INFRAVISION, "infravision", 25, 10, 1, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
-	"Your night vision seems to fade.");
+  TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
+      "Your night vision seems to fade.");
 
   spello(SPELL_INVISIBLE, "invisibility", 35, 25, 1, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_AFFECTS | MAG_ALTER_OBJS,
-	"You feel yourself exposed.");
+  TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE,
+      MAG_AFFECTS | MAG_ALTER_OBJS, "You feel yourself exposed.");
 
   spello(SPELL_LIGHTNING_BOLT, "lightning bolt", 30, 15, 1, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_LOCATE_OBJECT, "locate object", 25, 20, 1, POS_STANDING,
-	TAR_OBJ_WORLD, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_OBJ_WORLD, FALSE, MAG_MANUAL, NULL);
 
   spello(SPELL_MAGIC_MISSILE, "magic missile", 25, 10, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_POISON, "poison", 50, 20, 3, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_NOT_SELF | TAR_OBJ_INV, TRUE,
-	MAG_AFFECTS | MAG_ALTER_OBJS,
-	"You feel less sick.");
+  TAR_CHAR_ROOM | TAR_NOT_SELF | TAR_OBJ_INV, TRUE,
+  MAG_AFFECTS | MAG_ALTER_OBJS, "You feel less sick.");
 
   spello(SPELL_PROT_FROM_EVIL, "protection from evil", 40, 10, 3, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
-	"You feel less protected.");
+  TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
+      "You feel less protected.");
 
   spello(SPELL_REMOVE_CURSE, "remove curse", 45, 25, 5, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_EQUIP, FALSE,
-	MAG_UNAFFECTS | MAG_ALTER_OBJS,
-	NULL);
+  TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_EQUIP, FALSE,
+  MAG_UNAFFECTS | MAG_ALTER_OBJS, NULL);
 
   spello(SPELL_REMOVE_POISON, "remove poison", 40, 8, 4, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_UNAFFECTS | MAG_ALTER_OBJS,
-	NULL);
+  TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE,
+      MAG_UNAFFECTS | MAG_ALTER_OBJS, NULL);
 
   spello(SPELL_SANCTUARY, "sanctuary", 110, 85, 5, POS_STANDING,
-	TAR_CHAR_ROOM, FALSE, MAG_AFFECTS,
-	"The white aura around your body fades.");
+  TAR_CHAR_ROOM, FALSE, MAG_AFFECTS, "The white aura around your body fades.");
 
   spello(SPELL_SENSE_LIFE, "sense life", 20, 10, 2, POS_STANDING,
-	TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
-	"You feel less aware of your surroundings.");
+  TAR_CHAR_ROOM | TAR_SELF_ONLY, FALSE, MAG_AFFECTS,
+      "You feel less aware of your surroundings.");
 
   spello(SPELL_SHOCKING_GRASP, "shocking grasp", 30, 15, 3, POS_FIGHTING,
-	TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE,
-	NULL);
+  TAR_CHAR_ROOM | TAR_FIGHT_VICT, TRUE, MAG_DAMAGE, NULL);
 
   spello(SPELL_SLEEP, "sleep", 40, 25, 5, POS_STANDING,
-	TAR_CHAR_ROOM, TRUE, MAG_AFFECTS,
-	"You feel less tired.");
+  TAR_CHAR_ROOM, TRUE, MAG_AFFECTS, "You feel less tired.");
 
   spello(SPELL_STRENGTH, "strength", 35, 30, 1, POS_STANDING,
-	TAR_CHAR_ROOM, FALSE, MAG_AFFECTS,
-	"You feel weaker.");
+  TAR_CHAR_ROOM, FALSE, MAG_AFFECTS, "You feel weaker.");
 
   spello(SPELL_SUMMON, "summon", 75, 50, 3, POS_STANDING,
-	TAR_CHAR_WORLD | TAR_NOT_SELF, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_CHAR_WORLD | TAR_NOT_SELF, FALSE, MAG_MANUAL, NULL);
 
   spello(SPELL_TELEPORT, "teleport", 75, 50, 3, POS_STANDING,
-	TAR_CHAR_ROOM, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_CHAR_ROOM, FALSE, MAG_MANUAL, NULL);
 
   spello(SPELL_WATERWALK, "waterwalk", 40, 20, 2, POS_STANDING,
-	TAR_CHAR_ROOM, FALSE, MAG_AFFECTS,
-	"Your feet seem less buoyant.");
+  TAR_CHAR_ROOM, FALSE, MAG_AFFECTS, "Your feet seem less buoyant.");
 
   spello(SPELL_WORD_OF_RECALL, "word of recall", 20, 10, 2, POS_FIGHTING,
-	TAR_CHAR_ROOM, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_CHAR_ROOM, FALSE, MAG_MANUAL, NULL);
 
   spello(SPELL_IDENTIFY, "identify", 50, 25, 5, POS_STANDING,
-        TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_MANUAL,
-        NULL);
-
+  TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_MANUAL, NULL);
 
   /* NON-castable spells should appear below here. */
   spello(SPELL_IDENTIFY, "identify", 0, 0, 0, 0,
-	TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_MANUAL,
-	NULL);
+  TAR_CHAR_ROOM | TAR_OBJ_INV | TAR_OBJ_ROOM, FALSE, MAG_MANUAL, NULL);
 
   /* you might want to name this one something more fitting to your theme -Welcor*/
   spello(SPELL_DG_AFFECT, "Script-inflicted", 0, 0, 0, POS_SITTING,
-	TAR_IGNORE, TRUE, 0,
-	NULL);
+  TAR_IGNORE, TRUE, 0, NULL);
 
   /* Declaration of skills - this actually doesn't do anything except set it up
    * so that immortals can use these skills by default.  The min level to use


### PR DESCRIPTION
When looking at this diff, I suggest ignoring whitespace. There were a lot of lines in spell_parser.c that needed indenting changes.
