### PR TITLE
Potential fix for code scanning alert no. 2: Redundant null check due to previous dereference

### DIFF
--- a/src/act.social.c
+++ b/src/act.social.c
@@ -56,7 +56,7 @@ ACMD(do_action)
   if (!action->char_found)
     *arg = '\0';
 
-  if (action->char_found && argument)
+  if (action->char_found)
     one_argument(argument, arg);
   else
     *arg = '\0';


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/2](https://github.com/tbamud/tbamud/security/code-scanning/2)

General fix: ensure null checks happen before any dereference, or remove null checks that are impossible/redundant based on earlier dereferences.

Best fix here (minimal functional change): in `src/act.social.c`, inside `do_action`, remove `&& argument` from the condition at line 59:
- From `if (action->char_found && argument)`  
- To `if (action->char_found)`

Why this is best: `argument` was already dereferenced at line 43, so checking it later adds no safety and can confuse maintainers/static analysis. This keeps behavior the same on all existing reachable paths and resolves the warning without changing control flow meaningfully.

No new methods, definitions, or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
