### PR TITLE
Added a new trigger type for mobs, called "Damage", that triggers every

### DIFF
--- a/src/constants.c
+++ b/src/constants.c
@@ -877,6 +877,7 @@ const char *trig_types[] = {
   "Door",
   "UNUSED",
   "Time",
+	"Damage",
   "\n"
 };
 

--- a/src/dg_olc.h
+++ b/src/dg_olc.h
@@ -16,7 +16,7 @@
 
 #include "dg_scripts.h"
 
-#define NUM_TRIG_TYPE_FLAGS		20
+#define NUM_TRIG_TYPE_FLAGS		21
 
 /* Submodes of TRIGEDIT connectedness. */
 #define TRIGEDIT_MAIN_MENU              0

--- a/src/dg_scripts.h
+++ b/src/dg_scripts.h
@@ -71,6 +71,7 @@
 #define MTRIG_DOOR             (1 << 17)     /* door manipulated in room   */
 
 #define MTRIG_TIME             (1 << 19)     /* trigger based on game hour */
+#define MTRIG_DAMAGE           (1 << 20)     /* trigger whenever mob is damaged */
 
 /* obj trigger types */
 #define OTRIG_GLOBAL           (1 << 0)	     /* unused                     */
@@ -263,6 +264,7 @@ void time_wtrigger(room_data *room);
 
 int login_wtrigger(struct room_data *room, char_data *actor);
 
+int damage_mtrigger(char_data *ch, char_data *victim, int dam, int attacktype);
 /* function prototypes from dg_scripts.c */
 ACMD(do_attach) ;
 ACMD(do_detach);

--- a/src/dg_triggers.c
+++ b/src/dg_triggers.c
@@ -552,6 +552,33 @@ int cast_mtrigger(char_data *actor, char_data *ch, int spellnum)
   return 1;
 }
 
+int damage_mtrigger(char_data *actor, char_data *victim, int dam, int attacktype)
+{
+  trig_data *t;
+  char buf[MAX_INPUT_LENGTH];
+
+  if (victim == NULL)
+    return dam;
+
+  if (!SCRIPT_CHECK(victim, MTRIG_DAMAGE) || AFF_FLAGGED(victim, AFF_CHARM))
+    return dam;
+
+  for (t = TRIGGERS(SCRIPT(victim)); t; t = t->next) {
+    if (TRIGGER_CHECK(t, MTRIG_DAMAGE) &&
+        (rand_number(1, 100) <= GET_TRIG_NARG(t))) {
+      ADD_UID_VAR(buf, t, char_script_id(actor), "actor", 0);
+      ADD_UID_VAR(buf, t, char_script_id(victim), "victim", 0);
+      sprintf(buf, "%d", dam);
+      add_var(&GET_TRIG_VARS(t), "damage", buf, 0);
+      add_var(&GET_TRIG_VARS(t), "attacktype", skill_name(attacktype), 0);
+      return script_driver(&victim, t, MOB_TRIGGER, TRIG_NEW);
+    }
+  }
+
+  return dam;
+}
+
+
 int leave_mtrigger(char_data *actor, int dir)
 {
   trig_data *t;

--- a/src/fight.c
+++ b/src/fight.c
@@ -620,6 +620,11 @@ int damage(struct char_data *ch, struct char_data *victim, int dam, int attackty
   if (!IS_NPC(victim) && ((GET_LEVEL(victim) >= LVL_IMMORT) && PRF_FLAGGED(victim, PRF_NOHASSLE)))
     dam = 0;
 
+  dam = damage_mtrigger(ch, victim, dam, attacktype);
+  if (dam == -1) {
+  	return (0);
+  }
+
   if (victim != ch) {
     /* Start the attacker fighting the victim */
     if (GET_POS(ch) > POS_STUNNED && (FIGHTING(ch) == NULL))


### PR DESCRIPTION
time the mob is harmed, through any means.

Valid return values: 
-1: prevents damage from occurring. Will also prevent a fight from starting.
0: forces a miss.
>0 : the damage the mob will endure.

Available variables:
%actor%: the one doing the damage
%victim%: typically the same as %self% - the one being attacked %damage%: the damage inflicted. Always a non-negative number. %attacktype%: The attack type. Will be UNDEFINED when hitting with a weapon.