### PR TITLE
Fixes & Code Quality

### DIFF
--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -492,7 +492,8 @@ void look_at_room(struct char_data *ch, int ignore_brief)
   if (IS_DARK(IN_ROOM(ch)) && !CAN_SEE_IN_DARK(ch)) {
     send_to_char(ch, "It is pitch black...\r\n");
     return;
-  } else if (AFF_FLAGGED(ch, AFF_BLIND) && GET_LEVEL(ch) < LVL_IMMORT) {
+  } 
+  else if (AFF_FLAGGED(ch, AFF_BLIND) && GET_LEVEL(ch) < LVL_IMMORT) {
     send_to_char(ch, "You see nothing but infinite darkness...\r\n");
     return;
   }
@@ -511,17 +512,19 @@ void look_at_room(struct char_data *ch, int ignore_brief)
       send_to_char(ch, "]");
     }
   }
-  else
+  else {
     send_to_char(ch, "%s", world[IN_ROOM(ch)].name);
-  send_to_char(ch, "%s\r\n", CCNRM(ch, C_NRM));
+  }
+  send_to_char(ch, "%s\r\n", CCCYN(ch, C_NRM));
 
   if ((!IS_NPC(ch) && !PRF_FLAGGED(ch, PRF_BRIEF)) || ignore_brief ||
       ROOM_FLAGGED(IN_ROOM(ch), ROOM_DEATH)) {
     if(!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_AUTOMAP) && can_see_map(ch))
         str_and_map(world[target_room].description, ch, target_room);
-    else
+    }
+    else {
       send_to_char(ch, "%s", world[IN_ROOM(ch)].description);
-  }
+    }
 
   /* autoexits */
   if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_AUTOEXIT))

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -448,7 +448,7 @@ ACMD(do_exits)
     send_to_char(ch, "You can't see a damned thing, you're blind!\r\n");
     return;
   }
-  
+
   send_to_char(ch, "Obvious exits:\r\n");
 
   for (door = 0; door < DIR_COUNT; door++)
@@ -467,8 +467,9 @@ ACMD(do_exits)
       send_to_char(ch, "%-5s -[%5d]%s %s\r\n", dirs[door], GET_ROOM_VNUM(EXIT(ch, door)->to_room),
         EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN) ? "[HIDDEN]" : "", world[EXIT(ch, door)->to_room].name);
     }
-    else if (CONFIG_DISP_CLOSED_DOORS && EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED)) {
-      /* But we tell them the door is closed */
+    else if (CONFIG_DISP_CLOSED_DOORS && EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED))
+    {
+      /*But we tell them the door is closed */
       send_to_char(ch, "%-5s - The %s is closed%s\r\n", dirs[door],
         (EXIT(ch, door)->keyword) ? fname(EXIT(ch, door)->keyword) : "opening",
         EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN) ? " and hidden." : ".");
@@ -478,9 +479,9 @@ ACMD(do_exits)
       send_to_char(ch, "%-5s - %s\r\n", dirs[door], IS_DARK(EXIT(ch, door)->to_room) &&
         !CAN_SEE_IN_DARK(ch) ? "Too dark to tell." : world[EXIT(ch, door)->to_room].name);
     }
-		if (!len)
-	    send_to_char(ch, " None.\r\n");
   }
