### PR TITLE
Update wld2html.c

### DIFF
--- a/src/util/wld2html.c
+++ b/src/util/wld2html.c
@@ -257,6 +257,9 @@ void discrete_load(FILE * fl)
       fprintf(stderr, "Format error after room #%d\n", nr);
       exit(1);
     }
+    if (*line == 'T') //Toss triggers. THey currently break this util.
+      return;
+	  
     if (*line == '$')
       return;
 


### PR DESCRIPTION
Triggers on elements of the room break this utility. Added code to toss them since we don't need them. Can add handling that pulls the trigger info later if desired, but too time consuming to index them before building the room for this simple tool.