### PR TITLE
Fix tba for OSX 11

### DIFF
--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -28,6 +28,7 @@
 #include "modify.h"
 #include "asciimap.h"
 #include "quest.h"
+#include <stdlib.h>
 
 /* prototypes of local functions */
 /* do_diagnose utility functions */

--- a/src/act.item.c
+++ b/src/act.item.c
@@ -22,6 +22,7 @@
 #include "oasis.h"
 #include "act.h"
 #include "quest.h"
+#include  <stdlib.h>
 
 
 /* local function prototypes */

--- a/src/act.social.c
+++ b/src/act.social.c
@@ -19,6 +19,8 @@
 #include "screen.h"
 #include "spells.h"
 #include "act.h"
+#include  <stdlib.h>
+
 
 /* local defined functions for local use */
 /* do_action and do_gmote utility function */

--- a/src/act.wizard.c
+++ b/src/act.wizard.c
@@ -34,6 +34,7 @@
 #include "quest.h"
 #include "ban.h"
 #include "screen.h"
+#include  <stdlib.h>
 
 /* local utility functions with file scope */
 static int perform_set(struct char_data *ch, struct char_data *vict, int mode, char *val_arg);

--- a/src/aedit.c
+++ b/src/aedit.c
@@ -18,6 +18,8 @@
 #include "constants.h"
 #include "genolc.h"
 #include "act.h"
+#include  <stdlib.h>
+
 
 
 /* local utility functions */

--- a/src/asciimap.c
+++ b/src/asciimap.c
@@ -23,6 +23,8 @@
 #include "dg_scripts.h"
 #include "asciimap.h"
 
+#include  <stdlib.h>
+
 /******************************************************************************
  * Begin Local (File Scope) Defines and Global Variables
  *****************************************************************************/

--- a/src/ban.c
+++ b/src/ban.c
@@ -17,6 +17,8 @@
 #include "handler.h"
 #include "db.h"
 #include "ban.h"
+#include  <stdlib.h>
+
 
 /* global variables locally defined, used externally */
 struct ban_list_element *ban_list = NULL;

--- a/src/boards.c
+++ b/src/boards.c
@@ -39,6 +39,8 @@
 #include "handler.h"
 #include "improved-edit.h"
 #include "modify.h"
+#include  <stdlib.h>
+
 
 /* Board appearance order. */
 #define	NEWEST_AT_TOP	FALSE

--- a/src/cedit.c
+++ b/src/cedit.c
@@ -17,6 +17,8 @@
 #include "oasis.h"
 #include "improved-edit.h"
 #include "modify.h"
+#include  <stdlib.h>
+
 
 /* local scope functions, not used externally */
 static void cedit_disp_menu(struct descriptor_data *d);

--- a/src/comm.c
+++ b/src/comm.c
@@ -10,6 +10,8 @@
 
 #include "conf.h"
 #include "sysdep.h"
+#include  <stdlib.h>
+
 
 /* Begin conf.h dependent includes */
 

--- a/src/db.c
+++ b/src/db.c
@@ -39,6 +39,8 @@
 #include "msgedit.h"
 #include "screen.h"
 #include <sys/stat.h>
+#include  <stdlib.h>
+
 
 /*  declarations of most of the 'global' variables */
 struct config_data config_info; /* Game configuration list.	 */

--- a/src/dg_db_scripts.c
+++ b/src/dg_db_scripts.c
@@ -23,6 +23,8 @@
 #include "comm.h"
 #include "constants.h"
 #include "interpreter.h" /* For half_chop */
+#include  <stdlib.h>
+
 
 /* local functions */
 static void trig_data_init(trig_data *this_data);

--- a/src/dg_event.c
+++ b/src/dg_event.c
@@ -25,6 +25,8 @@
 #include "constants.h"
 #include "comm.h"  /* For access to the game pulse */
 #include "mud_event.h"
+#include  <stdlib.h>
+
 
 /***************************************************************************
  * Begin mud specific event queue functions

--- a/src/dg_handler.c
+++ b/src/dg_handler.c
@@ -23,6 +23,8 @@
 #include "spells.h"
 #include "dg_event.h"
 #include "constants.h"
+#include  <stdlib.h>
+
 
 /* frees memory associated with var */
 void free_var_el(struct trig_var_data *var)

--- a/src/dg_mobcmd.c
+++ b/src/dg_mobcmd.c
@@ -22,6 +22,8 @@
 #include "genzon.h" /* for real_zone_by_thing */
 #include "act.h"
 #include "fight.h"
+#include  <stdlib.h>
+
 
 
 /* Local file scope functions. */

--- a/src/dg_objcmd.c
+++ b/src/dg_objcmd.c
@@ -20,6 +20,8 @@
 #include "constants.h"
 #include "genzon.h" /* for access to real_zone_by_thing */
 #include "fight.h" /* for die() */
