### PR TITLE
Allow source code to compile on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,12 @@ src/test/testfile
 .settings
 
 .cproject
+
+# macOS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/configure
+++ b/configure
@@ -1227,18 +1227,28 @@ if eval "test \"`echo '$ac_cv_func_'crypt`\" = yes"; then
   cat >> confdefs.h <<\EOF
 #define CIRCLE_CRYPT 1
 EOF
+  CRYPTLIB="-lcrypt"
+  echo "CRYPTLIB set to: $CRYPTLIB" 1>&6
 
 else
   echo "$ac_t""no" 1>&6
-echo $ac_n "checking for crypt in -lcrypt""... $ac_c" 1>&6
-echo "configure:1235: checking for crypt in -lcrypt" >&5
-ac_lib_var=`echo crypt'_'crypt | sed 'y%./+-%__p_%'`
-if eval "test \"`echo '$''{'ac_cv_lib_$ac_lib_var'+set}'`\" = set"; then
-  echo $ac_n "(cached) $ac_c" 1>&6
-else
-  ac_save_LIBS="$LIBS"
-LIBS="-lcrypt  $LIBS"
-cat > conftest.$ac_ext <<EOF
+  echo $ac_n "checking for crypt in -lcrypt""... $ac_c" 1>&6
+  echo "configure:1235: checking for crypt in -lcrypt" >&5
+
+  OS_NAME=$(uname)
+  if [ "$OS_NAME" = "Darwin" ]; then
+    # macOS: No need for -lcrypt
+    CRYPTLIB=""
+    echo "CRYPTLIB not needed on macOS" 1>&6
+  else
+    # Other systems (Linux): Use -lcrypt
+    ac_lib_var=`echo crypt'_'crypt | sed 'y%./+-%__p_%'`
+    if eval "test \"`echo '$''{'ac_cv_lib_$ac_lib_var'+set}'`\" = set"; then
+      echo $ac_n "(cached) $ac_c" 1>&6
+    else
+      ac_save_LIBS="$LIBS"
+      LIBS="-lcrypt  $LIBS"
+      cat > conftest.$ac_ext <<EOF
 #line 1243 "configure"
 #include "confdefs.h"
 /* Override any gcc2 internal prototype to avoid an error.  */
@@ -1250,30 +1260,29 @@ int main() {
 crypt()
 ; return 0; }
 EOF