+    if (!len)
+      send_to_char(ch, " None.\r\n");
 }
 
 void look_at_room(struct char_data *ch, int ignore_brief)

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -485,7 +485,7 @@ ACMD(do_exits)
 
 void look_at_room(struct char_data *ch, int ignore_brief)
 {
-  trig_data *t;
+  trig_data * t;
   struct room_data *rm = &world[IN_ROOM(ch)];
   room_vnum target_room;
 
@@ -494,48 +494,57 @@ void look_at_room(struct char_data *ch, int ignore_brief)
   if (!ch->desc)
     return;
 
-  if (IS_DARK(IN_ROOM(ch)) && !CAN_SEE_IN_DARK(ch)) {
+  if (IS_DARK(IN_ROOM(ch)) && !CAN_SEE_IN_DARK(ch))
+  {
     send_to_char(ch, "It is pitch black...\r\n");
     return;
-  } 
-  else if (AFF_FLAGGED(ch, AFF_BLIND) && GET_LEVEL(ch) < LVL_IMMORT) {
+  }
+  else if (AFF_FLAGGED(ch, AFF_BLIND) && GET_LEVEL(ch) < LVL_IMMORT)
+  {
     send_to_char(ch, "You see nothing but infinite darkness...\r\n");
     return;
   }
+
   send_to_char(ch, "%s", CCCYN(ch, C_NRM));
-  if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_SHOWVNUMS)) {
+  if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_SHOWVNUMS))
+  {
     char buf[MAX_STRING_LENGTH];
 
     sprintbitarray(ROOM_FLAGS(IN_ROOM(ch)), room_bits, RF_ARRAY_MAX, buf);
     send_to_char(ch, "[%5d] ", GET_ROOM_VNUM(IN_ROOM(ch)));
-    send_to_char(ch, "%s [ %s] [ %s ]", world[IN_ROOM(ch)].name, buf, sector_types[world[IN_ROOM(ch)].sector_type]);
+    send_to_char(ch, "%s[ %s][ %s ]", world[IN_ROOM(ch)].name, buf, sector_types[world[IN_ROOM(ch)].sector_type]);
 
-    if (SCRIPT(rm)) {
+    if (SCRIPT(rm))
+    {
       send_to_char(ch, "[T");
       for (t = TRIGGERS(SCRIPT(rm)); t; t = t->next)
         send_to_char(ch, " %d", GET_TRIG_VNUM(t));
       send_to_char(ch, "]");
     }
   }
-  else {
+  else
+  {
     send_to_char(ch, "%s", world[IN_ROOM(ch)].name);
   }
+
   send_to_char(ch, "%s\r\n", CCCYN(ch, C_NRM));
 
   if ((!IS_NPC(ch) && !PRF_FLAGGED(ch, PRF_BRIEF)) || ignore_brief ||
-      ROOM_FLAGGED(IN_ROOM(ch), ROOM_DEATH)) {
-    if(!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_AUTOMAP) && can_see_map(ch))
-        str_and_map(world[target_room].description, ch, target_room);
-    }
-    else {
-      send_to_char(ch, "%s", world[IN_ROOM(ch)].description);
-    }
+    ROOM_FLAGGED(IN_ROOM(ch), ROOM_DEATH))
+  {
+    if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_AUTOMAP) && can_see_map(ch))
+      str_and_map(world[target_room].description, ch, target_room);
+  }
+  else
+  {
+    send_to_char(ch, "%s", world[IN_ROOM(ch)].description);
+  }
 
-  /* autoexits */
+  /*autoexits */
   if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_AUTOEXIT))
     do_auto_exits(ch);
 
-  /* now list characters & objects */
+  /*now list characters &objects */
   list_obj_to_char(world[IN_ROOM(ch)].contents, ch, SHOW_OBJ_LONG, FALSE);
   list_char_to_char(world[IN_ROOM(ch)].people, ch);
 }

--- a/src/act.informative.c
+++ b/src/act.informative.c
@@ -443,39 +443,44 @@ ACMD(do_exits)
 {
   int door, len = 0;
 
-  if (AFF_FLAGGED(ch, AFF_BLIND) && GET_LEVEL(ch) < LVL_IMMORT) {
+  if (AFF_FLAGGED(ch, AFF_BLIND) && GET_LEVEL(ch) < LVL_IMMORT)
+  {
     send_to_char(ch, "You can't see a damned thing, you're blind!\r\n");
     return;
   }
-
+  
   send_to_char(ch, "Obvious exits:\r\n");
 
-  for (door = 0; door < DIR_COUNT; door++) {
+  for (door = 0; door < DIR_COUNT; door++)
+  {
     if (!EXIT(ch, door) || EXIT(ch, door)->to_room == NOWHERE)
       continue;
     if (EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED) && !CONFIG_DISP_CLOSED_DOORS)
       continue;
     if (EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN) && !PRF_FLAGGED(ch, PRF_HOLYLIGHT))
-	  continue;
+      continue;
 
     len++;
 
     if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_SHOWVNUMS) && !EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED))
-      send_to_char(ch, "%-5s - [%5d]%s %s\r\n", dirs[door], GET_ROOM_VNUM(EXIT(ch, door)->to_room),
-      EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN) ? " [HIDDEN]" : "", world[EXIT(ch, door)->to_room].name);
+    {
+      send_to_char(ch, "%-5s -[%5d]%s %s\r\n", dirs[door], GET_ROOM_VNUM(EXIT(ch, door)->to_room),
+        EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN) ? "[HIDDEN]" : "", world[EXIT(ch, door)->to_room].name);
+    }
     else if (CONFIG_DISP_CLOSED_DOORS && EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED)) {
       /* But we tell them the door is closed */
       send_to_char(ch, "%-5s - The %s is closed%s\r\n", dirs[door],
-		(EXIT(ch, door)->keyword)? fname(EXIT(ch, door)->keyword) : "opening",
-		EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN) ? " and hidden." : ".");
-      }
+        (EXIT(ch, door)->keyword) ? fname(EXIT(ch, door)->keyword) : "opening",
+        EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN) ? " and hidden." : ".");
+    }
     else