+#include  <stdlib.h>
+
 
 
 

--- a/src/dg_olc.c
+++ b/src/dg_olc.c
@@ -21,6 +21,8 @@
 #include "genzon.h"      /* for real_zone_by_thing */
 #include "constants.h"   /* for the *trig_types */
 #include "modify.h"      /* for smash_tilde */
+#include  <stdlib.h>
+
 
 
 /* local functions */

--- a/src/dg_scripts.c
+++ b/src/dg_scripts.c
@@ -29,6 +29,8 @@
 #include "genzon.h" /* for real_zone_by_thing */
 #include "act.h"
 #include "modify.h"
+#include  <stdlib.h>
+
 
 #define PULSES_PER_MUD_HOUR     (SECS_PER_MUD_HOUR*PASSES_PER_SEC)
 

--- a/src/dg_variables.c
+++ b/src/dg_variables.c
@@ -26,6 +26,8 @@
 #include "quest.h"
 #include "act.h"
 #include "genobj.h"
+#include  <stdlib.h>
+
 
 /* Utility functions */
 

--- a/src/dg_wldcmd.c
+++ b/src/dg_wldcmd.c
@@ -20,6 +20,8 @@
 #include "constants.h"
 #include "genzon.h" /* for zone_rnum real_zone_by_thing */
 #include "fight.h"  /* for die() */
+#include  <stdlib.h>
+
 
 /* Local functions, macros, defines and structs */
 

--- a/src/genmob.c
+++ b/src/genmob.c
@@ -17,6 +17,8 @@
 #include "genzon.h"
 #include "dg_olc.h"
 #include "spells.h"
+#include  <stdlib.h>
+
 
 /* local functions */
 static void extract_mobile_all(mob_vnum vnum);

--- a/src/genobj.c
+++ b/src/genobj.c
@@ -19,6 +19,8 @@
 #include "handler.h"
 #include "interpreter.h"
 #include "boards.h" /* for board_info */
+#include  <stdlib.h>
+
 
 
 /* local functions */

--- a/src/genolc.c
+++ b/src/genolc.c
@@ -26,6 +26,8 @@
 #include "act.h"        /* for the space_to_minus function */
 #include "modify.h"      /* for smash_tilde */
 #include "quest.h"
+#include  <stdlib.h>
+
 
 /* Global variables defined here, used elsewhere */
 /* List of zones to be saved. */

--- a/src/genqst.c
+++ b/src/genqst.c
@@ -16,6 +16,8 @@
 #include "quest.h"
 #include "genolc.h"
 #include "genzon.h" /* for create_world_index */
+#include  <stdlib.h>
+
 
 
 /*-------------------------------------------------------------------*/

--- a/src/genshp.c
+++ b/src/genshp.c
@@ -14,6 +14,8 @@
 #include "genolc.h"
 #include "genshp.h"
 #include "genzon.h"
+#include  <stdlib.h>
+
 
 /* NOTE (gg): Didn't modify sedit much. Don't consider it as 'recent' as the
  * other editors with regard to updates or style. */

--- a/src/genwld.c
+++ b/src/genwld.c
@@ -18,6 +18,8 @@
 #include "shop.h"
 #include "dg_olc.h"
 #include "mud_event.h"
+#include  <stdlib.h>
+
 
 
 /* This function will copy the strings so be sure you free your own copies of 

--- a/src/genzon.c
+++ b/src/genzon.c
@@ -13,6 +13,7 @@
 #include "genolc.h"
 #include "genzon.h"
 #include "dg_scripts.h"
+#include  <stdlib.h>
 
 /* local functions */
 static void remove_cmd_from_list(struct reset_com **list, int pos);

--- a/src/graph.c
+++ b/src/graph.c
@@ -21,6 +21,7 @@
 #include "constants.h"
 #include "graph.h"
 #include "fight.h"
+#include  <stdlib.h>
 
 /* local functions */
 static int VALID_EDGE(room_rnum x, int y);

--- a/src/handler.c
+++ b/src/handler.c
@@ -24,6 +24,8 @@
 #include "fight.h"
 #include "quest.h"
 #include "mud_event.h"
+#include  <stdlib.h>
+
 
 /* local file scope variables */
 static int extractions_pending = 0;

--- a/src/hedit.c
+++ b/src/hedit.c
@@ -24,6 +24,7 @@
 #include "act.h"
 #include "hedit.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 /* local functions */
 static void hedit_disp_menu(struct descriptor_data *);

--- a/src/house.c
+++ b/src/house.c
@@ -19,6 +19,7 @@
 #include "house.h"
 #include "constants.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 /* local (file scope only) globals */
 static struct house_control_rec house_control[MAX_HOUSES];