-if { (eval echo configure:1254: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
-  rm -rf conftest*
-  eval "ac_cv_lib_$ac_lib_var=yes"
-else
-  echo "configure: failed program was:" >&5
-  cat conftest.$ac_ext >&5
-  rm -rf conftest*
-  eval "ac_cv_lib_$ac_lib_var=no"
-fi
-rm -f conftest*
-LIBS="$ac_save_LIBS"
-
-fi
-if eval "test \"`echo '$ac_cv_lib_'$ac_lib_var`\" = yes"; then
-  echo "$ac_t""yes" 1>&6
-  cat >> confdefs.h <<\EOF
+      if { (eval echo configure:1254: \"$ac_link\") 1>&5; (eval $ac_link) 2>&5; } && test -s conftest${ac_exeext}; then
+        rm -rf conftest*
+        eval "ac_cv_lib_$ac_lib_var=yes"
+      else
+        echo "configure: failed program was:" >&5
+        cat conftest.$ac_ext >&5
+        rm -rf conftest*
+        eval "ac_cv_lib_$ac_lib_var=no"
+      fi
+      rm -f conftest*
+      LIBS="$ac_save_LIBS"
+    fi
+    if eval "test \"`echo '$ac_cv_lib_'$ac_lib_var`\" = yes"; then
+      echo "$ac_t""yes" 1>&6
+      cat >> confdefs.h <<\EOF
 #define CIRCLE_CRYPT 1
 EOF
- CRYPTLIB="-lcrypt"
-else
-  echo "$ac_t""no" 1>&6
-fi
-
-    
+      CRYPTLIB="-lcrypt"
+      echo "CRYPTLIB set to: $CRYPTLIB on Linux" 1>&6
+    else
+      echo "$ac_t""no" 1>&6
+    fi
+  fi
 fi
 
 

--- a/src/Makefile.macOS
+++ b/src/Makefile.macOS
@@ -2,10 +2,10 @@
 # Clean-up provided by seqwith.
 
 # C compiler to use
-CC = @CC@
+CC = gcc
 
 # Any special flags you want to pass to the compiler
-MYFLAGS = @MYFLAGS@
+MYFLAGS = -Wall -Wno-char-subscripts -Wno-invalid-source-encoding -DMEMORY_DEBUG
 
 #flags for profiling (see hacker.doc for more information)
 PROFILE = 
@@ -16,9 +16,9 @@ PROFILE =
 
 BINDIR = ../bin
 
-CFLAGS = @CFLAGS@ $(MYFLAGS) $(PROFILE)
+CFLAGS = -g -O0 $(MYFLAGS) $(PROFILE)
 
-LIBS = @LIBS@ @CRYPTLIB@ @NETLIB@
+LIBS =
 
 SRCFILES := $(shell ls *.c | sort)
 OBJFILES := $(patsubst %.c,%.o,$(SRCFILES))  
@@ -30,7 +30,7 @@ all: .accepted
 	$(MAKE) utils
 
 .accepted:
-	@./licheck @MORE@
+	@./licheck less
 
 utils: .accepted
 	(cd util; $(MAKE) all)

--- a/src/conf.h.macOS
+++ b/src/conf.h.macOS
@@ -1,0 +1,367 @@
+#ifndef _CONF_H_
+#define _CONF_H_
+
+/* Define to empty if the keyword does not work.  */
+/* #undef const */
+
+/* Define if you don't have vprintf but do have _doprnt.  */
+/* #undef HAVE_DOPRNT */
+
+/* Define if you have <sys/wait.h> that is POSIX.1 compatible.  */
+#define HAVE_SYS_WAIT_H 1
+
+/* Define if you have the vprintf function.  */
+#define HAVE_VPRINTF 1
+
+/* Define to `int' if <sys/types.h> doesn't define.  */
+/* #undef pid_t */
+
+/* Define as the return type of signal handlers (int or void).  */
+#define RETSIGTYPE void
+
+/* Define to `unsigned' if <sys/types.h> doesn't define.  */
+/* #undef size_t */
+
+/* Define if you have the ANSI C header files.  */
+/* #undef STDC_HEADERS */
+
+/* Define if you can safely include both <sys/time.h> and <time.h>.  */
+#define TIME_WITH_SYS_TIME 1
+
+/* Define if we're compiling CircleMUD under any type of UNIX system.  */
+#define CIRCLE_UNIX 1
+
+/* Machine-specific dependencies for running on modern macOS systems 10.13+ (High Sierra)
+ * Updated by Victor Augusto Borges Dias de Almeida (aka Stoneheart), 26 June 2024.
+ * 
+ * Tested on:
+ *   - macOS 10.13: High Sierra - September 25, 2017 (Latest: 10.13.6)
+ *   - macOS 10.14: Mojave - September 24, 2018 (Latest: 10.14.6)
+ *   - macOS 10.15: Catalina - October 7, 2019 (Latest: 10.15.7)
+ *   - macOS 11: Big Sur - November 12, 2020 (Latest: 11.7.10)
+ *   - macOS 12: Monterey - October 25, 2021 (Latest: 12.7)
+ *   - macOS 13: Ventura - November 7, 2022 (Latest: 13.7)
+ *   - macOS 14: Sonoma - November 7, 2023 (Latest: 14.3)
+ *
+ * This file works on Apple Silicon Chips (M1, M2, M3) without futher configurations. */
+#if defined(__APPLE__) && defined(__MACH__)
+#define CIRCLE_MAC_OS   1
+#endif
+
+/* Define if the system is capable of using crypt() to encrypt.  */
+#define CIRCLE_CRYPT 1
+
+/* Define if we don't have proper support for the system's crypt().  */
+/* #undef HAVE_UNSAFE_CRYPT */
+
+/* Define is the system has struct in_addr.  */
+#define HAVE_STRUCT_IN_ADDR 1
+
+/* Define to `int' if <sys/socket.h> doesn't define.  */
+/* #undef socklen_t */
+
+/* Define to `int' if <sys/types.h> doesn't define.  */
+/* #undef ssize_t */
+
+/* Define if you have the gettimeofday function.  */
+#define HAVE_GETTIMEOFDAY 1
+
+/* Define if you have the inet_addr function.  */
+#define HAVE_INET_ADDR 1
+
+/* Define if you have the inet_aton function.  */
+#define HAVE_INET_ATON 1
+
+/* Define if you have the select function.  */
+#define HAVE_SELECT 1
+
+/* Define if you have the snprintf function.  */
+#define HAVE_SNPRINTF 1
+
+/* Define if you have the strcasecmp function.  */
+#define HAVE_STRCASECMP 1
+
+/* Define if you have the strdup function.  */
+#define HAVE_STRDUP 1
+
+/* Define if you have the strerror function.  */
+#define HAVE_STRERROR 1
+
+/* Define if you have the stricmp function.  */
+/* #undef HAVE_STRICMP */
+
+/* Define if you have the strlcpy function.  */
+#ifndef CIRCLE_MAC_OS
+#define HAVE_STRLCPY 1
+#else 
+#define HAVE_STRLCPY 0
+#endif
+
+/* Define if you have the strncasecmp function.  */
+#define HAVE_STRNCASECMP 1
+
+/* Define if you have the strnicmp function.  */
+/* #undef HAVE_STRNICMP */
+
+/* Define if you have the strstr function.  */
+#define HAVE_STRSTR 1
+
+/* Define if you have the vsnprintf function.  */
+#define HAVE_VSNPRINTF 1
+
+/* Define if you have the <arpa/inet.h> header file.  */
+#define HAVE_ARPA_INET_H 1
+
+/* Define if you have the <arpa/telnet.h> header file.  */
+#define HAVE_ARPA_TELNET_H 1
+
+/* Define if you have the <assert.h> header file.  */
+#define HAVE_ASSERT_H 1
+
+/* Define if you have the <crypt.h> header file.  */
+/* #undef HAVE_CRYPT_H */
+#ifdef CIRCLE_MAC_OS
+#define HAVE_CRYPT_H 1
+#endif
+
+/* Define if you have the <errno.h> header file.  */
+#define HAVE_ERRNO_H 1
+
+/* Define if you have the <fcntl.h> header file.  */
+#define HAVE_FCNTL_H 1
+
+/* Define if you have the <limits.h> header file.  */
+#define HAVE_LIMITS_H 1
+
+/* Define if you have the <mcheck.h> header file.  */
+/* #undef HAVE_MCHECK_H */
+#ifdef CIRCLE_MAC_OS
+#define HAVE_MCHECK_H 1
+#endif
+
+/* Define if you have the <memory.h> header file.  */
+#define HAVE_MEMORY_H 1
+
+/* Define if you have the <net/errno.h> header file.  */
+/* #undef HAVE_NET_ERRNO_H */
+
+/* Define if you have the <netdb.h> header file.  */
+#define HAVE_NETDB_H 1
+
+/* Define if you have the <netinet/in.h> header file.  */
+#define HAVE_NETINET_IN_H 1
+
+/* Define if you have the <signal.h> header file.  */
+#define HAVE_SIGNAL_H 1
+
+/* Define if you have the <string.h> header file.  */
+#define HAVE_STRING_H 1
+
+/* Define if you have the <strings.h> header file.  */
+#define HAVE_STRINGS_H 1
+
+/* Define if you have the <sys/fcntl.h> header file.  */
+#define HAVE_SYS_FCNTL_H 1
+
+/* Define if you have the <sys/resource.h> header file.  */
+#define HAVE_SYS_RESOURCE_H 1
+
+/* Define if you have the <sys/select.h> header file.  */
+#define HAVE_SYS_SELECT_H 1
+
+/* Define if you have the <sys/socket.h> header file.  */
+#define HAVE_SYS_SOCKET_H 1
+
+/* Define if you have the <sys/stat.h> header file.  */
+#define HAVE_SYS_STAT_H 1
+
+/* Define if you have the <sys/time.h> header file.  */
+#define HAVE_SYS_TIME_H 1
+
+/* Define if you have the <sys/types.h> header file.  */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define if you have the <sys/uio.h> header file.  */
+#define HAVE_SYS_UIO_H 1
+
+/* Define if you have the <unistd.h> header file.  */
+#define HAVE_UNISTD_H 1
+
+/* Define if you have the malloc library (-lmalloc).  */
+/* #undef HAVE_LIBMALLOC */
+
+/* Check for a prototype to accept. */
+/* #undef NEED_ACCEPT_PROTO */
+
+#ifndef CIRCLE_MAC_OS
+/* Check for a prototype to atoi. */
+#define NEED_ATOI_PROTO 
+/* Check for a prototype to atol. */
+#define NEED_ATOL_PROTO 
+#endif
+
+/* Check for a prototype to bind. */
+/* #undef NEED_BIND_PROTO */
+
+/* Check for a prototype to bzero. */
+/* #undef NEED_BZERO_PROTO */
+
+/* Check for a prototype to chdir. */
+/* #undef NEED_CHDIR_PROTO */
+
+/* Check for a prototype to close. */
+/* #undef NEED_CLOSE_PROTO */
+
+/* Check for a prototype to crypt. */
+/* #undef NEED_CRYPT_PROTO */
+
+/* Check for a prototype to fclose. */
+/* #undef NEED_FCLOSE_PROTO */
+
+/* Check for a prototype to fcntl. */
+/* #undef NEED_FCNTL_PROTO */
+
+/* Check for a prototype to fflush. */
+/* #undef NEED_FFLUSH_PROTO */
+
+/* Check for a prototype to fprintf. */
+/* #undef NEED_FPRINTF_PROTO */
+
+/* Check for a prototype to fputc. */
+/* #undef NEED_FPUTC_PROTO */
+
+/* Check for a prototype to fputs. */
+/* #undef NEED_FPUTS_PROTO */
+
+/* Check for a prototype to fread. */
+/* #undef NEED_FREAD_PROTO */
+
+/* Check for a prototype to fscanf. */
+/* #undef NEED_FSCANF_PROTO */
+
+/* Check for a prototype to fseek. */
+/* #undef NEED_FSEEK_PROTO */
+
+/* Check for a prototype to fwrite. */
+/* #undef NEED_FWRITE_PROTO */
+
+/* Check for a prototype to getpeername. */
+/* #undef NEED_GETPEERNAME_PROTO */
+
+/* Check for a prototype to getpid. */
+/* #undef NEED_GETPID_PROTO */
+
+/* Check for a prototype to getrlimit. */
+/* #undef NEED_GETRLIMIT_PROTO */
+
+/* Check for a prototype to getsockname. */
+/* #undef NEED_GETSOCKNAME_PROTO */
+
+/* Check for a prototype to gettimeofday. */
+/* #undef NEED_GETTIMEOFDAY_PROTO */
+
+/* Check for a prototype to htonl. */
+/* #undef NEED_HTONL_PROTO */
+
+/* Check for a prototype to htons. */
+/* #undef NEED_HTONS_PROTO */
+
+/* Check for a prototype to inet_addr. */
+/* #undef NEED_INET_ADDR_PROTO */
+
+/* Check for a prototype to inet_aton. */
+/* #undef NEED_INET_ATON_PROTO */
+
+/* Check for a prototype to inet_ntoa. */
+/* #undef NEED_INET_NTOA_PROTO */
+
+/* Check for a prototype to listen. */
+/* #undef NEED_LISTEN_PROTO */
+
+/* Check for a prototype to ntohl. */
+/* #undef NEED_NTOHL_PROTO */
+
+/* Check for a prototype to perror. */
+/* #undef NEED_PERROR_PROTO */
+
+/* Check for a prototype to printf. */
+/* #undef NEED_PRINTF_PROTO */
+
+/* Check for a prototype to qsort. */
+#ifndef CIRCLE_MAC_OS
+#define NEED_QSORT_PROTO 
+#endif
+
+/* Check for a prototype to read. */
+/* #undef NEED_READ_PROTO */
+
+/* Check for a prototype to remove. */
+/* #undef NEED_REMOVE_PROTO */
+
+/* Check for a prototype to rewind. */
+/* #undef NEED_REWIND_PROTO */
+
+/* Check for a prototype to select. */
+/* #undef NEED_SELECT_PROTO */
+
+/* Check for a prototype to setitimer. */
+/* #undef NEED_SETITIMER_PROTO */
+
+/* Check for a prototype to setrlimit. */
+/* #undef NEED_SETRLIMIT_PROTO */
+
+/* Check for a prototype to setsockopt. */
+/* #undef NEED_SETSOCKOPT_PROTO */
+
+/* Check for a prototype to snprintf. */
+/* #undef NEED_SNPRINTF_PROTO */
+
+/* Check for a prototype to socket. */
+/* #undef NEED_SOCKET_PROTO */
+
+/* Check for a prototype to sprintf. */
+/* #undef NEED_SPRINTF_PROTO */
+
+/* Check for a prototype to sscanf. */
+/* #undef NEED_SSCANF_PROTO */
+
+/* Check for a prototype to strcasecmp. */
+/* #undef NEED_STRCASECMP_PROTO */
+
+/* Check for a prototype to strdup. */
+/* #undef NEED_STRDUP_PROTO */
+
+/* Check for a prototype to strerror. */
+/* #undef NEED_STRERROR_PROTO */
+
+/* Check for a prototype to stricmp. */
+#define NEED_STRICMP_PROTO 
+
+/* Check for a prototype to strlcpy. */
+/* #undef NEED_STRLCPY_PROTO */
+
+/* Check for a prototype to strncasecmp. */
+/* #undef NEED_STRNCASECMP_PROTO */
+
+/* Check for a prototype to strnicmp. */
+#define NEED_STRNICMP_PROTO 
+
+/* Check for a prototype to system. */
+#ifndef CIRCLE_MAC_OS
+#define NEED_SYSTEM_PROTO 
+#endif
+
+/* Check for a prototype to time. */
+/* #undef NEED_TIME_PROTO */
+
+/* Check for a prototype to unlink. */
+/* #undef NEED_UNLINK_PROTO */
+
+/* Check for a prototype to vsnprintf. */
+/* #undef NEED_VSNPRINTF_PROTO */
+
+/* Check for a prototype to write. */
+/* #undef NEED_WRITE_PROTO */
+
+
+#endif /* _CONF_H_ */

--- a/src/sysdep.h
+++ b/src/sysdep.h
@@ -63,6 +63,24 @@
 
 /* Do not change anything below this line. */
 
+#if defined(__APPLE__) && defined(__MACH__)
+/* Machine-specific dependencies for running on modern macOS systems 10.13+ (High Sierra)
+*  Updated by Victor Augusto Borges Dias de Almeida (aka Stoneheart), 26 June 2024.
+* 
+*  Tested on:
+*    - macOS 10.13: High Sierra (Lobo) - September 25, 2017 (Latest: 10.13.6)
+*    - macOS 10.14: Mojave (Liberty) - September 24, 2018 (Latest: 10.14.6)
+*    - macOS 10.15: Catalina (Jazz) - October 7, 2019 (Latest: 10.15.7)
+*    - macOS 11: Big Sur (GoldenGate) - November 12, 2020 (Latest: 11.7.10)
+*    - macOS 12: Monterey (Star) - October 25, 2021 (Latest: 12.7)
+*    - macOS 13: Ventura (Rome) - November 7, 2022 (Latest: 13.7)
+*    - macOS 14: Sonoma (Sunburst) - November 7, 2023 (Latest: 14.3)
+*
+*  This file works on Apple Silicon Chips (M1, M2, M3) without futher configurations.
+*/
+#define CIRCLE_MAC_OS   1
+#endif
+
 /* Set up various machine-specific things based on the values determined from 
  * configure and conf.h. */
 
@@ -78,7 +96,7 @@
 #include <strings.h>
 #endif
 
-#if     (defined (STDC_HEADERS) || defined (__GNU_LIBRARY__))
+#if     (defined (STDC_HEADERS) || defined (__GNU_LIBRARY__) || defined(CIRCLE_MAC_OS))
 #include <stdlib.h>
 
 #else   /* No standard headers.  */
@@ -88,9 +106,8 @@
 #endif
 
 extern char *malloc(), *calloc(), *realloc();
-extern void free ();
-
-extern void abort (), exit ();
+extern void free();
+extern void abort(), exit();
 
 #endif  /* Standard headers.  */
 
@@ -150,8 +167,10 @@ extern void abort (), exit ();
 #include <sys/errno.h>
 #endif
 
+#ifndef CIRCLE_MAC_OS
 #ifdef HAVE_CRYPT_H
 #include <crypt.h>
+#endif
 #endif
 
 #ifdef TIME_WITH_SYS_TIME
@@ -434,8 +453,10 @@ struct in_addr {
    char *strerror(int errnum);
 #endif
 
+#ifndef CIRCLE_MAC_OS
 #ifdef NEED_STRLCPY_PROTO
    size_t strlcpy(char *dest, const char *src, size_t copylen);
+#endif
 #endif
 
 #ifdef NEED_SYSTEM_PROTO


### PR DESCRIPTION
### Pull Request Description

- Changes the `sysdep.h` file to ensure that the code will compile on modern macOS systems.
- Organizes the `Makefile.in` file so that it takes all **.c** files from the /src directory and compiles them in alphabetical order.
- Creates `Makefile.macOS` and `conf.h.macOS` to simplify copying when compiling for macOS.
- Adds macOS temporary files to the `.gitignore` file.

### Tested on

    - macOS 10.13: High Sierra - September 25, 2017 (Latest: 10.13.6)
    - macOS 10.14: Mojave - September 24, 2018 (Latest: 10.14.6)
    - macOS 10.15: Catalina - October 7, 2019 (Latest: 10.15.7)
    - macOS 11: Big Sur - November 12, 2020 (Latest: 11.7.10)
    - macOS 12: Monterey - October 25, 2021 (Latest: 12.7)
    - macOS 13: Ventura - November 7, 2022 (Latest: 13.7)
    - macOS 14: Sonoma - November 7, 2023 (Latest: 14.3)

  This changes works on Apple Silicon Chips (M1, M2, M3) without futher configurations.
