### PR TITLE
Potential fix for code scanning alert no. 55: Call to alloca in a loop

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -2102,20 +2102,25 @@ static void ExecuteMSDPPair( descriptor_t *apDescriptor, const char *apVariable,
                         !strcmp(apDescriptor->pProtocol->pVariables[i]->pValueString, "Unknown") )
                      {
                         /* Store the new value if it's valid */
-                        char *pBuffer = alloca(VariableNameTable[i].Max+1);
+                        char *pBuffer = malloc(VariableNameTable[i].Max + 1);
                         int j; /* Loop counter */
 
-                        for ( j = 0; j < VariableNameTable[i].Max && *apValue != '\0'; ++apValue )
+                        if ( pBuffer != NULL )
                         {
-                           if ( isprint(*apValue) )
-                              pBuffer[j++] = *apValue;
-                        }
-                        pBuffer[j++] = '\0';
+                           for ( j = 0; j < VariableNameTable[i].Max && *apValue != '\0'; ++apValue )
+                           {
+                              if ( isprint(*apValue) )
+                                 pBuffer[j++] = *apValue;
+                           }
+                           pBuffer[j++] = '\0';
 
-                        if ( j >= VariableNameTable[i].Min )
-                        {
-                           free(apDescriptor->pProtocol->pVariables[i]->pValueString);
-                           apDescriptor->pProtocol->pVariables[i]->pValueString = AllocString(pBuffer);
+                           if ( j >= VariableNameTable[i].Min )
+                           {
+                              free(apDescriptor->pProtocol->pVariables[i]->pValueString);
+                              apDescriptor->pProtocol->pVariables[i]->pValueString = AllocString(pBuffer);
+                           }
+
+                           free(pBuffer);
                         }
                      }
                   }


### PR DESCRIPTION
Potential fix for [https://github.com/tbamud/tbamud/security/code-scanning/55](https://github.com/tbamud/tbamud/security/code-scanning/55)

General fix: avoid `alloca` in loops; use heap allocation (`malloc`/`free`) or allocate once outside the loop.

Best fix here (minimal behavior change): in `src/protocol.c` at the block around line 2105, replace:
- `char *pBuffer = alloca(VariableNameTable[i].Max+1);`
with:
- `char *pBuffer = malloc(VariableNameTable[i].Max + 1);`
- guard for `NULL` allocation
- keep existing sanitization/copy logic
- `free(pBuffer)` after `AllocString` path and also on short-value path.

No new project dependency is needed. `malloc/free` are standard C library functions (already used in file via `free(...)`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
