### PR TITLE
Added check for NOTHING key in has_key()

### DIFF
--- a/src/act.movement.c
+++ b/src/act.movement.c
@@ -461,6 +461,9 @@ int has_key(struct char_data *ch, obj_vnum key)
 {
   struct obj_data *o;
 
+  if (key == NOTHING)
+    return (0);
+
   for (o = ch->carrying; o; o = o->next_content)
     if (GET_OBJ_VNUM(o) == key)
       return (1);


### PR DESCRIPTION
Ref comment on tbamud.com: 

> We (our players) noticed that on locked doors with key num -1 you can unlock those doors by having a corpse (vnum -1) in your inventory.

Since corpses have vnum NOTHING, and doors and containers can be set to have key == NOTHING, this means corpses act as a key.