### PR TITLE
Fix for pointer in fread() db.c to fix Raspberry Pi load issue

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2873,12 +2873,16 @@ char *fread_string(FILE *fl, const char *error)
     /* If there is a '~', end the string; else put an "\r\n" over the '\n'. */
     /* now only removes trailing ~'s -- Welcor */
     point = strchr(tmp, '\0');
-    for (point-- ; (*point=='\r' || *point=='\n'); point--);
+    for (point-- ; (*point=='\r' || *point=='\n') && point > tmp; point--);
     if (*point=='~') {
       *point='\0';
       done = 1;
     } else {
-      *(++point) = '\r';
+      if (*point == '\n' || *point == '\r')
+        *point = '\r';
+      else
+        *(++point) = '\r';
+
       *(++point) = '\n';
       *(++point) = '\0';
     }


### PR DESCRIPTION
This corrects an issue encountered when loading world information on the Raspberry Pi. Sometimes, there is a ~ stored in the memory location in front of tmp char array. The for loop will decrement below the starting memory address, making it read the ~ and think it's at the end of the room, causing an error and preventing the MUD from loading.

This change checks the memory address of 'point', ensuring it is > the starting memory address of 'tmp' before decrementing it in the for() loop. Then, the if/else checks to ensure the carriage return and newline are properly placed to prevent duplication.