### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request_target:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/1](https://github.com/tbamud/tbamud/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/build.yml` so the workflow does not inherit potentially broad defaults.  
Best minimal fix without changing behavior: set workflow-level permissions to:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only build steps, and applies to all jobs unless overridden later.

Edit location: directly under the `on:` block (before `jobs:`), or at the start of the `build` job. Workflow-level is cleaner here since there is only one job shown.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
