### PR TITLE
Potential fix for code scanning alert no. 73: Potential use after free

### DIFF
--- a/src/dg_triggers.c
+++ b/src/dg_triggers.c
@@ -246,7 +246,8 @@ void entry_memory_mtrigger(char_data *ch)
   for (actor = world[IN_ROOM(ch)].people; actor && SCRIPT_MEM(ch);
        actor = actor->next_in_room) {
     if (actor!=ch && SCRIPT_MEM(ch)) {
-      for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); mem = mem->next) {
+      for (mem = SCRIPT_MEM(ch); mem && SCRIPT_MEM(ch); ) {
+        struct script_memory *next_mem = mem->next;
         if (char_script_id(actor)==mem->id) {
           struct script_memory *prev;
           if (mem->cmd) command_interpreter(ch, mem->cmd);
@@ -271,6 +272,7 @@ void entry_memory_mtrigger(char_data *ch)
           if (mem->cmd) free(mem->cmd);
           free(mem);
         }
+        mem = next_mem;
       } /* for (mem =..... */
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/73](https://github.com/tbamud/tbamud/security/code-scanning/73)

General fix: when deleting the current node during list traversal, store `next = mem->next` before `free(mem)`, then continue iteration from `next`. Do not let loop control read fields from a freed node.

Best minimal fix in `src/dg_triggers.c` (shown region):  
- Change the inner `for` loop so it does not use `mem = mem->next` in the loop header.  
- Introduce `next_mem` temporary pointer.  
- At start of each iteration, set `next_mem = mem->next`.  
- After potential deletion/free, set `mem = next_mem`.  
This preserves existing behavior while removing use-after-free risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
