### PR TITLE
Potential fix for code scanning alert no. 3: Redundant null check due to previous dereference

### DIFF
--- a/src/dg_variables.c
+++ b/src/dg_variables.c
@@ -465,7 +465,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
  * will return the number of bags of gold.
  * Addition inspired by Jamie Nelson */
       else if (!str_cmp(var, "findmob")) {
-        if (!field || !*field || !subfield || !*subfield) {
+        if (!*field || !subfield || !*subfield) {
           script_log("findmob.vnum(mvnum) - illegal syntax");
           strcpy(str, "0");
         } else {


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/3](https://github.com/tbamud/tbamud/security/code-scanning/3)

General fix: when a pointer is dereferenced earlier in the same guaranteed path, later NULL checks on that same pointer should be removed (or moved before first dereference if safety is needed). Here, functionality already assumes `field` is non-NULL by line 295.

Best minimal fix (no behavior change): in `src/dg_variables.c`, in the `findmob` branch around line 468, remove the redundant `!field` condition and keep the emptiness/content checks:
- Change `if (!field || !*field || !subfield || !*subfield)`  
- To `if (!*field || !subfield || !*subfield)`

No imports, new methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
