### PR TITLE
Potential fix for code scanning alert no. 4: Redundant null check due to previous dereference

### DIFF
--- a/src/dg_variables.c
+++ b/src/dg_variables.c
@@ -486,7 +486,7 @@ void find_replacement(void *go, struct script_data *sc, trig_data *trig,
       }
       /* Addition inspired by Jamie Nelson. */
       else if (!str_cmp(var, "findobj")) {
-        if (!field || !*field || !subfield || !*subfield) {
+        if (!*field || !subfield || !*subfield) {
           script_log("findobj.vnum(ovnum) - illegal syntax");
           strcpy(str, "0");
         } else {


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/4](https://github.com/tbamud/tbamud/security/code-scanning/4)

To fix this without changing functionality, remove the redundant `!field` check in the `findobj` branch condition, since `field` has already been dereferenced earlier in the same function (`if (!*field)`).

Best single change:
- **File:** `src/dg_variables.c`
- **Region:** `else if (!str_cmp(var, "findobj"))` block around line 489
- Replace:
  - `if (!field || !*field || !subfield || !*subfield) {`
- With:
  - `if (!*field || !subfield || !*subfield) {`

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