+    {
       send_to_char(ch, "%-5s - %s\r\n", dirs[door], IS_DARK(EXIT(ch, door)->to_room) &&
-		!CAN_SEE_IN_DARK(ch) ? "Too dark to tell." : world[EXIT(ch, door)->to_room].name);
+        !CAN_SEE_IN_DARK(ch) ? "Too dark to tell." : world[EXIT(ch, door)->to_room].name);
+    }
+		if (!len)
+	    send_to_char(ch, " None.\r\n");
   }
-
-  if (!len)
-    send_to_char(ch, " None.\r\n");
 }
 
 void look_at_room(struct char_data *ch, int ignore_brief)

--- a/src/handler.c
+++ b/src/handler.c
@@ -671,17 +671,25 @@ struct char_data *get_char_num(mob_rnum nr)
 /* put an object in a room */
 void obj_to_room(struct obj_data *object, room_rnum room)
 {
-  if (!object || room == NOWHERE || room > top_of_world)
+  if (!object || room == NOWHERE || room > top_of_world){
     log("SYSERR: Illegal value(s) passed to obj_to_room. (Room #%d/%d, obj %p)",
 	room, top_of_world, (void *)object);
-  else {
-    object->next_content = world[room].contents;
-    world[room].contents = object;
-    IN_ROOM(object) = room;
-    object->carried_by = NULL;
-    if (ROOM_FLAGGED(room, ROOM_HOUSE))
-      SET_BIT_AR(ROOM_FLAGS(room), ROOM_HOUSE_CRASH);
   }
+	else {
+	  if (world[room].contents == NULL){  // if list is empty
+		  world[room].contents = object; // add object to list
+    }
+		else {
+			struct obj_data *i = world[room].contents; // define a temporary pointer
+			while (i->next_content != NULL) i = i->next_content; // find the first without a next_content
+			i->next_content = object; // add object at the end
+		}
+	object->next_content = NULL; // mostly for sanity. should do nothing.
+	IN_ROOM(object) = room
+	object->carried_by = NULL;
+	if (ROOM_FLAGGED(room, ROOM_HOUSE))
+	  SET_BIT_AR(ROOM_FLAGS(room), ROOM_HOUSE_CRASH);
+	}
 }
 
 /* Take an object from a room */

--- a/src/handler.c
+++ b/src/handler.c
@@ -675,21 +675,21 @@ void obj_to_room(struct obj_data *object, room_rnum room)
     log("SYSERR: Illegal value(s) passed to obj_to_room. (Room #%d/%d, obj %p)",
 	room, top_of_world, (void *)object);
   }
-	else {
-	  if (world[room].contents == NULL){  // if list is empty
-		  world[room].contents = object; // add object to list
+  else {
+    if (world[room].contents == NULL){  // if list is empty
+      world[room].contents = object; // add object to list
     }
-		else {
-			struct obj_data *i = world[room].contents; // define a temporary pointer
-			while (i->next_content != NULL) i = i->next_content; // find the first without a next_content
-			i->next_content = object; // add object at the end
-		}
-	object->next_content = NULL; // mostly for sanity. should do nothing.
-	IN_ROOM(object) = room
-	object->carried_by = NULL;
-	if (ROOM_FLAGGED(room, ROOM_HOUSE))
-	  SET_BIT_AR(ROOM_FLAGS(room), ROOM_HOUSE_CRASH);
-	}
+    else {
+      struct obj_data *i = world[room].contents; // define a temporary pointer
+      while (i->next_content != NULL) i = i->next_content; // find the first without a next_content
+        i->next_content = object; // add object at the end
+    }
+    object->next_content = NULL; // mostly for sanity. should do nothing.
+    IN_ROOM(object) = room
+    object->carried_by = NULL;
+    if (ROOM_FLAGGED(room, ROOM_HOUSE))
+      SET_BIT_AR(ROOM_FLAGS(room), ROOM_HOUSE_CRASH);
+  }
 }
 
 /* Take an object from a room */


### PR DESCRIPTION
**Update handler.c** 
Fixes the display order of objects in obj_to_room().
Objects are now displayed in the order they are placed/dropped. This prevents fountains, boards, etcetera from "moving" around the room.

**Update act.informative.c** 
Fixes unguarded else clauses due to inconsistent use of {} in look_at_room().
Fixes unguarded blocks of code in ACMD(do_exits) that could cause the server to report scripted trigger events (mob movements, exit links to rooms being reassigned, and doors being opened or closed) as script errors. Particularly, if this code is copy and pasted into do_auto_exits(). 