### PR TITLE
Potential fix for code scanning alert no. 70: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/src/shop.c
+++ b/src/shop.c
@@ -1052,7 +1052,7 @@ static void read_line(FILE *shop_f, const char *string, void *data)
 {
   char buf[READ_SIZE];
 
-  if (!get_line(shop_f, buf) || !sscanf(buf, string, data)) {
+  if (!get_line(shop_f, buf) || sscanf(buf, string, data) != 1) {
     log("SYSERR: Error in shop #%d, near '%s' with '%s'", SHOP_NUM(top_shop), buf, string);
     exit(1);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/70](https://github.com/tbamud/tbamud/security/code-scanning/70)

To fix this safely without changing intended functionality, update the `sscanf` return-value check in `read_line` to require exactly one successful conversion for this helper’s current usage pattern.

- **General fix:** For `scanf`-like calls, compare return value to the expected number of matched items (or check `< expected`) instead of using truthiness/nonzero checks.
- **Best concrete fix here:** In `src/shop.c` at `read_line` (around line 1055), replace `!sscanf(buf, string, data)` with `sscanf(buf, string, data) != 1`.
- This preserves behavior for malformed lines (still logs + exits), and makes failure handling explicit for both `0` and negative returns.
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