--- a/src/ibt.c
+++ b/src/ibt.c
@@ -35,6 +35,7 @@
 #include "oasis.h"
 #include "improved-edit.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 IBT_DATA * first_bug  = NULL;
 IBT_DATA * last_bug   = NULL;

--- a/src/improved-edit.c
+++ b/src/improved-edit.c
@@ -13,6 +13,7 @@
 #include "improved-edit.h"
 #include "dg_scripts.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 
 void send_editor_help(struct descriptor_data *d)

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -37,6 +37,7 @@
 #include "prefedit.h"
 #include "ibt.h"
 #include "mud_event.h"
+#include  <stdlib.h>
 
 /* local (file scope) functions */
 static int perform_dupe_check(struct descriptor_data *d);

--- a/src/lists.c
+++ b/src/lists.c
@@ -11,6 +11,7 @@
 #include "utils.h"
 #include "db.h"
 #include "dg_event.h"
+#include  <stdlib.h>
 
 static struct iterator_data Iterator;
 static bool loop = FALSE;

--- a/src/mail.c
+++ b/src/mail.c
@@ -19,6 +19,7 @@
 #include "handler.h"
 #include "mail.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 /* local (file scope) function prototypes */
 static void postmaster_send_mail(struct char_data *ch, struct char_data *mailman, int cmd, char *arg);

--- a/src/medit.c
+++ b/src/medit.c
@@ -26,6 +26,7 @@
 #include "screen.h"
 #include "fight.h"
 #include "modify.h"      /* for smash_tilde */
+#include  <stdlib.h>
 
 /* local functions */
 static void medit_setup_new(struct descriptor_data *d);

--- a/src/mobact.c
+++ b/src/mobact.c
@@ -21,6 +21,7 @@
 #include "act.h"
 #include "graph.h"
 #include "fight.h"
+#include  <stdlib.h>
 
 
 /* local file scope only function prototypes */

--- a/src/modify.c
+++ b/src/modify.c
@@ -26,6 +26,7 @@
 #include "modify.h"
 #include "quest.h"
 #include "ibt.h"
+#include  <stdlib.h>
 
 /* local (file scope) function prototpyes  */
 static char *next_page(char *str, struct char_data *ch);

--- a/src/msgedit.c
+++ b/src/msgedit.c
@@ -18,6 +18,7 @@
 #include "genolc.h"
 #include "interpreter.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 /* Statics */
 static void free_messages_type(struct msg_type *msg);

--- a/src/mud_event.c
+++ b/src/mud_event.c
@@ -14,6 +14,7 @@
 #include "constants.h"
 #include "comm.h"  /* For access to the game pulse */
 #include "mud_event.h"
+#include  <stdlib.h>
 
 /* Global List */
 struct list_data * world_events = NULL;

--- a/src/oasis.c
+++ b/src/oasis.c
@@ -27,6 +27,7 @@
 #include "quest.h"
 #include "ibt.h"
 #include "msgedit.h"
+#include  <stdlib.h>
 
 /* Global variables defined here, used elsewhere */
 const char *nrm, *grn, *cyn, *yel;

--- a/src/oasis_copy.c
+++ b/src/oasis_copy.c
@@ -23,6 +23,7 @@
 #include "improved-edit.h"
 #include "constants.h"
 #include "dg_scripts.h"
+#include  <stdlib.h>
 
 /* Local, filescope function prototypes */
 /* Utility function for buildwalk */

--- a/src/oasis_list.c
+++ b/src/oasis_list.c
@@ -24,7 +24,8 @@
 #include "quest.h"
 #include "modify.h"
 #include "spells.h"
