### PR TITLE
Minor tweak to fix unlimited liquid containers.

### DIFF
--- a/src/act.item.c
+++ b/src/act.item.c
@@ -873,7 +873,7 @@ ACMD(do_drink)
     send_to_char(ch, "Your stomach can't contain anymore!\r\n");
     return;
   }
-  if (GET_OBJ_VAL(temp, 1) < 1) {
+  if ((GET_OBJ_VAL(temp, 1) < 1) && (GET_OBJ_VAL(temp, 0) != -1)) {
     send_to_char(ch, "It is empty.\r\n");
     return;
   }


### PR DESCRIPTION
A fix was made on commit 08374524 which took care of water containers showing as empty. I am not sure what changed prior that caused the previously-working code there to no longer function, but it appears that change did break unlimited liquid containers. I had a fountain in one of my zones that was always showing as empty because it was set to unlimited (-1).

I have not extensively tested this but it did fix my problem. My personal project is based on v3.68 and I can't currently build the latest upstream rev. If this fountain/container problem has been fixed by some other means then please disregard. Thanks!