### PR TITLE
Fix "SYSERR: Invalid keyword (Flags) in IBT file"

### DIFF
--- a/src/ibt.c
+++ b/src/ibt.c
@@ -177,6 +177,13 @@ static IBT_DATA *read_ibt( char *filename, FILE *fp )
             }
             break;
 
+          case 'F':
+            if (!str_cmp(word, "Flags")) {
+              fMatch = TRUE;
+              fread_flags(fp, ibtData->flags, 4);
+            }
+            break;
+
           case 'I':
             TXT_KEY("IdNum", id_num, fread_line(fp));
             break;


### PR DESCRIPTION
In ibt.c, the read_ibt function is called to pull existing ideas/bugs/typos from files upon load. However, it is missing an entry to lookup the "Flags" line, which tracks whether an idea/bug/typo is in progress, priority, or completed.

This pull request fixes that by adding the appropriate case to the switch.