- 
+#include  <stdlib.h>
+
 #define MAX_OBJ_LIST 100
  
 struct obj_list_item {

--- a/src/objsave.c
+++ b/src/objsave.c
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "modify.h"
 #include "genolc.h" /* for strip_cr and sprintascii */
+#include  <stdlib.h>
 
 /* these factors should be unique integers */
 #define RENT_FACTOR    1

--- a/src/oedit.c
+++ b/src/oedit.c
@@ -24,6 +24,8 @@
 #include "dg_olc.h"
 #include "fight.h"
 #include "modify.h"
+#include  <stdlib.h>
+
 
 /* local functions */
 static void oedit_setup_new(struct descriptor_data *d);

--- a/src/players.c
+++ b/src/players.c
@@ -22,6 +22,7 @@
 #include "config.h" /* for pclean_criteria[] */
 #include "dg_scripts.h" /* To enable saving of player variables to disk */
 #include "quest.h"
+#include  <stdlib.h>
 
 #define LOAD_HIT	0
 #define LOAD_MANA	1

--- a/src/prefedit.c
+++ b/src/prefedit.c
@@ -20,6 +20,7 @@
 #include "oasis.h"
 #include "prefedit.h"
 #include "screen.h"
+#include  <stdlib.h>
 
 /* Internal (static) functions */
 static void prefedit_setup(struct descriptor_data *d, struct char_data *vict);

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -30,6 +30,7 @@
 #include "dg_scripts.h"
 #include "act.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 /* Globals */
 const char * RGBone = "F022";

--- a/src/qedit.c
+++ b/src/qedit.c
@@ -24,6 +24,7 @@
 #include "interpreter.h"
 #include "modify.h"
 #include "quest.h"
+#include  <stdlib.h>
 
 /*-------------------------------------------------------------------*/
 /*. Function prototypes . */

--- a/src/quest.c
+++ b/src/quest.c
@@ -20,6 +20,7 @@
 #include "screen.h"
 #include "quest.h"
 #include "act.h" /* for do_tell */
+#include  <stdlib.h>
 
 
 /*--------------------------------------------------------------------------

--- a/src/redit.c
+++ b/src/redit.c
@@ -21,6 +21,7 @@
 #include "dg_olc.h"
 #include "constants.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 /* local functions */
 static void redit_setup_new(struct descriptor_data *d);

--- a/src/sedit.c
+++ b/src/sedit.c
@@ -19,6 +19,7 @@
 #include "oasis.h"
 #include "constants.h"
 #include "shop.h"
+#include  <stdlib.h>
 
 /* local functions */
 static void sedit_setup_new(struct descriptor_data *d);

--- a/src/shop.c
+++ b/src/shop.c
@@ -25,6 +25,7 @@
 #include "modify.h"
 #include "spells.h"  /* for skill_name() */
 #include "screen.h"
+#include  <stdlib.h>
 
 /* Global variables definitions used externally */
 /* Constant list for printing out who we sell to */

--- a/src/sysdep.h
+++ b/src/sysdep.h
@@ -87,7 +87,9 @@
 #include <memory.h>
 #endif
 
+/*
 extern char *malloc(), *calloc(), *realloc();
+*/
 extern void free ();
 
 extern void abort (), exit ();

--- a/src/tedit.c
+++ b/src/tedit.c
@@ -16,6 +16,7 @@
 #include "oasis.h"
 #include "improved-edit.h"
 #include "modify.h"
+#include  <stdlib.h>
 
 extern time_t motdmod;
 extern time_t newsmod;

--- a/src/util/autowiz.c
+++ b/src/util/autowiz.c
@@ -12,6 +12,7 @@
 #include "structs.h"
 #include "utils.h"
 #include "db.h"
+#include  <stdlib.h>
 
 #define IMM_LMARG "   "
 #define IMM_NSIZE  16

--- a/src/util/shopconv.c
+++ b/src/util/shopconv.c
@@ -11,6 +11,7 @@
 #include "utils.h"
 #include "db.h"
 #include "shop.h"
+#include  <stdlib.h>
 
 void basic_mud_log(const char *x, ...)
 {

--- a/src/util/sign.c
+++ b/src/util/sign.c
@@ -10,6 +10,7 @@
 
 #include "conf.h"
 #include "sysdep.h"
+#include  <stdlib.h>
 
 
 /*

--- a/src/util/split.c
+++ b/src/util/split.c
@@ -21,6 +21,7 @@
 
 #include "conf.h"
 #include "sysdep.h"
+#include  <stdlib.h>
 
 int main(void)
 {

--- a/src/util/webster.c
+++ b/src/util/webster.c
@@ -9,6 +9,7 @@
 
 #include "conf.h"
 #include "sysdep.h"
+#include  <stdlib.h>
 
 
 #define MEM_USE 10000

--- a/src/util/wld2html.c
+++ b/src/util/wld2html.c
@@ -11,6 +11,7 @@
 
 #include "conf.h"
 #include "sysdep.h"
+#include  <stdlib.h>
 
 
 #define NOWHERE    -1		/* nil reference for room-database         */

--- a/src/utils.c
+++ b/src/utils.c
@@ -22,6 +22,7 @@
 #include "handler.h"
 #include "interpreter.h"
 #include "class.h"
+#include  <stdlib.h>
 
 
 /** Aportable random number function.

--- a/src/zedit.c
+++ b/src/zedit.c
@@ -17,6 +17,7 @@
 #include "genzon.h"
 #include "oasis.h"
 #include "dg_scripts.h"
+#include  <stdlib.h>
 
 /* Nasty internal macros to clean up the code. */
 #define MYCMD		(OLC_ZONE(d)->cmd[subcmd])


### PR DESCRIPTION
Some very minor fixes to make circle/tba compile under modern OSX (11.3).

```
$ gcc --version
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.5 (clang-1205.0.22.9)
Target: x86_64-apple-darwin20.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```
