### PR TITLE
Fix bug in process_output

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -1596,7 +1596,7 @@ static int process_output(struct descriptor_data *t)
     result = write_to_descriptor(t->descriptor, osb);
 
   if (result < 0) {	/* Oops, fatal error. Bye! */
-    close_socket(t);
+//    close_socket(t); // close_socket is called after return of negative result
     return (-1);
   } else if (result == 0)	/* Socket buffer full. Try later. */
     return (0);


### PR DESCRIPTION
Based on error report from JTP in the tbamud forums. If an attacker was able to start a session and then break the connection, the  process_output function would fail. This would trigger two calls to close_socket on the same descriptor. This in turn results in a double free on the character struct.