### PR TITLE
[DG Scripts: Syntax Highlight v2]: Rewrite trigedit syntax highlighting and script formatting

### DIFF
--- a/lib/text/news
+++ b/lib/text/news
@@ -7,6 +7,11 @@ NEW COMMANDS AND NEW MUD BEHAVIOR:
 **  Check out the latest news and information on the tbaMUD codebase at
     @Chttp://tbamud.com@n.
 
+**  Trigedit now colour codes trigger scripts by meaning, and /f validates
+    the whole trigger before formatting: unmatched blocks, broken expressions
+    and unknown commands are reported by line, and nothing is changed until
+    they are fixed.
+
 **  A new "areas" command will list open areas and their suggested levels. 
 
 **  New preference editor for players: prefedit. Use it to enable two new

--- a/src/dg_objcmd.c
+++ b/src/dg_objcmd.c
@@ -830,6 +830,34 @@ static const struct obj_command_info obj_cmd_info[] = {
     { "\n", 0, 0 }        /* this must be last */
 };
 
+/**
+ * @brief Checks whether a token is accepted by the object command dispatcher.
+ *
+ * @details Reproduces the lookup done by obj_command_interpreter() -- a
+ * prefix match of the token against each table entry -- so abbreviations are
+ * recognised exactly like they are at runtime. Index 0 ("RESERVED") is
+ * skipped. Used by the trigedit syntax modules to classify script lines.
+ *
+ * @param command First token of a script line.
+ * @return true when the object dispatcher would accept the token.
+ */
+bool dg_obj_command_exists(const char *command)
+{
+    if (!command || !*command) {
+        return false;
+    }
+
+    size_t length = strlen(command);
+
+    for (int i = 1; *obj_cmd_info[i].command != '\n'; i++) {
+        if (!strncmp(obj_cmd_info[i].command, command, length)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /* This is the command interpreter used by objects, called by script_driver. */
 void obj_command_interpreter(obj_data *obj, char *argument)
 {

--- a/src/dg_olc.c
+++ b/src/dg_olc.c
@@ -182,11 +182,156 @@ void trigedit_setup_existing(struct descriptor_data *d, int rtrg_num)
   OLC_VAL(d) = 0;  /* Has changed flag. (It hasn't so far, we just made it.) */
 }
 
+/**
+ * @brief Counts how many lines (separated by \\r or \\n) a text holds.
+ *
+ * @param string Text to count; null or empty returns 0.
+ * @return Number of non-empty lines found.
+ */
+static int count_trigger_lines(const char *string)
+{
+    if (!string || !*string) {
+        return 0;
+    }
+
+    char *copy = strdup(string);
+    char *line = strtok(copy, "\r\n");
+    int count = 0;
+
+    while (line != NULL) {
+        count++;
+        line = strtok(NULL, "\r\n");
+    }
+
+    free(copy);
+    return count;
+}
+
+/**
+ * @brief Copies the first lines of a script for display on the menu.
+ *
+ * @details Recognises CRLF, CR and LF without cutting a line in half. A limit
+ * of zero or less copies the whole script. The caller must free the returned
+ * buffer.
+ *
+ * @param commands Original script text.
+ * @param line_limit Maximum number of lines; zero or negative removes the limit.
+ * @param truncated Receives true when part of the script was left out of the copy.
+ * @return Allocated copy of the selected text, or NULL if commands is null or the allocation fails.
+ */
+static char *copy_trigger_lines_for_menu(const char *commands, int line_limit, bool *truncated)
+{
+    const char *end;
+    char *copy;
+    size_t length;
+    int lines = 0;
+
+    if (truncated) {
+        *truncated = FALSE;
+    }
+
+    if (!commands) {
+        return NULL;
+    }
+
+    if (line_limit <= 0) {
+        return strdup(commands);
+    }
+
+    end = commands;
+
+    while (*end && lines < line_limit) {
+        while (*end && *end != '\r' && *end != '\n') {
+            end++;
+        }
+
+        if (*end == '\r' && end[1] == '\n') {
+            end += 2;
+        } else if (*end) {
+            end++;
+        }
+
+        lines++;
+    }
+
+    if (truncated) {
+        *truncated = *end != '\0';
+    }
+
+    length = (size_t)(end - commands);
+    copy = (char *)malloc(length + 1);
+
+    if (!copy) {
+        return NULL;
+    }
+
+    memcpy(copy, commands, length);
+    copy[length] = '\0';
+
+    return copy;
+}
+
+/**
+ * @brief Prints the trigger command list on the trigedit main menu.
+ *
+ * @details Honours DG_SHOW_COMMANDS_ON_MENU (show the script at all),
+ * DG_HIGHLIGHT_ON_MENU (apply semantic highlighting) and
+ * DG_LINE_LIMIT_ON_MENU (cap how many lines are shown). Choice 6 stays the
+ * command editor, which always shows the whole script.
+ *
+ * @param d Descriptor being shown the menu.
+ * @param trig Trigger being edited; its attach_type drives the highlighting.
+ */
+static void trigedit_disp_commands(struct descriptor_data *d, struct trig_data *trig)
+{
+  bool truncated = FALSE;
+  char *menu_commands;
+
+  get_char_colors(d->character);
+
+  if (!DG_SHOW_COMMANDS_ON_MENU)
+    return;
+
+  if (!OLC_STORAGE(d) || !*OLC_STORAGE(d)) {
+    write_to_output(d, "%sThis trigger has no commands.%s\r\n", cyn, nrm);
+    return;
+  }
+
+  menu_commands = copy_trigger_lines_for_menu(OLC_STORAGE(d), DG_LINE_LIMIT_ON_MENU, &truncated);
+
+  if (!menu_commands) {
+    write_to_output(d, "\tRCould not prepare the commands for display.\tn\r\n");
+    return;
+  }
+
+  if (DG_HIGHLIGHT_ON_MENU) {
+    char *highlighted = command_syntax_highlighting(menu_commands, trig->attach_type);
+
+    if (highlighted) {
+      write_to_output(d, "%s", highlighted);
+      free(highlighted);
+    } else {
+      write_to_output(d, "%s", menu_commands);
+    }
+  } else {
+    write_to_output(d, "%s%s%s", cyn, menu_commands, nrm);
+  }
+
+  if (truncated) {
+    write_to_output(d, "%s(%s%d%s line%s shown; choose '6' to see them all.)%s\r\n",
+                    grn, yel, DG_LINE_LIMIT_ON_MENU, grn,
+                    DG_LINE_LIMIT_ON_MENU == 1 ? "" : "s", nrm);
+  }
+
+  free(menu_commands);
+}
+
 static void trigedit_disp_menu(struct descriptor_data *d)
 {
   struct trig_data *trig = OLC_TRIG(d);
   char *attach_type;
   char trgtypes[256];
+  int trigger_lines;
 
   get_char_colors(d->character);
 
@@ -203,6 +348,8 @@ static void trigedit_disp_menu(struct descriptor_data *d)
 
   clear_screen(d);
 
+  trigger_lines = count_trigger_lines(OLC_STORAGE(d));
+
   write_to_output(d,
   "Trigger Editor [%s%d%s]\r\n\r\n"
   "%s1)%s Name         : %s%s\r\n"
@@ -210,10 +357,7 @@ static void trigedit_disp_menu(struct descriptor_data *d)
   "%s3)%s Trigger types: %s%s\r\n"
   "%s4)%s Numeric Arg  : %s%d\r\n"
   "%s5)%s Arguments    : %s%s\r\n"
-  "%s6)%s Commands:\r\n%s%s\r\n"
-  "%sW%s) Copy Trigger\r\n"
-  "%sQ)%s Quit\r\n"
-  "Enter Choice :",
+  "%s6)%s Commands     : %s%d line%s%s\r\n",
 
   grn, OLC_NUM(d), nrm, 			/* vnum on the title line */
   grn, nrm, yel, GET_TRIG_NAME(trig),		/* name                   */
@@ -221,7 +365,16 @@ static void trigedit_disp_menu(struct descriptor_data *d)
   grn, nrm, yel, trgtypes,			/* greet/drop/etc         */
   grn, nrm, yel, trig->narg,			/* numeric arg            */
   grn, nrm, yel, trig->arglist?trig->arglist:"",/* strict arg             */
-  grn, nrm, cyn, OLC_STORAGE(d),		/* the command list       */
+  grn, nrm, yel, trigger_lines,			/* command line count     */
+  trigger_lines == 1 ? "" : "s", nrm);
+
+  trigedit_disp_commands(d, trig);
+
+  write_to_output(d,
+  "\r\n"
+  "%sW)%s Copy Trigger\r\n"
+  "%sQ)%s Quit\r\n"
+  "Enter Choice :",
   grn, nrm, grn, nrm);                          /* quit colors            */
 
   OLC_MODE(d) = TRIGEDIT_MAIN_MENU;
@@ -259,230 +412,6 @@ static void trigedit_disp_types(struct descriptor_data *d)
                      cyn, bitbuf, nrm);
 
 }
-
-/****************************************************************************************
- DG Scripts Code Syntax Highlighting
- Created by Victor Almeida (aka Stoneheart) in Brazil 
- from BrMUD:Tormenta www.tormenta.com.br
- 
- License: Attribution 4.0 International (CC BY 4.0)
- http://creativecommons.org/licenses/by/4.0/
- 
- You are free to:
- Share — copy and redistribute the material in any medium or format
- Adapt — remix, transform, and build upon the material for any purpose, even commercially.
- 
- The licensor cannot revoke these freedoms as long as you follow the license terms.
- 
- Under the following terms:
- Attribution — You must give appropriate credit, provide a link to the license, and indicate
- if changes were made. You may do so in any reasonable manner, but not in any way that
- suggests the licensor endorses you or your use.
- *****************************************************************************************/
-
-// Change a string for another without memory bugs
-static char *str_replace(const char *string, const char *substr, const char *replacement) {
-    char *tok = NULL;
-    char *newstr = NULL;
-    char *oldstr = NULL;
-    char *head = NULL;
-    
-    // if either substr or replacement is NULL, duplicate string a let caller handle it
-    if (substr == NULL || replacement == NULL) {
-        return strdup (string);
-    }
-    
-    newstr = strdup (string);
-    head = newstr;
-    while ((tok = strstr(head, substr))) {
-        oldstr = newstr;
-        newstr = malloc(strlen(oldstr) - strlen(substr) + strlen (replacement) + 1);
-        // Failed to alloc mem, free old string and return NULL
-        if (newstr == NULL) {
-            free (oldstr);
-            return NULL;
-        }
-        memcpy (newstr, oldstr, tok - oldstr);
-        memcpy (newstr + (tok - oldstr), replacement, strlen (replacement));
-        memcpy (newstr + (tok - oldstr) + strlen(replacement), tok + strlen (substr), strlen (oldstr) - strlen (substr) - (tok - oldstr));
-        memset (newstr + strlen (oldstr) - strlen(substr) + strlen (replacement) , 0, 1 );
-
-        // move back head right after the last replacement
-        head = newstr + (tok - oldstr) + strlen( replacement);
-        free (oldstr);
-    }
-    
-    return newstr;
-}
-
-// You can easily change the color code (\tn) to the old one (@n or &n)
-#define SYNTAX_TERMS        49
-static const char *syntax_color_replacement[SYNTAX_TERMS][2] =
-{
-    // script logic (10)
-    { "if",             "\tcif\tn" }, // 0
-    { "elseif",         "\tcelseif\tn" },
-    { "else",           "\tcelse\tn" },
-    { "end",            "\tcend\tn" },
-    { "switch",         "\tcswitch\tn" },
-    { "case",           "\tccase\tY" },
-    { "default",        "\tcdefault\tn" },
-    { "break",          "\tcbreak\tn" },
-    { "while",          "\tcwhile\tn" },
-    { "done",           "\tcdone\tn" },
-    // commands (15)
-    { "eval ",          "\tceval\tY " }, //10
-    { "nop ",           "\tcnop\tY " },
-    { "extract ",       "\tcextract\tY " },
-    { "dg_letter ",     "\tcdg_letter\tY " },
-    { "makeuid ",       "\tcmakeuid\tY " },
-    { "dg_cast ",       "\tcdg_cast\tY " },
-    { "dg_affect ",     "\tcdg_affect\tY " },
-    { "global ",        "\tcglobal\tY " },
-    { "context ",       "\tccontext\tY " },
-    { "remote ",        "\tcremot\tce\tY " },
-    { "rdelete ",       "\tcrdelete\tY " }, // 20
-    { "set ",           "\tcset\tY " },
-    { "unset ",         "\tcunset\tY " },
-    { "attach ",        "\tcattach\tY " },
-    { "detach ",        "\tcdetach\tY " },
-    // stopping (3)
-    { "wait",           "\trwait"   },
-    { "return",         "\trreturn" },
-    { "halt",           "\trhalt"   },
-    // operands (12)
-    { "||",             "\tc||\tY" },
-    { "&&",             "\tc&&\tY" },
-    { "==",             "\tc==\tY" }, // 30
-    { "!=",             "\tc!=\tY" },
-    { "<=",             "\tc<=\tY" },
-    { ">=",             "\tc>=\tY" },
-    { "< ",             "\tc< \tY" },
-    { "> ",             "\tc> \tY" },
-    { "/=",             "\tc/=\tY" },
-    { "!",              "\tc!\tn"  },
-    { "(",              "\tc(\tY"  },
-    { ")",              "\tc)\tn"  },
-    // corrective (4)
-    { "\tc!\tn=",       "\tc!=\tY" }, // 40
-    { "%s\tcend\tn%",    "\tm%\tosend%\tn" },
-    { "%\tc)",          "\tm%\tc)" },
-    { ")\tn%",          ")\tm%"},
-    // variables (5)
-    { "% ",             "\tm%\tn " },
-    { "%,",             "\tm%\tn," },
-    { "%.",             "\tm%\tn." },
-    { "%:",             "\tm%\tn:" },
-    { "%",              "\tm%\to" } // 48
-};
-
-// Here you can include more commands usually used in your triggers
-#define COMMAND_TERMS   36
-static const char *command_color_replacement[COMMAND_TERMS][2] =
-{
-    // Mob specific commands (25)
-    { "mlog",            "\tcmlog\tn" },  // 0
-    { "masound",         "\tcmasound\tn" },
-    { "mkill",           "\tcmkill\tn" },
-    { "mjunk",           "\tcmjunk\tn" },
-    { "mdamage",         "\tcmdamage\tn" },
-    { "mdoor",           "\tcmdoor\tn" },
-    { "mecho",           "\tcmecho\tn" },
-    { "mrecho",          "\tcmrecho\tn" },
-    { "mechoaround",     "\tcmechoaround\tn" },
-    { "msend",           "\tcmsend\tn" },
-    { "mload",           "\tcmload\tn" }, // 10
-    { "mpurge",          "\tcmpurge\tn" },
-    { "mgoto",           "\tcmgoto\tn" },
-    { "mteleport",       "\tcmteleport\tn" },
-    { "mforce",          "\tcmforce\tn" },
-    { "mhunt",           "\tcmhunt\tn" },
-    { "mremember",       "\tcmremember\tn" },
-    { "mforget",         "\tcmforget\tn" },
-    { "mtransform",      "\tcmtransform\tn" },
-    { "mzoneecho",       "\tcmzoneecho\tn" },
-    { "mfollow",         "\tcmfollow\tn" }, // 20
-    { "mquest",          "\tcmquest\tn" },
-    { "malign",          "\tcmalign\tn" },
-    { "mcast",           "\tcmcast\tn" },
-    { "mdismiss",        "\tcmdismiss\tn" },
-    // common commands (10)
-    { "drop ",           "\tcdrop \tn" },
-    { "emote ",          "\tcemote \tn" },
-    { "give ",           "\tcgive \tn" },
-    { "say ",            "\tcsay \tn" },
-    { "tell ",           "\tctell \tn" },
-    { "unlock ",         "\tcunlock \tn" }, // 30
-    { "lock ",           "\tclock \tn" },
-    { "open ",           "\tcopen \tn" },
-    { "close ",          "\tcclose \tn" },
-    { "junk ",          "\tcjunk \tn" } // 34
-};
-
-
-static void script_syntax_highlighting(struct descriptor_data *d, char *string)
-{
-    ACMD(do_action);
-    char buffer[MAX_STRING_LENGTH] = "";
-    char *newlist, *curtok;
-    
-    size_t i;
-
-    // Parse script text line by line
-    newlist = strdup(string);
-    for (curtok = strtok(newlist, "\r\n"); curtok; curtok = strtok(NULL, "\r\n")) {
-        char *line = strdup(curtok);
-        bool comment = FALSE;
-        
-        // Find if is a comment
-        for (i=0;i <= strlen(line);i++) {
-            // skip initial spaces
-            if (strncmp(&line[i], " ", 1) == 0) {
-                continue;
-            }
-            // is a comment, highlight
-            if (strncmp(&line[i], "*", 1) == 0) {
-                line = str_replace(line, "*", "\tg*");
-                comment = TRUE;
-                break;
-            }
-            // not a comment
-            else {
-                comment = FALSE;
-                break;
-            }
-        }
-        
-        // Highlight lines
-        if (!comment) {
-            // Syntax replacement
-            for (i=0;i < SYNTAX_TERMS;i++) {
-                line = str_replace(line, syntax_color_replacement[i][0], syntax_color_replacement[i][1]);
-            }
-
-            // Commands replacement
-            for (i=0;i < COMMAND_TERMS;i++) {
-                line = str_replace(line, command_color_replacement[i][0], command_color_replacement[i][1]);
-            }
-        
-            // Socials replacement (experimental)
-            int cmd;
-            for (cmd = 0; *complete_cmd_info[cmd].command != '\n'; cmd++) {
-                if (complete_cmd_info[cmd].command_pointer == do_action) {
-                    char replace_social[MAX_INPUT_LENGTH];
-                    snprintf(replace_social, MAX_INPUT_LENGTH, "\tc%s\tn", complete_cmd_info[cmd].command);
-                    line = str_replace(line, complete_cmd_info[cmd].command, replace_social);
-                }
-            }
-        }
-
-        strncat(buffer, line, sizeof(buffer) - strlen(buffer) - 1);
-        strncat(buffer, "\tn\r\n", sizeof(buffer) - strlen(buffer) - 1);
-    }
-    
-    page_string(d, buffer, TRUE);
-}
-/****************************************************************************************/
 
 void trigedit_parse(struct descriptor_data *d, char *arg)
 {
@@ -527,7 +456,7 @@ void trigedit_parse(struct descriptor_data *d, char *arg)
          d->backstr = NULL;
          if (OLC_STORAGE(d)) {
            clear_screen(d);
-           script_syntax_highlighting(d, OLC_STORAGE(d));
+           dg_olc_script_syntax_highlighting(d, OLC_STORAGE(d));
            d->backstr = strdup(OLC_STORAGE(d));
          }
          d->str = &OLC_STORAGE(d);
@@ -1084,112 +1013,4 @@ void trigedit_string_cleanup(struct descriptor_data *d, int terminator)
       trigedit_disp_menu(d);
       break;
   }
-}
-
-int format_script(struct descriptor_data *d)
-{
-  char nsc[MAX_CMD_LENGTH], *t, line[READ_SIZE];
-  char *sc;
-  size_t len = 0, nlen = 0, llen = 0;
-  int indent = 0, indent_next = FALSE, line_num = 0, ret, i; // Declare i here
-  int block_stack[READ_SIZE]; // Stack to track block types
-  int stack_top = -1; // Initialize stack as empty
-  int switch_indent[READ_SIZE]; // Array to track switch indent levels
-  int switch_top = -1; // Index for switch_indent array
-  int case_indent = 0; // Track indent for case blocks
-  int in_switch = 0; // Flag to indicate if we're inside a switch block
-
-  if (!d->str || !*d->str)
-    return FALSE;
-
-  sc = strdup(*d->str); // Work on a copy
-  t = strtok(sc, "\n\r");
-  *nsc = '\0';
-
-  while (t) {
-    line_num++;
-    skip_spaces(&t);
-
-    if (!strn_cmp(t, "switch ", 7)) {
-      indent_next = TRUE;
-      stack_top++;
-      block_stack[stack_top] = 's'; // 's' for switch
-      switch_top++;
-      switch_indent[switch_top] = indent; // Save current indent level for switch
-      in_switch++; // We're entering a switch block
-    } else if (!strn_cmp(t, "case", 4) || !strn_cmp(t, "default", 7)) {
-      if (in_switch > 0) { // If we're inside a switch
-        indent = switch_indent[switch_top] + 1; // Indent cases one level under switch
-        indent_next = TRUE; // Indent the next line after case
-        case_indent = indent; // Save indent for case block
-      }
-    } else if (!strn_cmp(t, "if ", 3) || !strn_cmp(t, "while ", 6)) {
-      indent_next = TRUE;
-      stack_top++;
-      block_stack[stack_top] = 'l'; // 'l' for loop or conditional
-    } else if (!strn_cmp(t, "end", 3) || !strn_cmp(t, "done", 4)) {
-      if (stack_top < 0) {
-        write_to_output(d, "Unmatched 'end' or 'done' (line %d)!\r\n", line_num);
-        free(sc);
-        return FALSE;
-      }
-      if (block_stack[stack_top] == 's') {
-        indent = switch_indent[switch_top]; // Reset to the exact indent level where switch was declared
-        switch_top--; // Decrease switch stack if ending a switch
-        case_indent = 0; // Reset case indent since we're leaving the switch
-        in_switch--; // We're leaving a switch block
-      } else {
-        indent--; // For other blocks like while
-      }
-      stack_top--;
-      indent_next = FALSE; // Reset for next line
-    } else if (!strn_cmp(t, "else", 4)) {
-      if (stack_top < 0 || block_stack[stack_top] != 'l') {
-        write_to_output(d, "Unmatched 'else' (line %d)!\r\n", line_num);
-        free(sc);
-        return FALSE;
-      }
-      indent--; // Reduce indent for else, then increment for next statement
-      indent_next = TRUE;
-    } else if (!strn_cmp(t, "break", 5)) {
-      if (stack_top < 0 || (block_stack[stack_top] != 's' && block_stack[stack_top] != 'l')) {
-        write_to_output(d, "Break not in case or loop (line %d)!\r\n", line_num);
-        free(sc);
-        return FALSE;
-      }
-      indent = case_indent + 1; // Indent break one level deeper than case
-      indent_next = FALSE; // Ensure no automatic increase for next line after break
-    }
-
-    *line = '\0';
-    for (nlen = 0, i = 0; i < indent; i++) {
-      strncat(line, "  ", sizeof(line) - strlen(line) - 1);
-      nlen += 2;
-    }
-
-    ret = snprintf(line + nlen, sizeof(line) - nlen, "%s\r\n", t);
-    llen = (size_t)ret;
-    if (ret < 0 || llen + nlen + len > d->max_str - 1) {
-      write_to_output(d, "String too long, formatting aborted\r\n");
-      free(sc);
-      return FALSE;
-    }
-    len = len + nlen + llen;
-    strcat(nsc, line);  /* strcat OK, size checked above */
-
-    if (indent_next) {
-      indent++;
-      indent_next = FALSE;
-    }
-    t = strtok(NULL, "\n\r");
-  }
-
-  if (stack_top >= 0)
-    write_to_output(d, "Unmatched block statements ignored.\r\n");
-
-  free(*d->str);
-  *d->str = strdup(nsc);
-  free(sc);
-
-  return TRUE;
 }

--- a/src/dg_olc.h
+++ b/src/dg_olc.h
@@ -15,6 +15,7 @@
 #define _DG_OLC_H_
 
 #include "dg_scripts.h"
+#include "dg_olc_syntax.h"
 
 #define NUM_TRIG_TYPE_FLAGS		21
 

--- a/src/dg_olc_syntax.c
+++ b/src/dg_olc_syntax.c
@@ -1,0 +1,396 @@
+/**
+ * @file dg_olc_syntax.c
+ * @brief Core tokenisation and classification of DG scripts.
+ *
+ * @details Holds the growable buffers, the structural command tables and the
+ * line parser shared by trigedit's highlighting and formatting.
+ *
+ * @note DG Scripts Code Syntax Format and Highlighting.
+ * Developed by Victor Augusto Borges Dias de Almeida (aka Stoneheart) in Brazil.
+ * Created and tested on BrMUD Engine, ported to tbaMUD.
+ * BrMUD: Tormenta - play.brmud.com.br 4000
+ *
+ * @author Victor Augusto Borges Dias de Almeida (Stoneheart) (BrMUD Engine, 2002-2026).
+ * @copyright Victor Augusto Borges Dias de Almeida (C) 2002 - 2026.
+ * @date 2026-06-26
+ */
+
+#include <stdint.h>
+
+#include "conf.h"
+#include "sysdep.h"
+#include "structs.h"
+
+#include "dg_olc_syntax.h"
+#include "dg_scripts.h"
+#include "oasis.h"
+#include "utils.h"
+
+/**
+ * @brief Table of the DG Scripts flow control keywords, terminated by an entry with name = NULL.
+ */
+static const struct dg_command_spec control_commands[] = {
+    { "if",         true,   true  },
+    { "elseif",     true,   true  },
+    { "else",       false,  false },
+    { "end",        false,  false },
+    { "while",      true,   true  },
+    { "switch",     true,   true  },
+    { "case",       true,   true  },
+    { "default",    false,  false },
+    { "break",      false,  false },
+    { "done",       false,  false },
+    { NULL,         false,  false }
+};
+
+/**
+ * @brief Table of the generic script commands, terminated by name = NULL.
+ * @details Holds the commands that are not specific to mobs, objects or rooms.
+ */
+static const struct dg_command_spec generic_commands[] = {
+    { "eval",       true,   true  },
+    { "nop",        true,   false },
+    { "extract",    true,   false },
+    { "dg_letter",  true,   false },
+    { "makeuid",    true,   false },
+    { "dg_cast",    true,   false },
+    { "dg_affect",  true,   false },
+    { "global",     true,   false },
+    { "context",    true,   false },
+    { "remote",     true,   false },
+    { "rdelete",    true,   false },
+    { "return",     true,   true  },
+    { "set",        true,   false },
+    { "unset",      true,   false },
+    { "wait",       true,   false },
+    { "attach",     true,   false },
+    { "detach",     true,   false },
+    { "halt",       false,  false },
+    { NULL,         false,  false }
+};
+
+/**
+ * @brief Duplicates a string into a freshly allocated buffer.
+ *
+ * @param source Text to duplicate; NULL returns NULL.
+ * @return New buffer holding the copy, or NULL if source is null or the allocation fails.
+ */
+char *dg_syntax_str_dup(const char *source)
+{
+    char *copy;
+    size_t length;
+
+    if (!source) {
+        return NULL;
+    }
+
+    length = strlen(source) + 1;
+    /* The cast keeps MEMORY_DEBUG builds quiet: zmalloc.h redefines malloc()
+     * to a function returning unsigned char *. */
+    copy = (char *)malloc(length);
+
+    if (copy) {
+        memcpy(copy, source, length);
+    }
+
+    return copy;
+}
+
+/**
+ * @brief Ensures room for required bytes, including the null terminator.
+ *
+ * @details Does nothing when the current capacity is already enough.
+ * Otherwise doubles the capacity starting at 128 until it reaches required
+ * (guarded against size_t overflow) and reallocates buffer->data.
+ *
+ * @param buffer Buffer to grow.
+ * @param required Total bytes needed (including the null terminator).
+ * @return true if the buffer already had or now has enough room; false if the reallocation fails.
+ */
+static bool syntax_buffer_reserve(struct syntax_text_buffer *buffer, size_t required)
+{
+    if (required <= buffer->capacity) {
+        return true;
+    }
+
+    size_t capacity = buffer->capacity ? buffer->capacity : 128;
+
+    while (capacity < required) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = required;
+            break;
+        }
+        capacity *= 2;
+    }
+
+    char *expanded = (char *)realloc(buffer->data, capacity);
+
+    if (!expanded) {
+        return false;
+    }
+
+    buffer->data = expanded;
+    buffer->capacity = capacity;
+
+    return true;
+}
+
+/**
+ * @brief Appends len bytes to the buffer and keeps it null-terminated.
+ *
+ * @param buffer Destination buffer.
+ * @param text Start of the bytes to copy (does not need to be null-terminated).
+ * @param len Number of bytes to copy from text.
+ * @return true if the bytes were appended; false on invalid argument, overflow or allocation failure.
+ */
+bool dg_syntax_buffer_append_n(struct syntax_text_buffer *buffer, const char *text, size_t len)
+{
+    if (!buffer || !text || len > SIZE_MAX - buffer->length - 1
+        || !syntax_buffer_reserve(buffer, buffer->length + len + 1)) {
+        return false;
+    }
+
+    memcpy(buffer->data + buffer->length, text, len);
+    buffer->length += len;
+    buffer->data[buffer->length] = '\0';
+
+    return true;
+}
+
+/**
+ * @brief Appends a whole string to the buffer.
+ *
+ * @param buffer Destination buffer.
+ * @param text Null-terminated text to copy.
+ * @return true if the text was appended; false if text is null or dg_syntax_buffer_append_n() fails.
+ */
+bool dg_syntax_buffer_append(struct syntax_text_buffer *buffer, const char *text)
+{
+    return text && dg_syntax_buffer_append_n(buffer, text, strlen(text));
+}
+
+/**
+ * @brief Copies a range of characters into a null-terminated buffer.
+ *
+ * @param start Start of the range to copy.
+ * @param len Number of characters to copy.
+ * @return New buffer with the null-terminated copy, or NULL if start is null, len is invalid or the allocation fails.
+ */
+char *dg_syntax_copy_text_range(const char *start, size_t len)
+{
+    if (!start || len == SIZE_MAX) {
+        return NULL;
+    }
+
+    char *copy = (char *)malloc(len + 1);
+
+    if (!copy) {
+        return NULL;
+    }
+
+    memcpy(copy, start, len);
+    copy[len] = '\0';
+    return copy;
+}
+
+/**
+ * @brief Copies the command token of a parsed line into a null-terminated buffer.
+ *
+ * @details Shared by the classification (which needs the command to query the
+ * dispatchers) and by the format_script() error messages (which only need a
+ * readable excerpt). When the token does not fit in dest the copy is
+ * truncated and the function returns false.
+ *
+ * @param parsed Line already analysed by dg_syntax_parse_line().
+ * @param dest Destination buffer.
+ * @param dest_size Size of dest in bytes, including the null terminator.
+ * @return true if the whole token fit; false if it was truncated or some argument is invalid.
+ */
+bool dg_syntax_copy_command(const struct dg_parsed_line *parsed, char *dest, size_t dest_size)
+{
+    if (!parsed || !parsed->first || !dest || !dest_size) {
+        return false;
+    }
+
+    size_t length = parsed->command_length < dest_size ? parsed->command_length : dest_size - 1;
+
+    memcpy(dest, parsed->first, length);
+    dest[length] = '\0';
+
+    return length == parsed->command_length;
+}
+
+/**
+ * @brief Compares a token that is not null-terminated against a command name.
+ *
+ * @param token Start of the token within the original line.
+ * @param token_length Length of the token.
+ * @param name Null-terminated command name to compare against.
+ * @return true if token and name have the same length and contents.
+ */
+bool dg_syntax_token_equals(const char *token, size_t token_length, const char *name)
+{
+    return token && name && strlen(name) == token_length && !strn_cmp(token, name, token_length);
+}
+
+/**
+ * @brief Looks a token up in a table of control or generic commands.
+ *
+ * @param commands Table to search (control_commands[] or generic_commands[]), terminated by name = NULL.
+ * @param token Start of the token to look for.
+ * @param token_length Length of the token.
+ * @return Pointer to the matching entry, or NULL if none matches.
+ */
+static const struct dg_command_spec *find_command_spec(
+    const struct dg_command_spec *commands, const char *token, size_t token_length)
+{
+    for (size_t i = 0; commands[i].name; i++) {
+        if (dg_syntax_token_equals(token, token_length, commands[i].name)) {
+            return &commands[i];
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Returns the type of the trigger being edited, or DG_TRIGGER_ANY outside trigedit.
+ *
+ * @param d Descriptor being inspected.
+ * @return MOB_TRIGGER, OBJ_TRIGGER or WLD_TRIGGER if d is editing a trigger
+ * with a valid attach_type; DG_TRIGGER_ANY otherwise.
+ */
+int dg_syntax_descriptor_trigger_type(const struct descriptor_data *d)
+{
+    if (d && d->olc && OLC_TRIG(d)
+    && OLC_TRIG(d)->attach_type >= MOB_TRIGGER
+    && OLC_TRIG(d)->attach_type <= WLD_TRIGGER) {
+        return OLC_TRIG(d)->attach_type;
+    }
+
+    return DG_TRIGGER_ANY;
+}
+
+/**
+ * @brief Queries the real dispatchers to classify a specific command.
+ *
+ * @details Uses dg_mob_command_exists()/dg_obj_command_exists()/
+ * dg_wld_command_exists()/dg_player_command_exists() (the very dispatch
+ * tables used at runtime, not a list of its own) to decide the category;
+ * when trigger_type is a specific type, only the matching table (plus the
+ * player/social one) is queried.
+ *
+ * @param command Command word to classify.
+ * @param trigger_type MOB_TRIGGER, OBJ_TRIGGER, WLD_TRIGGER or DG_TRIGGER_ANY.
+ * @return The matching category, or DG_LINE_UNKNOWN if no dispatcher recognises the command.
+ */
+static enum dg_line_kind classify_entity_command(const char *command, int trigger_type)
+{
+    if (!command || !*command) {
+        return DG_LINE_UNKNOWN;
+    }
+
+    if ((trigger_type == DG_TRIGGER_ANY || trigger_type == MOB_TRIGGER)
+        && dg_mob_command_exists(command)) {
+        return DG_LINE_MOB;
+    }
+
+    if ((trigger_type == DG_TRIGGER_ANY || trigger_type == OBJ_TRIGGER)
+        && dg_obj_command_exists(command)) {
+        return DG_LINE_OBJ;
+    }
+
+    if ((trigger_type == DG_TRIGGER_ANY || trigger_type == WLD_TRIGGER)
+        && dg_wld_command_exists(command)) {
+        return DG_LINE_WLD;
+    }
+
+    if ((trigger_type == DG_TRIGGER_ANY || trigger_type == MOB_TRIGGER)
+        && dg_player_command_exists(command)) {
+        return DG_LINE_PLAYER;
+    }
+
+    return DG_LINE_UNKNOWN;
+}
+
+/**
+ * @brief Splits off the first token and classifies the line without touching the source.
+ *
+ * @details Skips leading spaces and recognises empty and comment lines (first
+ * non-space character `*`) before extracting the command. Classification
+ * follows this order: control_commands[], then generic_commands[], then the
+ * `%` prefix (dynamic command), then classify_entity_command().
+ *
+ * @param line Script line to analyse.
+ * @param trigger_type MOB_TRIGGER, OBJ_TRIGGER, WLD_TRIGGER or DG_TRIGGER_ANY.
+ * @param parsed Output struct, filled in with the result.
+ * @return false only if line or parsed are null; true in every other case, even with kind DG_LINE_UNKNOWN.
+ */
+bool dg_syntax_parse_line(const char *line, int trigger_type, struct dg_parsed_line *parsed)
+{
+    char command[MAX_INPUT_LENGTH];
+
+    if (!line || !parsed) {
+        return false;
+    }
+
+    memset(parsed, 0, sizeof(*parsed));
+    parsed->first = line;
+
+    while (isspace((unsigned char)*parsed->first)) {
+        parsed->first++;
+    }
+
+    if (!*parsed->first) {
+        parsed->kind = DG_LINE_EMPTY;
+        parsed->argument = parsed->first;
+        return true;
+    }
+
+    if (*parsed->first == '*') {
+        parsed->kind = DG_LINE_COMMENT;
+        parsed->argument = parsed->first + strlen(parsed->first);
+        return true;
+    }
+
+    while (parsed->first[parsed->command_length]
+        && !isspace((unsigned char)parsed->first[parsed->command_length])) {
+        parsed->command_length++;
+    }
+
+    parsed->argument = parsed->first + parsed->command_length;
+
+    while (*parsed->argument && isspace((unsigned char)*parsed->argument)) {
+        parsed->argument++;
+    }
+
+    parsed->spec = find_command_spec(control_commands, parsed->first, parsed->command_length);
+
+    if (parsed->spec) {
+        parsed->kind = DG_LINE_CONTROL;
+        return true;
+    }
+
+    parsed->spec = find_command_spec(generic_commands, parsed->first, parsed->command_length);
+
+    if (parsed->spec) {
+        parsed->kind = DG_LINE_GENERIC;
+        return true;
+    }
+
+    if (*parsed->first == '%') {
+        parsed->kind = DG_LINE_DYNAMIC;
+        return true;
+    }
+
+    if (!dg_syntax_copy_command(parsed, command, sizeof(command))) {
+        /* No DG command comes close to MAX_INPUT_LENGTH: if it did not fit,
+         * it does not exist. */
+        parsed->kind = DG_LINE_UNKNOWN;
+        return true;
+    }
+
+    parsed->kind = classify_entity_command(command, trigger_type);
+
+    return true;
+}

--- a/src/dg_olc_syntax.h
+++ b/src/dg_olc_syntax.h
@@ -1,0 +1,98 @@
+/**
+ * @file dg_olc_syntax.h
+ * @brief Public interface and shared structures of the DG script analyser.
+ *
+ * @details The declarations in the first section are used by the rest of the
+ * MUD. The shared section is meant for the dg_olc_syntax*.c modules only; it
+ * stays in this file as an architectural decision of the project.
+ *
+ * @note DG Scripts Code Syntax Format and Highlighting.
+ * Developed by Victor Augusto Borges Dias de Almeida (aka Stoneheart) in Brazil.
+ * Created and tested on BrMUD Engine, ported to tbaMUD.
+ * BrMUD: Tormenta - play.brmud.com.br 4000
+ *
+ * @author Victor Augusto Borges Dias de Almeida (Stoneheart) (BrMUD Engine, 2002-2026).
+ * @copyright Victor Augusto Borges Dias de Almeida (C) 2002 - 2026.
+ * @date 2026-06-26
+ */
+
+#ifndef DG_OLC_SYNTAX_H
+#define DG_OLC_SYNTAX_H
+
+#include <stddef.h>
+
+struct descriptor_data;
+
+/* Public interface. */
+char *command_syntax_highlighting(const char *string, int trigger_type);
+void dg_olc_script_syntax_highlighting(struct descriptor_data *d, char *string);
+int format_script(struct descriptor_data *d);
+
+#define DG_TRIGGER_ANY              (-1)    /**< Accepts commands of any trigger type. */
+
+#define DG_SHOW_COMMANDS_ON_MENU    1       /**< Show the script text on the trigedit main menu. */
+#define DG_HIGHLIGHT_ON_MENU        1       /**< Apply semantic highlighting to the script shown on the menu. */
+#define DG_LINE_LIMIT_ON_MENU       16      /**< Cap the number of script lines shown on the menu; 0 = no limit. */
+
+/**
+ * @brief Text buffer that grows on demand, used to build highlighted/formatted strings.
+ *
+ * @details Starts zeroed ({ NULL, 0, 0 }); syntax_buffer_reserve() reallocates
+ * data in powers of two as needed. Always kept null-terminated by the
+ * dg_syntax_buffer_append*() functions.
+ */
+struct syntax_text_buffer {
+    char *data;      /**< Allocated buffer (may be NULL if nothing was written yet). */
+    size_t length;   /**< Bytes used in data, not counting the null terminator. */
+    size_t capacity; /**< Bytes allocated in data. */
+};
+
+/**
+ * @brief Classification of a DG script line, used for colouring and validation.
+ */
+enum dg_line_kind {
+    DG_LINE_EMPTY,    /**< Blank line, or whitespace only. */
+    DG_LINE_COMMENT,  /**< Comment line; first non-space character is '*'. */
+    DG_LINE_CONTROL,  /**< Flow control keyword (if/while/switch/case/...), see control_commands[]. */
+    DG_LINE_GENERIC,  /**< Generic script command (eval/set/wait/...), see generic_commands[]. */
+    DG_LINE_MOB,      /**< `m*` command recognised through dg_mob_command_exists(). */
+    DG_LINE_OBJ,      /**< `o*` command recognised through dg_obj_command_exists(). */
+    DG_LINE_WLD,      /**< `w*` command recognised through dg_wld_command_exists(). */
+    DG_LINE_PLAYER,   /**< Normal player/social command recognised through dg_player_command_exists(). */
+    DG_LINE_DYNAMIC,  /**< Line starting with '%'; the command is resolved at runtime by a variable. */
+    DG_LINE_UNKNOWN   /**< No table nor dispatcher recognised the command. */
+};
+
+/**
+ * @brief Describes how a control/generic command keyword must be validated and highlighted.
+ *
+ * @details Used by the control_commands[] and generic_commands[] tables,
+ * searched by find_command_spec().
+ */
+struct dg_command_spec {
+    const char *name;            /**< Keyword (e.g. "if", "eval"). */
+    bool requires_argument;      /**< If true, format_script() reports an error when the argument is empty. */
+    bool expression_argument;    /**< If true, the argument is treated as an expression. */
+};
+
+/**
+ * @brief Result of tokenising a script line, filled in by dg_syntax_parse_line().
+ */
+struct dg_parsed_line {
+    const char *first;          /**< Start of the command within the line, after leading spaces. */
+    const char *argument;       /**< Start of the argument, after the command and the spaces that follow it. */
+    size_t command_length;      /**< Length of the command token pointed to by first. */
+    enum dg_line_kind kind;     /**< Line classification. */
+    const struct dg_command_spec *spec;     /**< Matching specification, or NULL. */
+};
+
+char *dg_syntax_str_dup(const char *source);
+char *dg_syntax_copy_text_range(const char *start, size_t len);
+bool dg_syntax_buffer_append_n(struct syntax_text_buffer *buffer, const char *text, size_t len);
+bool dg_syntax_buffer_append(struct syntax_text_buffer *buffer, const char *text);
+bool dg_syntax_token_equals(const char *token, size_t token_length, const char *name);
+bool dg_syntax_parse_line(const char *line, int trigger_type, struct dg_parsed_line *parsed);
+bool dg_syntax_copy_command(const struct dg_parsed_line *parsed, char *dest, size_t dest_size);
+int dg_syntax_descriptor_trigger_type(const struct descriptor_data *d);
+
+#endif /* DG_OLC_SYNTAX_H */

--- a/src/dg_olc_syntax_format.c
+++ b/src/dg_olc_syntax_format.c
@@ -1,0 +1,446 @@
+/**
+ * @file dg_olc_syntax_format.c
+ * @brief Structural validation and formatting of DG scripts inside trigedit.
+ *
+ * @details Validates expressions and blocks, lists every problem found, and
+ * only replaces the original text when the reindentation is safe.
+ *
+ * @note DG Scripts Code Syntax Format and Highlighting.
+ * Developed by Victor Augusto Borges Dias de Almeida (aka Stoneheart) in Brazil.
+ * Created and tested on BrMUD Engine, ported to tbaMUD.
+ * BrMUD: Tormenta - play.brmud.com.br 4000
+ *
+ * @author Victor Augusto Borges Dias de Almeida (Stoneheart) (BrMUD Engine, 2002-2026).
+ * @copyright Victor Augusto Borges Dias de Almeida (C) 2002 - 2026.
+ * @date 2026-06-26
+ */
+
+#include "conf.h"
+#include "sysdep.h"
+#include "structs.h"
+
+#include "comm.h"
+#include "dg_olc_syntax.h"
+#include "dg_scripts.h"
+#include "utils.h"
+
+/* Only GCC-compatible compilers understand the printf format attribute; on
+ * everything else the call sites simply lose the compile-time check. */
+#if defined(__GNUC__)
+#define DG_SYNTAX_PRINTF(fmt, args) __attribute__ ((format(printf, fmt, args)))
+#else
+#define DG_SYNTAX_PRINTF(fmt, args)
+#endif
+
+/**
+ * @brief Type of control block tracked by the format_script() indentation stack.
+ */
+enum dg_format_block_type {
+    DG_FORMAT_IF,      /**< Block opened by 'if', closed by 'end'. */
+    DG_FORMAT_WHILE,   /**< Block opened by 'while', closed by 'done'. */
+    DG_FORMAT_SWITCH   /**< Block opened by 'switch', closed by 'done'. */
+};
+
+/**
+ * @brief One level of the stack of blocks left open while format_script() formats/validates.
+ */
+struct dg_format_block {
+    enum dg_format_block_type type; /**< Block type. */
+    size_t line;        /**< Line (1-based) where the block was opened, used in error messages. */
+    bool case_active;   /**< True inside the body of a 'case' or 'default'. */
+    bool else_seen;     /**< True if this 'if' already had an 'else'; a second one is an error. */
+    bool default_seen;  /**< True if this 'switch' already had a 'default'. */
+};
+
+/**
+ * @brief Computes the current indentation, including active case bodies.
+ *
+ * @param stack Stack of open blocks.
+ * @param depth Number of valid levels in stack.
+ * @return Indentation level: depth plus one for each switch with case_active on the stack.
+ */
+static size_t dg_format_indent(const struct dg_format_block *stack, size_t depth)
+{
+    size_t indent = depth;
+
+    for (size_t i = 0; i < depth; i++) {
+        if (stack[i].type == DG_FORMAT_SWITCH && stack[i].case_active) {
+            indent++;
+        }
+    }
+
+    return indent;
+}
+
+/**
+ * @brief Returns true if there is an open while or switch that a break can target.
+ *
+ * @param stack Stack of open blocks.
+ * @param depth Number of valid levels in stack.
+ * @return true if any level of the stack, innermost to outermost, is DG_FORMAT_WHILE or DG_FORMAT_SWITCH.
+ */
+static bool dg_format_has_break_target(const struct dg_format_block *stack, size_t depth)
+{
+    while (depth > 0) {
+        depth--;
+        if (stack[depth].type == DG_FORMAT_WHILE || stack[depth].type == DG_FORMAT_SWITCH) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Validates quotes, parentheses, variables and boolean operators of an expression.
+ *
+ * @details Walks the expression of an if/while/switch/return checking that
+ * double quotes, variable `%` signs and parentheses are balanced, and that
+ * `&`/`|` always appear doubled (`&&`/`||`). Stops at the first problem found.
+ *
+ * @note A `&`/`|` followed by an alphanumeric character is accepted as a
+ * colour code (`&Y`, `&n`) rather than an incomplete operator. The editor's
+ * `/t` command converts the whole script between tabbed codes and `&X`, so
+ * without this exception any coloured text inside an `eval` would block the
+ * formatting of the script.
+ *
+ * @param expression Expression text to validate.
+ * @return First problem found, or NULL if the expression looks well formed.
+ */
+static const char *validate_expression(const char *expression)
+{
+    int parentheses = 0;
+    bool in_quote = false, in_variable = false;
+
+    for (const char *p = expression; *p; p++) {
+        if (*p == '\\' && in_quote && p[1]) {
+            p++;
+            continue;
+        }
+        if (*p == '"' && !in_variable) {
+            in_quote = !in_quote;
+            continue;
+        }
+        if (*p == '%' && !in_quote) {
+            in_variable = !in_variable;
+            continue;
+        }
+        if (in_quote || in_variable) {
+            continue;
+        }
+        if (*p == '(') {
+            parentheses++;
+        } else if (*p == ')' && --parentheses < 0) {
+            return "unmatched closing parenthesis";
+        } else if ((*p == '&' || *p == '|') && p[1] == *p) {
+            p++;
+        } else if ((*p == '&' || *p == '|') && !isalnum((unsigned char)p[1])) {
+            return "incomplete boolean operator; use && or ||";
+        }
+    }
+
+    if (in_quote) {
+        return "unterminated double quote";
+    }
+
+    if (in_variable) {
+        return "variable missing its closing '%'";
+    }
+
+    if (parentheses > 0) {
+        return "unmatched opening parenthesis";
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Appends one problem to the script validation report.
+ * @param d Descriptor that receives the report.
+ * @param error_count Total problem counter; incremented by this function.
+ * @param line Script line the problem relates to.
+ * @param format Formatted description of the problem.
+ *
+ * @warning The printf format attribute is mandatory: validate_expression()
+ * returns messages that contain `%` and must be passed as an argument to
+ * "%s", never as the format itself.
+ */
+static void DG_SYNTAX_PRINTF(4, 5) report_syntax_error(
+    struct descriptor_data *d,
+    size_t *error_count,
+    size_t line,
+    const char *format,
+    ...
+) {
+    char message[512];
+    va_list args;
+
+    if (!d || !error_count || !format) {
+        return;
+    }
+
+    if (*error_count == 0) {
+        write_to_output(d, "\tOProblems found in the script:\r\n\n");
+    }
+
+    va_start(args, format);
+    vsnprintf(message, sizeof(message), format, args);
+    va_end(args);
+    write_to_output(d, "  \trLine %-3lu\tn: %s.\r\n", (unsigned long)line, message);
+    (*error_count)++;
+}
+
+/**
+ * @brief Reindents and validates the structure and commands of the script being edited.
+ *
+ * @details Lists every problem found in a single pass and keeps the original
+ * text whenever there is any error. Command validation honours the
+ * MOB/OBJ/WLD type of the trigger.
+ *
+ * @param d Descriptor whose *d->str holds the script to reindent/validate.
+ * @return TRUE if the script was reindented successfully and *d->str was
+ * replaced; FALSE if there was any syntax/structure error (nothing is
+ * changed) or an allocation failure.
+ */
+int format_script(struct descriptor_data *d)
+{
+    struct syntax_text_buffer formatted = { NULL, 0, 0 };
+    struct dg_format_block *stack = NULL;
+    const char *cursor, *line_end;
+    size_t depth = 0, error_count = 0, line_number = 0, max_depth, output_limit;
+    bool output_overflow = false;
+    int trigger_type;
+
+    if (!d || !d->str || !*d->str) {
+        return FALSE;
+    }
+
+    /* Every open block consumes at least one line, so the number of line
+     * separators plus one is a safe ceiling for the depth - and orders of
+     * magnitude smaller than the size of the script in bytes. */
+    max_depth = 1;
+
+    for (cursor = *d->str; *cursor; cursor++) {
+        if (*cursor == '\r' || *cursor == '\n') {
+            max_depth++;
+        }
+    }
+
+    stack = (struct dg_format_block *)calloc(max_depth, sizeof(*stack));
+
+    if (!stack) {
+        write_to_output(d, "Out of memory while formatting the script.\r\n");
+        return FALSE;
+    }
+
+    /* string_add() reserves 3 bytes for "\r\n\0"; without that slack the
+     * editor would refuse the next line typed after the formatting. */
+    output_limit = d->max_str < (size_t)MAX_CMD_LENGTH ? d->max_str : (size_t)MAX_CMD_LENGTH;
+
+    if (output_limit <= 3) {
+        write_to_output(d, "The editor has no room for the formatted script.\r\n");
+        free(stack);
+        return FALSE;
+    }
+
+    trigger_type = dg_syntax_descriptor_trigger_type(d);
+    cursor = *d->str;
+
+    while (*cursor) {
+        struct dg_parsed_line parsed;
+        char *raw_line;
+        const char *line;
+        size_t line_length, indent;
+        bool activate_case = false;
+
+        line_number++;
+        line_end = cursor;
+
+        while (*line_end && *line_end != '\r' && *line_end != '\n') {
+            line_end++;
+        }
+        line_length = (size_t)(line_end - cursor);
+        raw_line = dg_syntax_copy_text_range(cursor, line_length);
+
+        if (!raw_line) {
+            goto allocation_failure;
+        }
+
+        line = raw_line;
+
+        while (isspace((unsigned char)*line)) {
+            line++;
+        }
+
+        if (!dg_syntax_parse_line(line, trigger_type, &parsed)) {
+            free(raw_line);
+            goto allocation_failure;
+        }
+
+        if (parsed.kind == DG_LINE_UNKNOWN) {
+            char command[64];
+
+            if (!dg_syntax_copy_command(&parsed, command, sizeof(command))) {
+                memcpy(command + sizeof(command) - 4, "...", 4);
+            }
+
+            report_syntax_error(d, &error_count, line_number,
+                "unknown command '%s', or invalid for this trigger type", command);
+        }
+
+        if (parsed.spec && parsed.spec->requires_argument && !*parsed.argument) {
+            report_syntax_error(d, &error_count, line_number,
+                "command '%s' is missing its argument", parsed.spec->name);
+        } else if (parsed.spec && parsed.spec->expression_argument) {
+            const char *expression_error = validate_expression(parsed.argument);
+
+            if (expression_error) {
+                report_syntax_error(d, &error_count, line_number, "%s", expression_error);
+            }
+        }
+
+        indent = dg_format_indent(stack, depth);
+        if (parsed.kind == DG_LINE_CONTROL && dg_syntax_token_equals(parsed.first, parsed.command_length, "elseif")) {
+            if (!depth || stack[depth - 1].type != DG_FORMAT_IF) {
+                report_syntax_error(d, &error_count, line_number, "'elseif' without a matching 'if'");
+            } else {
+                if (stack[depth - 1].else_seen) {
+                    report_syntax_error(d, &error_count, line_number, "'elseif' after 'else'");
+                }
+                indent--;
+            }
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && dg_syntax_token_equals(parsed.first, parsed.command_length, "else")) {
+            if (!depth || stack[depth - 1].type != DG_FORMAT_IF) {
+                report_syntax_error(d, &error_count, line_number, "'else' without a matching 'if'");
+            } else {
+                if (stack[depth - 1].else_seen) {
+                    report_syntax_error(d, &error_count, line_number, "more than one 'else' in the same 'if'");
+                } else {
+                    stack[depth - 1].else_seen = true;
+                }
+                indent--;
+            }
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && dg_syntax_token_equals(parsed.first, parsed.command_length, "end")) {
+            if (!depth || stack[depth - 1].type != DG_FORMAT_IF) {
+                report_syntax_error(d, &error_count, line_number, "'end' without a matching 'if'");
+            } else {
+                depth--;
+                indent = dg_format_indent(stack, depth);
+            }
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && dg_syntax_token_equals(parsed.first, parsed.command_length, "done")) {
+            if (!depth || (stack[depth - 1].type != DG_FORMAT_WHILE
+                && stack[depth - 1].type != DG_FORMAT_SWITCH)) {
+                report_syntax_error(d, &error_count, line_number,
+                    "'done' without a matching 'while' or 'switch'");
+            } else {
+                depth--;
+                indent = dg_format_indent(stack, depth);
+            }
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && (dg_syntax_token_equals(parsed.first, parsed.command_length, "case")
+                || dg_syntax_token_equals(parsed.first, parsed.command_length, "default"))) {
+            bool is_default = dg_syntax_token_equals(parsed.first, parsed.command_length, "default");
+
+            if (!depth || stack[depth - 1].type != DG_FORMAT_SWITCH) {
+                report_syntax_error(d, &error_count, line_number, "'case/default' outside a 'switch'");
+            } else if (stack[depth - 1].default_seen) {
+                report_syntax_error(d, &error_count, line_number,
+                    is_default ? "more than one 'default' in the same 'switch'" : "'case' after 'default'");
+            } else {
+                stack[depth - 1].case_active = false;
+                stack[depth - 1].default_seen = is_default;
+                indent = dg_format_indent(stack, depth);
+                activate_case = true;
+            }
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && dg_syntax_token_equals(parsed.first, parsed.command_length, "break")) {
+            if (!dg_format_has_break_target(stack, depth)) {
+                report_syntax_error(d, &error_count, line_number, "'break' outside a 'while' or 'switch'");
+            } else if (depth && stack[depth - 1].type == DG_FORMAT_SWITCH
+                && stack[depth - 1].case_active) {
+                /* Line the 'break' up with the 'case', but keep the body
+                 * active: whatever comes next stays at the case indentation. */
+                indent--;
+            }
+        }
+
+        if (!output_overflow) {
+            if (*line) {
+                for (size_t i = 0; i < indent; i++) {
+                    if (!dg_syntax_buffer_append(&formatted, "  ")) {
+                        free(raw_line);
+                        goto allocation_failure;
+                    }
+                }
+                if (!dg_syntax_buffer_append(&formatted, line)) {
+                    free(raw_line);
+                    goto allocation_failure;
+                }
+            }
+            if (!dg_syntax_buffer_append(&formatted, "\r\n")) {
+                free(raw_line);
+                goto allocation_failure;
+            }
+            if (formatted.length + 3 > output_limit) {
+                report_syntax_error(d, &error_count, line_number,
+                    "the formatted text would exceed the allowed limit");
+                output_overflow = true;
+            }
+        }
+
+        if (activate_case) {
+            stack[depth - 1].case_active = true;
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && dg_syntax_token_equals(parsed.first, parsed.command_length, "if")) {
+            stack[depth++] = (struct dg_format_block){ DG_FORMAT_IF, line_number, false, false, false };
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && dg_syntax_token_equals(parsed.first, parsed.command_length, "while")) {
+            stack[depth++] = (struct dg_format_block){ DG_FORMAT_WHILE, line_number, false, false, false };
+        } else if (parsed.kind == DG_LINE_CONTROL
+            && dg_syntax_token_equals(parsed.first, parsed.command_length, "switch")) {
+            stack[depth++] = (struct dg_format_block){ DG_FORMAT_SWITCH, line_number, false, false, false };
+        }
+        free(raw_line);
+
+        if (*line_end == '\r' && line_end[1] == '\n') {
+            cursor = line_end + 2;
+        } else if (*line_end) {
+            cursor = line_end + 1;
+        } else {
+            cursor = line_end;
+        }
+    }
+
+    for (size_t i = 0; i < depth; i++) {
+        const char *block_name = stack[i].type == DG_FORMAT_IF ? "if"
+            : stack[i].type == DG_FORMAT_WHILE ? "while" : "switch";
+
+        report_syntax_error(d, &error_count, stack[i].line,
+            "block '%s' was never closed", block_name);
+    }
+
+    if (error_count) {
+        write_to_output(d, "\r\n\tOTotal: \tY%lu\tO problem%s; the script was left unchanged.\tn\r\n",
+            (unsigned long)error_count, error_count == 1 ? "" : "s");
+        goto fail;
+    }
+
+    free(stack);
+    free(*d->str);
+    *d->str = formatted.data ? formatted.data : dg_syntax_str_dup("");
+    return *d->str ? TRUE : FALSE;
+
+allocation_failure:
+    write_to_output(d, "Out of memory while formatting the script.\r\n");
+fail:
+    free(stack);
+
+    if (formatted.data) {
+        free(formatted.data);
+    }
+
+    return FALSE;
+}

--- a/src/dg_olc_syntax_highlight.c
+++ b/src/dg_olc_syntax_highlight.c
@@ -1,0 +1,485 @@
+/**
+ * @file dg_olc_syntax_highlight.c
+ * @brief Semantic highlighting of DG scripts inside trigedit.
+ *
+ * @details Colours commands, variables, strings, numbers, operators and
+ * comments using the classification produced by the syntax core.
+ *
+ * @note DG Scripts Code Syntax Format and Highlighting.
+ * Developed by Victor Augusto Borges Dias de Almeida (aka Stoneheart) in Brazil.
+ * Created and tested on BrMUD Engine, ported to tbaMUD.
+ * BrMUD: Tormenta - play.brmud.com.br 4000
+ *
+ * @author Victor Augusto Borges Dias de Almeida (Stoneheart) (BrMUD Engine, 2002-2026).
+ * @copyright Victor Augusto Borges Dias de Almeida (C) 2002 - 2026.
+ * @date 2026-06-26
+ */
+
+#include "conf.h"
+#include "sysdep.h"
+#include "structs.h"
+
+#include "comm.h"
+#include "dg_olc_syntax.h"
+#include "dg_scripts.h"
+#include "modify.h"
+#include "utils.h"
+
+
+#define DG_COLOR_CONTROL    "\tM"  /**< Flow control keywords. */
+#define DG_COLOR_GENERIC    "\tC"  /**< Generic DG commands. */
+#define DG_COLOR_MOB        "\tG"  /**< Mob-only commands. */
+#define DG_COLOR_OBJ        "\tY"  /**< Object-only commands. */
+#define DG_COLOR_WLD        "\tB"  /**< Room-only commands. */
+#define DG_COLOR_PLAYER     "\tG"  /**< Normal and social commands. */
+#define DG_COLOR_DYNAMIC    "\tm"  /**< Body of a command resolved by a variable. */
+#define DG_COLOR_VARIABLE   "\to"  /**< Body of an expression between percent signs. */
+#define DG_COLOR_DELIMITER  "\tm"  /**< Percent delimiters of commands and variables. */
+#define DG_COLOR_STRING     "\ty"  /**< Strings delimited by double quotes. */
+#define DG_COLOR_NUMBER     "\tY"  /**< Numeric values. */
+#define DG_COLOR_OPERATOR   "\tC"  /**< Operators, in light cyan. */
+#define DG_COLOR_COMMENT    "\tg"  /**< Script comments. */
+#define DG_COLOR_ERROR      "\tR"  /**< Unknown or invalid command. */
+#define DG_COLOR_RESET      "\tn"  /**< Restores the normal colour. */
+
+/**
+ * @brief An operator recognised by the highlighter, with its length precomputed.
+ */
+struct dg_syntax_operator {
+    const char *text;  /**< Operator text. */
+    size_t length;     /**< Length of text, without the null terminator. */
+};
+
+/**
+ * @brief Returns the length of the DG operator starting at text, or zero.
+ *
+ * @details The table mirrors ops[] from eval_lhs_op_rhs() (dg_scripts.c) plus
+ * the parentheses, and is ordered so that two-character operators come before
+ * one-character ones - that way `!=` is never read as `!`.
+ *
+ * @param text Position to test.
+ * @return Length of the recognised operator (1 or 2), or 0 if text does not start with a known operator.
+ */
+static size_t dg_operator_length(const char *text)
+{
+    static const struct dg_syntax_operator operators[] = {
+        { "||", 2 },
+        { "&&", 2 },
+        { "==", 2 },
+        { "!=", 2 },
+        { "<=", 2 },
+        { ">=", 2 },
+        { "/=", 2 },
+        { "+",  1 },
+        { "-",  1 },
+        { "/",  1 },
+        { "*",  1 },
+        { "!",  1 },
+        { "<",  1 },
+        { ">",  1 },
+        { "(",  1 },
+        { ")",  1 },
+        { NULL, 0 }
+    };
+
+    for (size_t i = 0; operators[i].text; i++) {
+        if (!strncmp(text, operators[i].text, operators[i].length)) {
+            return operators[i].length;
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Colours variables, strings, numbers and operators inside arguments.
+ *
+ * @details Does not interpret operators or numbers inside strings. Inside
+ * variables it highlights parentheses and operators, plus the numbers found
+ * between parentheses, restoring the variable colour after each token.
+ * Treats `\` as an escape inside double quotes (copies the next character
+ * without reinterpreting it); outside variables, operators are only coloured
+ * when expression is true.
+ *
+ * @param output Output buffer the coloured argument is appended to.
+ * @param argument Argument text to colour.
+ * @param expression If true, recognises and colours operators (used by if/while/switch/return).
+ * @return true if the argument was fully processed; false on allocation failure.
+ */
+static bool append_highlighted_argument(
+    struct syntax_text_buffer *output,
+    const char *argument,
+    bool expression
+) {
+    bool in_quote = false, in_variable = false, in_variable_quote = false;
+    size_t variable_parenthesis_depth = 0;
+
+    for (const char *p = argument; *p;) {
+        size_t operator_length;
+
+        if (in_quote) {
+            if (*p == '\\' && p[1]) {
+                if (!dg_syntax_buffer_append_n(output, p, 2)) {
+                    return false;
+                }
+                p += 2;
+                continue;
+            }
+
+            if (!dg_syntax_buffer_append_n(output, p, 1)) {
+                return false;
+            }
+
+            if (*p++ == '"') {
+                in_quote = false;
+                if (!dg_syntax_buffer_append(output, DG_COLOR_RESET)) {
+                    return false;
+                }
+            }
+
+            continue;
+        }
+        if (in_variable) {
+            if (in_variable_quote) {
+                if (*p == '\\' && p[1]) {
+                    if (!dg_syntax_buffer_append_n(output, p, 2)) {
+                        return false;
+                    }
+                    p += 2;
+                    continue;
+                }
+
+                if (!dg_syntax_buffer_append_n(output, p, 1)) {
+                    return false;
+                }
+
+                if (*p++ == '"') {
+                    in_variable_quote = false;
+                    if (!dg_syntax_buffer_append(output, DG_COLOR_VARIABLE)) {
+                        return false;
+                    }
+                }
+
+                continue;
+            }
+
+            if (*p == '%') {
+                if (!dg_syntax_buffer_append(output, DG_COLOR_DELIMITER)
+                    || !dg_syntax_buffer_append_n(output, p, 1)
+                    || !dg_syntax_buffer_append(output, DG_COLOR_RESET)) {
+                    return false;
+                }
+                in_variable = false;
+                variable_parenthesis_depth = 0;
+                p++;
+                continue;
+            }
+
+            if (variable_parenthesis_depth && *p == '"') {
+                if (!dg_syntax_buffer_append(output, DG_COLOR_STRING)
+                    || !dg_syntax_buffer_append_n(output, p, 1)) {
+                    return false;
+                }
+                in_variable_quote = true;
+                p++;
+                continue;
+            }
+
+            if (*p == '(' || *p == ')') {
+                if (!dg_syntax_buffer_append(output, DG_COLOR_OPERATOR)
+                    || !dg_syntax_buffer_append_n(output, p, 1)
+                    || !dg_syntax_buffer_append(output, DG_COLOR_VARIABLE)) {
+                    return false;
+                }
+                if (*p == '(') {
+                    variable_parenthesis_depth++;
+                } else if (variable_parenthesis_depth) {
+                    variable_parenthesis_depth--;
+                }
+                p++;
+                continue;
+            }
+
+            operator_length = variable_parenthesis_depth ? dg_operator_length(p) : 0;
+
+            if (operator_length) {
+                if (!dg_syntax_buffer_append(output, DG_COLOR_OPERATOR)
+                    || !dg_syntax_buffer_append_n(output, p, operator_length)
+                    || !dg_syntax_buffer_append(output, DG_COLOR_VARIABLE)) {
+                    return false;
+                }
+                p += operator_length;
+                continue;
+            }
+
+            if (variable_parenthesis_depth && isdigit((unsigned char)*p)) {
+                const char *number_end = p + 1;
+
+                while (isdigit((unsigned char)*number_end)) {
+                    number_end++;
+                }
+                if (!dg_syntax_buffer_append(output, DG_COLOR_NUMBER)
+                    || !dg_syntax_buffer_append_n(output, p, (size_t)(number_end - p))
+                    || !dg_syntax_buffer_append(output, DG_COLOR_VARIABLE)) {
+                    return false;
+                }
+                p = number_end;
+                continue;
+            }
+            if (!dg_syntax_buffer_append_n(output, p, 1)) {
+                return false;
+            }
+            p++;
+            continue;
+        }
+
+        if (*p == '"') {
+            if (!dg_syntax_buffer_append(output, DG_COLOR_STRING)
+                || !dg_syntax_buffer_append_n(output, p, 1)) {
+                return false;
+            }
+            in_quote = true;
+            p++;
+            continue;
+        }
+
+        if (*p == '%') {
+            if (!dg_syntax_buffer_append(output, DG_COLOR_DELIMITER)
+                || !dg_syntax_buffer_append_n(output, p, 1)
+                || !dg_syntax_buffer_append(output, DG_COLOR_VARIABLE)) {
+                return false;
+            }
+            in_variable = true;
+            p++;
+            continue;
+        }
+
+        operator_length = expression ? dg_operator_length(p) : 0;
+
+        if (operator_length) {
+            if (!dg_syntax_buffer_append(output, DG_COLOR_OPERATOR)
+                || !dg_syntax_buffer_append_n(output, p, operator_length)
+                || !dg_syntax_buffer_append(output, DG_COLOR_RESET)) {
+                return false;
+            }
+            p += operator_length;
+            continue;
+        }
+
+        if (isdigit((unsigned char)*p)) {
+            const char *number_end = p + 1;
+
+            while (isdigit((unsigned char)*number_end)) {
+                number_end++;
+            }
+
+            if (!dg_syntax_buffer_append(output, DG_COLOR_NUMBER)
+                || !dg_syntax_buffer_append_n(output, p, (size_t)(number_end - p))
+                || !dg_syntax_buffer_append(output, DG_COLOR_RESET)) {
+                return false;
+            }
+            p = number_end;
+            continue;
+        }
+
+        if (!dg_syntax_buffer_append_n(output, p, 1)) {
+            return false;
+        }
+
+        p++;
+    }
+    return true;
+}
+
+/**
+ * @brief Returns the semantic colour tied to a line category.
+ *
+ * @param kind Line category.
+ * @return Matching DG_COLOR_* constant.
+ */
+static const char *dg_line_color(enum dg_line_kind kind)
+{
+    switch (kind) {
+        case DG_LINE_CONTROL:
+            return DG_COLOR_CONTROL;
+        case DG_LINE_GENERIC:
+            return DG_COLOR_GENERIC;
+        case DG_LINE_MOB:
+            return DG_COLOR_MOB;
+        case DG_LINE_OBJ:
+            return DG_COLOR_OBJ;
+        case DG_LINE_WLD:
+            return DG_COLOR_WLD;
+        case DG_LINE_PLAYER:
+            return DG_COLOR_PLAYER;
+        case DG_LINE_DYNAMIC:
+            return DG_COLOR_DYNAMIC;
+        case DG_LINE_UNKNOWN:
+            return DG_COLOR_ERROR;
+        case DG_LINE_EMPTY:
+        case DG_LINE_COMMENT:
+            break;
+    }
+
+    return DG_COLOR_RESET;
+}
+
+/**
+ * @brief Applies lexical highlighting to a single line.
+ *
+ * @details Keeps the leading spaces uncoloured. Empty lines return only those
+ * spaces (or an empty string). Comment lines, lines with an unknown command
+ * and the wait command get a single colour to the end of the line; every
+ * other line gets the command colour (dg_line_color()) followed by the
+ * argument highlighted by append_highlighted_argument().
+ *
+ * @param source Original line (without \\r or \\n) to highlight.
+ * @param trigger_type MOB_TRIGGER, OBJ_TRIGGER, WLD_TRIGGER or DG_TRIGGER_ANY.
+ * @return Allocated buffer with the highlighted line, or NULL on allocation or parsing failure.
+ */
+static char *highlight_script_line(const char *source, int trigger_type)
+{
+    struct syntax_text_buffer output = { NULL, 0, 0 };
+    struct dg_parsed_line parsed;
+    const char *color;
+
+    if (!dg_syntax_parse_line(source, trigger_type, &parsed)) {
+        return NULL;
+    }
+
+    if (!dg_syntax_buffer_append_n(&output, source, (size_t)(parsed.first - source))) {
+        return NULL;
+    }
+
+    if (parsed.kind == DG_LINE_EMPTY) {
+        return output.data ? output.data : dg_syntax_str_dup("");
+    }
+
+    if (parsed.kind == DG_LINE_COMMENT) {
+        color = DG_COLOR_COMMENT;
+    } else if (parsed.kind == DG_LINE_UNKNOWN) {
+        color = DG_COLOR_ERROR;
+    } else if (parsed.kind == DG_LINE_GENERIC
+        && dg_syntax_token_equals(parsed.first, parsed.command_length, "wait")) {
+        color = DG_COLOR_GENERIC;
+    } else {
+        color = NULL;
+    }
+
+    if (color) {
+        if (!dg_syntax_buffer_append(&output, color)
+            || !dg_syntax_buffer_append(&output, parsed.first)
+            || !dg_syntax_buffer_append(&output, DG_COLOR_RESET)) {
+            free(output.data);
+            return NULL;
+        }
+        return output.data;
+    }
+
+    color = dg_line_color(parsed.kind);
+
+    if (!dg_syntax_buffer_append(&output, color)
+        || !dg_syntax_buffer_append_n(&output, parsed.first, parsed.command_length)
+        || !dg_syntax_buffer_append(&output, DG_COLOR_RESET)
+        || !dg_syntax_buffer_append_n(&output, parsed.first + parsed.command_length,
+            (size_t)(parsed.argument - parsed.first - parsed.command_length))
+        || !append_highlighted_argument(&output, parsed.argument,
+            parsed.spec && parsed.spec->expression_argument)) {
+        free(output.data);
+        return NULL;
+    }
+
+    return output.data;
+}
+
+/**
+ * @brief Highlights a script using the command set of the given type.
+ * @param string Script text.
+ * @param trigger_type MOB_TRIGGER, OBJ_TRIGGER, WLD_TRIGGER, or an invalid value to accept them all.
+ * @return Allocated buffer that must be freed by the caller, or NULL on error.
+ */
+char *command_syntax_highlighting(const char *string, int trigger_type)
+{
+    struct syntax_text_buffer output = { NULL, 0, 0 };
+    const char *cursor, *line_end;
+
+    if (!string) {
+        return NULL;
+    }
+
+    if (trigger_type < MOB_TRIGGER || trigger_type > WLD_TRIGGER) {
+        trigger_type = DG_TRIGGER_ANY;
+    }
+
+    cursor = string;
+
+    while (*cursor) {
+        char *source_line, *highlighted_line;
+        size_t line_length;
+        line_end = cursor;
+
+        while (*line_end && *line_end != '\r' && *line_end != '\n') {
+            line_end++;
+        }
+
+        line_length = (size_t)(line_end - cursor);
+        source_line = dg_syntax_copy_text_range(cursor, line_length);
+        highlighted_line = source_line ? highlight_script_line(source_line, trigger_type) : NULL;
+
+        if (source_line) {
+            free(source_line);
+        }
+
+        if (!highlighted_line || !dg_syntax_buffer_append(&output, highlighted_line)
+            || !dg_syntax_buffer_append(&output, "\tn\r\n")) {
+            if (highlighted_line) {
+                free(highlighted_line);
+            }
+
+            if (output.data) {
+                free(output.data);
+            }
+
+            return NULL;
+        }
+
+        free(highlighted_line);
+
+        if (*line_end == '\r' && line_end[1] == '\n') {
+            cursor = line_end + 2;
+        } else if (*line_end) {
+            cursor = line_end + 1;
+        } else {
+            cursor = line_end;
+        }
+    }
+
+    return output.data ? output.data : dg_syntax_str_dup("");
+}
+
+/**
+ * @brief Shows a highlighted copy of the script in the pager.
+ *
+ * @details Uses dg_syntax_descriptor_trigger_type(d) to restrict the
+ * highlighting to the type of the trigger being edited. Does nothing if d or
+ * string are null.
+ *
+ * @param d Descriptor that will receive the paged text.
+ * @param string Script text to highlight.
+ */
+void dg_olc_script_syntax_highlighting(struct descriptor_data *d, char *string)
+{
+    if (!d || !string) {
+        return;
+    }
+
+    char *highlighted = command_syntax_highlighting(string, dg_syntax_descriptor_trigger_type(d));
+
+    if (!highlighted) {
+        write_to_output(d, "Could not highlight the script: out of memory.\r\n");
+        return;
+    }
+
+    page_string(d, highlighted, TRUE);
+    free(highlighted);
+}

--- a/src/dg_scripts.c
+++ b/src/dg_scripts.c
@@ -16,6 +16,7 @@
 #include "sysdep.h"
 #include "structs.h"
 #include "dg_scripts.h"
+#include "dg_olc_syntax.h"
 #include "utils.h"
 #include "comm.h"
 #include "interpreter.h"
@@ -790,8 +791,24 @@ static void do_stat_trigger(struct char_data *ch, trig_data *trig)
 
     cmd_list = trig->cmdlist;
     while (cmd_list) {
-      if (cmd_list->cmd)
-        len += snprintf(sb + len, sizeof(sb)-len, "%s\r\n", cmd_list->cmd);
+      if (cmd_list->cmd) {
+        char *highlighted = command_syntax_highlighting(cmd_list->cmd, trig->attach_type);
+
+        if (highlighted) {
+          /* snprintf returns the length the line would have taken; without
+           * the clamp a truncated line would push len past sb and the next
+           * sizeof(sb)-len would underflow. Highlighting can inflate a line
+           * by ~40%, so that is reachable. */
+          int written = snprintf(sb + len, sizeof(sb)-len, "%s", highlighted);
+
+          free(highlighted);
+
+          if (written < 0 || (size_t)written >= sizeof(sb) - len)
+            len = sizeof(sb) - 1;
+          else
+            len += written;
+        }
+      }
 
       if (len>MAX_STRING_LENGTH-80) {
         snprintf(sb + len, sizeof(sb)-len, "*** Overflow - script too long! ***\r\n");

--- a/src/dg_scripts.h
+++ b/src/dg_scripts.h
@@ -392,8 +392,15 @@ ACMD(do_mlog);
 /* from dg_olc.c... thinking these should be moved to oasis.h */
 void trigedit_save(struct descriptor_data *d);
 void trigedit_string_cleanup(struct descriptor_data *d, int terminator);
-int format_script(struct descriptor_data *d);
 void trigedit_setup_existing(struct descriptor_data *d, int rtrg_num);
+
+/* Script command lookups shared with the trigedit syntax modules
+ * (dg_olc_syntax*.c). Each one queries the very dispatch table used at
+ * runtime, so the editor never drifts from what the game accepts. */
+bool dg_mob_command_exists(const char *command);
+bool dg_obj_command_exists(const char *command);
+bool dg_wld_command_exists(const char *command);
+bool dg_player_command_exists(const char *command);
 
 /* from dg_objcmd.c */
 room_rnum obj_room(obj_data *obj);

--- a/src/dg_wldcmd.c
+++ b/src/dg_wldcmd.c
@@ -651,6 +651,34 @@ static const struct wld_command_info wld_cmd_info[] = {
     { "\n", 0, 0 }        /* this must be last */
 };
 
+/**
+ * @brief Checks whether a token is accepted by the room command dispatcher.
+ *
+ * @details Reproduces the lookup done by wld_command_interpreter() -- a
+ * prefix match of the token against each table entry -- so abbreviations are
+ * recognised exactly like they are at runtime. Index 0 ("RESERVED") is
+ * skipped. Used by the trigedit syntax modules to classify script lines.
+ *
+ * @param command First token of a script line.
+ * @return true when the room dispatcher would accept the token.
+ */
+bool dg_wld_command_exists(const char *command)
+{
+    if (!command || !*command) {
+        return false;
+    }
+
+    size_t length = strlen(command);
+
+    for (int i = 1; *wld_cmd_info[i].command != '\n'; i++) {
+        if (!strncmp(wld_cmd_info[i].command, command, length)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 /* This is the command interpreter used by rooms, called by script_driver. */
 void wld_command_interpreter(room_data *room, char *argument)
 {

--- a/src/improved-edit.c
+++ b/src/improved-edit.c
@@ -12,6 +12,7 @@
 #include "interpreter.h"
 #include "improved-edit.h"
 #include "dg_scripts.h"
+#include "dg_olc_syntax.h"
 #include "modify.h"
 
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -396,6 +396,62 @@ static const struct mob_script_command_t mob_script_commands[] = {
   { "mlog"     , do_mlog     , 0 },
   { "\n" , do_not_here , 0 } };
 
+/**
+ * @brief Checks whether a token is a mob-only DG script command.
+ *
+ * @details Queries mob_script_commands[], the same table used at runtime by
+ * script_command_interpreter(), instead of keeping a separate list. Used by
+ * the trigedit syntax modules to classify and colour script lines.
+ *
+ * @param command First token of a script line.
+ * @return true only on a full (non-abbreviated) match in the `m*` table.
+ */
+bool dg_mob_command_exists(const char *command)
+{
+    if (!command || !*command) {
+        return false;
+    }
+
+    for (int i = 0; *mob_script_commands[i].command_name != '\n'; i++) {
+        if (!str_cmp(command, mob_script_commands[i].command_name)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Checks whether a token can be dispatched by the normal interpreter.
+ *
+ * @details Accepts command names, sort keys and abbreviations, mirroring the
+ * resolution done by command_interpreter(). Immortal-only commands are
+ * rejected because an NPC running a script cannot use them.
+ *
+ * @param command First token of a script line.
+ * @return true for commands an NPC may attempt to execute.
+ */
+bool dg_player_command_exists(const char *command)
+{
+    const struct command_info *commands = complete_cmd_info ? complete_cmd_info : cmd_info;
+
+    if (!command || !*command) {
+        return false;
+    }
+
+    for (int i = 0; *commands[i].command != '\n'; i++) {
+        if (!commands[i].command_pointer || commands[i].minimum_level >= LVL_IMMORT) {
+            continue;
+        }
+        if ((commands[i].command && is_abbrev(command, commands[i].command))
+            || (commands[i].sort_as && *commands[i].sort_as && is_abbrev(command, commands[i].sort_as))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 int script_command_interpreter(struct char_data *ch, char *arg) {
   /* DG trigger commands */
 


### PR DESCRIPTION
# Replace the trigedit syntax highlighter and script formatter with a tokenising implementation

## Summary

This replaces the two pieces of trigedit tooling that live inside `dg_olc.c` — `script_syntax_highlighting()` and `format_script()` — with a self-contained module split across four new files. Both replaced functions were originally contributed by me (the CC BY 4.0 banner in `dg_olc.c` credits "Victor Almeida (aka Stoneheart) ... from BrMUD:Tormenta"); this is the v2 of that work, developed and run in production on the BrMUD engine and now ported back upstream.

The old implementation coloured scripts by running ~85 blind substring replacements per line against a hardcoded table. The new one tokenises each line, classifies it against **the very dispatch tables the game uses at runtime**, and colours it semantically. The formatter went from "reindent and hope" to a real structural validator that reports every problem it finds and refuses to touch the script when any exist.

Net effect: **332 lines removed from `dg_olc.c`**, ~1,450 lines added in four new files, no behavioural regressions found, and one measured memory leak eliminated.

---

## Why

### 1. The old highlighter leaked memory on every use — measurably

`script_syntax_highlighting()` reassigns its working pointer on every replacement without freeing the previous buffer:

```c
newlist = strdup(string);              /* never freed                        */
for (curtok = strtok(newlist, "\r\n"); curtok; curtok = strtok(NULL, "\r\n")) {
    char *line = strdup(curtok);       /* never freed                        */
    ...
    line = str_replace(line, ...);     /* previous `line` leaked, ~85x/line  */
    ...
    strncat(buffer, line, ...);        /* `line` still never freed           */
}
```

I instrumented the original function with counting allocators and ran it on an 8-line trigger:

```
allocations : 645
frees       :  19
LEAKED      : 626 blocks, ~17122 bytes
-> ~78 leaked blocks per script line
```

That happens **every time a builder opens the command list in trigedit**. On a busy building session this is not trivial. `str_replace()`'s return value is also never checked for `NULL`, so an allocation failure dereferences a null pointer.

### 2. Substring replacement corrupts text it should not touch

Because the old code matched raw substrings anywhere on the line, `"if"` matched inside unrelated words, socials matched inside quoted strings passed to `msend`/`mecho`, and colour codes inserted by earlier passes were re-matched by later ones. The table carries four entries explicitly labelled `// corrective` to patch up damage caused by its own earlier rules — a clear sign the approach had run out of road.

The output buffer was also a fixed `char buffer[MAX_STRING_LENGTH]`, silently truncating long scripts.

### 3. The command list was hardcoded and drifted from reality

`command_color_replacement[36][2]` listed 25 mob commands by hand. `mat`, `mlog` and every object and room command were missing, so they rendered as plain text. Any command added to the game later would never be recognised without editing this table too.

### 4. `format_script()` validated almost nothing

It matched block keywords by prefix (`!strn_cmp(t, "end", 3)`), so `endure`, `casey` and `donee` were treated as block keywords. It never checked that a command existed, never validated expressions, and when it detected unbalanced blocks it printed `"Unmatched block statements ignored."` and reformatted anyway — producing indentation that actively misrepresented the script's structure.

It also carries two latent array-bounds issues: `block_stack[READ_SIZE]` is pushed without a bound check, and `snprintf(line + nlen, sizeof(line) - nlen, ...)` underflows once `nlen` (2 × indent) exceeds `sizeof(line)`. **To be precise about severity: neither is reachable through trigedit as shipped** — the `llen + nlen + len > d->max_str - 1` guard aborts first, because `d->max_str == MAX_CMD_LENGTH == sizeof(nsc)`. I verified this under AddressSanitizer at nesting depths from 100 to 300, all of which abort cleanly. Only after artificially raising `max_str` to 1 MB did ASan report a `stack-buffer-overflow` in `strcat(nsc, line)`. So: real defects, correctly gated today, and gone either way in the rewrite.

---

## What's new

### Architecture

| File | Lines | Responsibility |
|---|---|---|
| `dg_olc_syntax.h` | 99 | Public interface, shared structs, feature defines |
| `dg_olc_syntax.c` | 396 | Tokeniser, line classifier, growable text buffers |
| `dg_olc_syntax_highlight.c` | 503 | Semantic colouring |
| `dg_olc_syntax_format.c` | 446 | Structural validation and reindentation |

The core parses a line once into a `struct dg_parsed_line` (command token, argument, classification, spec) and both the highlighter and the formatter consume that same result, so the editor can never disagree with itself about what a line is.

### Classification comes from the real dispatchers

Instead of a private list, the classifier asks the game:

```c
bool dg_mob_command_exists(const char *command);     /* interpreter.c, mob_script_commands[] */
bool dg_obj_command_exists(const char *command);     /* dg_objcmd.c,   obj_cmd_info[]        */
bool dg_wld_command_exists(const char *command);     /* dg_wldcmd.c,   wld_cmd_info[]        */
bool dg_player_command_exists(const char *command);  /* interpreter.c, complete_cmd_info     */
```

Each helper lives next to the table it queries and reproduces that table's own lookup rule, so abbreviations resolve exactly as they do at runtime. Commands added to the game are recognised by the editor for free, with no second list to maintain.

`dg_player_command_exists()` skips entries with `minimum_level >= LVL_IMMORT`, since an NPC running a script cannot execute an immortal command.

### Highlighting is trigger-type aware

The highlighter takes the trigger's `attach_type`, so `oload` in a **mob** trigger is flagged red as invalid, while the same line in an **object** trigger is coloured as a valid object command. Nine categories are distinguished:

| Category | Colour | Notes |
|---|---|---|
| Flow control (`if`, `while`, `switch`, ...) | `\tM` light magenta | |
| Generic DG commands (`eval`, `set`, `wait`, ...) | `\tC` light cyan | |
| Mob commands | `\tG` light green | |
| Object commands | `\tY` light yellow | |
| Room commands | `\tB` light blue | |
| Player/social commands | `\tG` light green | |
| Dynamic (`%var%` as the command) | `\tm` dark magenta | |
| Comments | `\tg` dark green | |
| Unknown / invalid for this trigger type | `\tR` light red | |

Inside arguments it further colours strings, numbers, operators and variables, with correct lexical state: it does not treat operators or digits inside a quoted string as tokens, it honours `\` escapes inside quotes, and inside `%...%` it highlights nested parentheses, operators and numbers before restoring the variable colour. The operator table mirrors `ops[]` from `eval_lhs_op_rhs()` and is ordered longest-first so `!=` is never read as `!`.

Output is built in a `struct syntax_text_buffer` that grows in powers of two, so **there is no length ceiling** and no truncation.

### `/f` is now a validator, and it is atomic

`format_script()` makes one pass, collects **every** problem, prints a numbered report, and leaves `*d->str` untouched if the count is non-zero. It only rewrites the script when the reindentation is provably safe.

Structural checks:

- `elseif` / `else` / `end` without a matching `if`
- more than one `else` in the same `if`; `elseif` after `else`
- `done` without a matching `while` or `switch`
- `case` / `default` outside a `switch`; more than one `default`; `case` after `default`
- `break` outside a `while` or `switch`
- blocks left open at end of script, reported **at the line where the block was opened**

Expression checks (on `if` / `elseif` / `while` / `switch` / `case` / `return` / `eval`):

- unterminated double quote
- unmatched opening or closing parenthesis
- variable missing its closing `%`
- incomplete boolean operator (`&` or `|` instead of `&&` / `||`)
- required argument missing

Command checks:

- unknown command, or command invalid for this trigger's type

Sample output:

```
Problems found in the script:

  Line 3  : 'else' without a matching 'if'.
  Line 7  : unterminated double quote.
  Line 12 : unknown command 'mecoh', or invalid for this trigger type.
  Line 1  : block 'while' was never closed.

Total: 4 problems; the script was left unchanged.
```

Two deliberate details worth calling out:

- **Colour codes inside expressions are allowed.** `&` followed by an alphanumeric is treated as a colour code, not an incomplete operator. Without this exception the editor's `/t` command (which converts the whole script between tabbed codes and `&X`) would make any coloured text inside an `eval` unformattable.
- **The block stack is heap-allocated and sized from the input.** The number of line separators plus one is a safe ceiling on nesting depth, so there is no fixed array to overflow regardless of how the script is nested.

### Trigedit main menu shows the script

Choice `6` still opens the command editor exactly as before. What changed is that the menu now previews the script under it, driven by three compile-time switches in `dg_olc_syntax.h`.

The `6)` label now reports the line count, and when the preview is capped a footer points at choice `6` for the full listing. Setting `DG_SHOW_COMMANDS_ON_MENU` to `0` restores a menu with no script body at all.

### Command 'stat trigger' output is highlighted

`do_stat_trigger()` now runs each command line through the highlighter using the trigger's own `attach_type`. It also gained a clamp the original was missing: `snprintf()` returns the length a line *would* have needed, so a truncated line used to push `len` past `sizeof(sb)` and make the following `sizeof(sb) - len` underflow. Highlighting inflates lines by roughly 40%, which makes that reachable, so the clamp is now required rather than merely tidy.

---

## Files changed

**New**

```
src/dg_olc_syntax.h
src/dg_olc_syntax.c
src/dg_olc_syntax_highlight.c
src/dg_olc_syntax_format.c
```

**Modified**

| File | Change |
|---|---|
| `src/dg_olc.c` | Removed the CC banner, `str_replace()`, both replacement tables, `script_syntax_highlighting()` and the old `format_script()` (332 lines). Added the menu preview helpers and rewired the editor entry point. |
| `src/dg_olc.h` | Includes `dg_olc_syntax.h`. |
| `src/dg_scripts.c` | Highlighted `stat trigger` output plus the `snprintf` clamp. |
| `src/dg_scripts.h` | `format_script()` prototype moved to `dg_olc_syntax.h`; four `dg_*_command_exists()` prototypes added. |
| `src/interpreter.c` | `dg_mob_command_exists()`, `dg_player_command_exists()`. |
| `src/dg_objcmd.c` | `dg_obj_command_exists()`. |
| `src/dg_wldcmd.c` | `dg_wld_command_exists()`. |
| `src/improved-edit.c` | Includes `dg_olc_syntax.h` for `format_script()`. |

```
 src/dg_objcmd.c     |  28 +++
 src/dg_olc.c        | 497 +++++++++++++++++-----------------------------------
 src/dg_olc.h        |   1 +
 src/dg_scripts.c    |  21 ++-
 src/dg_scripts.h    |   9 +-
 src/dg_wldcmd.c     |  28 +++
 src/improved-edit.c |   1 +
 src/interpreter.c   |  56 ++++++
 8 files changed, 300 insertions(+), 341 deletions(-)
```

Both `Makefile.in` and `CMakeLists.txt` glob `*.c`, so the new files are picked up automatically. Only `depend` needs regenerating (`rm -f depend && make depend`).

No file formats, save paths or OLC menu states were touched. Existing triggers load, save and run unchanged.

---

## Configuration

Everything tunable is a compile-time define, so a fork can adjust the feel of
the editor without touching logic.

### Menu preview — `src/dg_olc_syntax.h`

```c
#define DG_SHOW_COMMANDS_ON_MENU    1   /* show the script on the main menu at all */
#define DG_HIGHLIGHT_ON_MENU        1   /* apply semantic highlighting to it       */
#define DG_LINE_LIMIT_ON_MENU       16  /* cap the lines shown; 0 = no limit       */
```

| Define | Effect |
|---|---|
| `DG_SHOW_COMMANDS_ON_MENU` | `0` drops the script body from the main menu entirely. The `6)` label and its line count still show. |
| `DG_HIGHLIGHT_ON_MENU` | `0` prints the preview in plain cyan instead of semantic colours. Ignored when the preview is off. |
| `DG_LINE_LIMIT_ON_MENU` | Maximum lines previewed. `0` or negative means no limit. When the preview is capped, a footer points at choice `6` for the full listing. |

These gate **the main menu preview only**. Choice `6` always opens the editor
on the complete, highlighted script, and `stat trigger` always highlights,
regardless of how these are set.

To reproduce the pre-PR menu exactly — full script, unlimited, plain cyan:

```c
#define DG_SHOW_COMMANDS_ON_MENU    1
#define DG_HIGHLIGHT_ON_MENU        0
#define DG_LINE_LIMIT_ON_MENU       0
```

### Colour scheme — `src/dg_olc_syntax_highlight.c`

The `DG_COLOR_*` block at the top of the file maps each semantic category to a
colour code, so the whole palette can be re-themed in one place:

```c
#define DG_COLOR_CONTROL    "\tM"  /* if, while, switch, ...      */
#define DG_COLOR_GENERIC    "\tC"  /* eval, set, wait, ...        */
#define DG_COLOR_MOB        "\tG"  /* m* commands                 */
#define DG_COLOR_OBJ        "\tY"  /* o* commands                 */
#define DG_COLOR_WLD        "\tB"  /* w* commands                 */
#define DG_COLOR_PLAYER     "\tG"  /* normal and social commands  */
#define DG_COLOR_DYNAMIC    "\tm"  /* %var% used as the command   */
#define DG_COLOR_VARIABLE   "\to"  /* body of a %...% expression  */
#define DG_COLOR_DELIMITER  "\tm"  /* the % signs themselves      */
#define DG_COLOR_STRING     "\ty"  /* quoted strings              */
#define DG_COLOR_NUMBER     "\tY"  /* numeric literals            */
#define DG_COLOR_OPERATOR   "\tC"  /* operators and parentheses   */
#define DG_COLOR_COMMENT    "\tg"  /* * comment lines             */
#define DG_COLOR_ERROR      "\tR"  /* unknown or invalid command  */
#define DG_COLOR_RESET      "\tn"  /* restore normal colour       */
```

One caveat worth knowing before re-theming: on clients that negotiate xterm-256, `\to` and `\tO` are genuine oranges (`ESC[38;5;208m` and `ESC[38;5;214m`). On plain-ANSI clients `ColourRGB()` falls back to `GetAnsiColour()`, which collapses `F520`, `F530` and `F500` to the same bold red — so `DG_COLOR_VARIABLE` and `DG_COLOR_ERROR` become indistinguishable there. Switching `DG_COLOR_VARIABLE` to `\tw` avoids the collision in both modes if that matters for your player base.

## Behaviour changes for anyone upgrading

1. **`/f` no longer reformats a script that has errors.** It prints a full report and leaves the buffer alone. This is the intended improvement, but it is a change in habit: previously `/f` always rewrote the script.
2. **Unknown commands are flagged.** They render red and block formatting. Custom commands are covered because the lookup goes through `complete_cmd_info`, but an immortal-only command used inside a script will now be reported.
3. **Highlighting respects the trigger type.** A command valid for a different attach type is shown as an error.
4. **Blank lines are not shown in `stat trigger`** and are not counted by the menu line count, since the highlighter emits nothing for an empty line.
5. **The trigedit main menu shows at most 16 script lines by default.** Set `DG_LINE_LIMIT_ON_MENU` to `0` for the previous unlimited behaviour.

---

## Portability notes

- `%zu` is avoided in favour of `%lu` with an explicit `(unsigned long)` cast, because the bundled `bsd-snprintf.c` fallback does not implement the `z` length modifier.
- The `printf` format attribute on the error reporter sits behind a `DG_SYNTAX_PRINTF` macro guarded by `__GNUC__`, so non-GCC toolchains just lose the compile-time check instead of failing to build.
- `malloc()` / `realloc()` / `calloc()` results are explicitly cast, because `zmalloc.h` redefines them to return `unsigned char *` under `-DMEMORY_DEBUG`.
- `dg_obj_command_exists()` and `dg_wld_command_exists()` reproduce the dispatcher's own prefix match rather than assuming every table entry ends in a space — `wld_cmd_info[]` has `{ "wlog", ... }` without the trailing space that every other entry carries, and a length-based assumption would misclassify it.
- All four new files are pure ASCII with LF endings (`file -I` reports `us-ascii`).

---

## Testing

**Build** — clean under `gcc -Wall`. All nine touched translation units recompiled with **zero warnings**; `bin/circle` links.

**World boot** — `./bin/circle -c -d lib` completes: 189 zones, 12,733 rooms, 3,705 mobs, 4,765 objects, 1 quest, "Done."

**Automated** — a standalone harness links the three syntax modules against stubbed dispatchers and runs **36 assertions under AddressSanitizer + UndefinedBehaviorSanitizer, all passing**:

- *Formatting*: `if`/`else`/`end`, `while`/`done`, `switch`/`case`/`default`/`break`, nested blocks, comments and blank lines preserved, `&Y` colour codes inside `eval`
- *Structural errors*: all eight cases listed above, each verified to report the right message **and** leave the script byte-identical
- *Expression errors*: all six cases
- *Command validation*: unknown command, and an object command inside a mob trigger
- *Nesting*: 50 levels formats cleanly; 400 levels is refused cleanly with the script untouched, where the old code's guards were the only thing standing between it and a corrupted stack
- *Highlighting*: 13 cases covering every category, variable delimiters, strings, numbers, operators and the empty script

**Not covered automatically** — the in-game rendering of the menu preview, which needs a builder-level character; verified manually in trigedit against mob, object and room triggers.

---

## Notes

- The `NESTED-IFS` help entry (`lib/text/help/help.hlp`) already tells builders to always run `/f` and warns that unmatched `if`/`end` pairs crash the MUD. That advice is now more accurate than it was, since `/f` genuinely refuses to proceed. It could optionally be expanded to mention the new validation categories.

## Screenshots (Before)

<img width="629" height="485" alt="before-tstat" src="https://github.com/user-attachments/assets/d394733f-eb7d-4f5a-ba79-064f23456471" />

<img width="634" height="599" alt="before-trigedit-menu" src="https://github.com/user-attachments/assets/c0d40d2f-2166-4b42-9ba0-8778a1f713f3" />

<img width="633" height="453" alt="before-edit-trigger" src="https://github.com/user-attachments/assets/51fdd24e-c0c9-46dd-af09-c5b284fbd6ac" />

## Screenshots (After)
<img width="634" height="489" alt="after-tstat" src="https://github.com/user-attachments/assets/058ea9bf-bf19-44da-a3c8-1b4a7c5d589b" />

<img width="625" height="470" alt="after-trigedit_menu" src="https://github.com/user-attachments/assets/f21e060e-0cd2-454b-bab2-0ff30479b026" />

<img width="624" height="456" alt="after-edit-trigger" src="https://github.com/user-attachments/assets/723893df-55f3-4142-8568-531a135965a3" />

## Screenshots (After, tstat 63)
<img width="595" height="519" alt="after-tstat-63" src="https://github.com/user-attachments/assets/2e91ab92-90b1-4467-94c9-6d4fe09d89d3" />

<img width="683" height="470" alt="after-tstat-63-cont" src="https://github.com/user-attachments/assets/386b0609-c916-424e-a1cf-b46c14d95495" />
