### PR TITLE
Potential fix for code scanning alert no. 5: Redundant null check due to previous dereference

### DIFF
--- a/src/improved-edit.c
+++ b/src/improved-edit.c
@@ -421,7 +421,7 @@ void parse_edit_action(int command, char *string, struct descriptor_data *d)
         strncat(buf, *d->str, sizeof(buf) - strlen(buf) - 1);
       *s = temp;
       strncat(buf, buf2, sizeof(buf) - strlen(buf) - 1);
-      if (s && *s)
+      if (*s)
         strncat(buf, s, sizeof(buf) - strlen(buf) - 1);
       RECREATE(*d->str, char, strlen(buf) + 3);
 


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/5](https://github.com/tbamud/tbamud/security/code-scanning/5)

To fix this without changing behavior, remove the redundant null test `s &&` at line 424 and keep only `*s` check.

Best minimal change in `src/improved-edit.c`:
- In `PARSE_INSERT` branch, after `strncat(buf, buf2, ...)`, replace:
  - `if (s && *s)`
- with:
  - `if (*s)`

Why this is best:
- It preserves existing functionality (append remaining suffix only when non-empty).
- It aligns with proven non-null invariant established earlier (`s == NULL` already handled, and `*s` used prior).
- It resolves CodeQL warning directly with minimal risk and no API or logic changes.
- No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
